### PR TITLE
Add small and icon options to Button

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -52,6 +52,18 @@ export const big = (): React.ReactElement => (
   </Button>
 )
 
+export const small = (): React.ReactElement => (
+  <Button type="button" small>
+    Click Me
+  </Button>
+)
+
+export const icon = (): React.ReactElement => (
+  <Button type="button" icon>
+    Click Me
+  </Button>
+)
+
 export const unstyled = (): React.ReactElement => (
   <Button type="button" unstyled>
     Click Me

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -10,6 +10,39 @@ describe('Button component', () => {
     expect(queryByTestId('button')).toBeInTheDocument()
   })
 
+  describe('renders uswds classes', () => {
+    it('usa-button', () => {
+      const { queryByTestId } = render(<Button type="button">Click Me</Button>)
+      expect(queryByTestId('button')).toHaveClass('usa-button')
+    })
+
+    const optionalClasses = [
+      ['secondary', 'usa-button--secondary'],
+      ['base', 'usa-button--base'],
+      ['accent', 'usa-button--accent-cool'],
+      ['outline', 'usa-button--outline'],
+      ['inverse', 'usa-button--inverse'],
+      ['big', 'usa-button--big'],
+      ['small', 'usa-button--small'],
+      ['icon', 'usa-button--icon'],
+      ['unstyled', 'usa-button--unstyled'],
+    ]
+
+    optionalClasses.map(data => {
+      it(`${data[1]}`, () => {
+        const additionalProps: { [key: string]: boolean } = {}
+        additionalProps[data[0]] = true
+
+        const { queryByTestId } = render(
+          <Button type="button" {...additionalProps}>
+            Click Me
+          </Button>
+        )
+        expect(queryByTestId('button')).toHaveClass(data[1])
+      })
+    })
+  })
+
   it('implements an onClick handler', () => {
     const onClickFn = jest.fn()
     const { getByText } = render(

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,6 +11,8 @@ interface ButtonProps {
   outline?: boolean
   inverse?: boolean
   big?: boolean
+  small?: boolean
+  icon?: boolean
   unstyled?: boolean
 }
 
@@ -27,6 +29,8 @@ export const Button = (
     outline,
     inverse,
     big,
+    small,
+    icon,
     unstyled,
     onClick,
     className,
@@ -41,6 +45,8 @@ export const Button = (
       'usa-button--outline': outline,
       'usa-button--inverse': inverse,
       'usa-button--big': big,
+      'usa-button--small': small,
+      'usa-button--icon': icon,
       'usa-button--unstyled': unstyled,
     },
     className


### PR DESCRIPTION
During our use we found that `small` and `icon` classes were not available.