### PR TITLE
Support custom classNames for Tag

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -2,6 +2,7 @@ import { configure, addDecorator } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 
 import 'uswds/dist/css/uswds.css'
+import './custom-story.css'
 
 configure(require.context('../src', true, /\.stories\.tsx?$/), module)
 

--- a/.storybook/custom-story.css
+++ b/.storybook/custom-story.css
@@ -1,0 +1,3 @@
+.custom-class {
+  background: #fa9441;
+}

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -17,3 +17,7 @@ export const defaultTag = (): React.ReactElement => <Tag>My Tag</Tag>
 export const customBg = (): React.ReactElement => (
   <Tag background="#e44608">My Tag</Tag>
 )
+
+export const customClass = (): React.ReactElement => (
+  <Tag className="custom-class">My Tag</Tag>
+)

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -21,4 +21,12 @@ background: ${backgroundColor};
 `)
     })
   })
+
+  describe('with a className prop', () => {
+    it('applies the className', () => {
+      const customClass = 'custom-class'
+      const { getByTestId } = render(<Tag className={customClass}>My Tag</Tag>)
+      expect(getByTestId('tag')).toHaveClass(`${customClass}`)
+    })
+  })
 })

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,20 +1,24 @@
 import React from 'react'
+import classnames from 'classnames'
 
 interface TagProps {
   children: React.ReactNode
   background?: string
+  className?: string
 }
 
 export const Tag = (props: TagProps): React.ReactElement => {
-  const { children, background } = props
+  const { children, background, className } = props
 
   const style: React.CSSProperties = {}
   if (background) {
     style.background = background
   }
 
+  const tagClasses = classnames('usa-tag', className)
+
   return (
-    <span data-testid="tag" className="usa-tag" style={{ ...style }}>
+    <span data-testid="tag" className={tagClasses} style={{ ...style }}>
       {children}
     </span>
   )


### PR DESCRIPTION
I wanted to use the `Tag` component but with a custom `className`. This PR updates the `Tag` component to take an optional `className` prop and append it to the default class of `usa-tag`.

Updated tests and storybook for this as well.