### PR TITLE
Add title component

### DIFF
--- a/src/components/Title/Title.stories.tsx
+++ b/src/components/Title/Title.stories.tsx
@@ -14,6 +14,4 @@ Source: https://designsystem.digital.gov/components/header/
 
 const testTitle = <a href="#testlink">Project Title</a>
 
-export const defaultTitle = (): React.ReactElement => (
-  <Title text={true}>{testTitle}</Title>
-)
+export const defaultTitle = (): React.ReactElement => <Title>{testTitle}</Title>

--- a/src/components/Title/Title.stories.tsx
+++ b/src/components/Title/Title.stories.tsx
@@ -12,9 +12,8 @@ Source: https://designsystem.digital.gov/components/header/
   },
 }
 
-const testTitle = 'Test Title'
-const testLink = '#testLinkOne'
+const testTitle = <a href="#testlink">Project Title</a>
 
 export const defaultTitle = (): React.ReactElement => (
-  <Title title={testTitle} link={testLink}></Title>
+  <Title title={testTitle}></Title>
 )

--- a/src/components/Title/Title.stories.tsx
+++ b/src/components/Title/Title.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Title } from './Title'
+
+export default {
+  title: 'Title',
+  parameters: {
+    info: `
+USWDS 2.0 Title component
+
+Source: https://designsystem.digital.gov/components/header/
+`,
+  },
+}
+
+const testTitle = 'Test Title'
+const testLink = '#testLinkOne'
+
+export const defaultTitle = (): React.ReactElement => (
+  <Title title={testTitle} link={testLink}></Title>
+)

--- a/src/components/Title/Title.stories.tsx
+++ b/src/components/Title/Title.stories.tsx
@@ -15,5 +15,5 @@ Source: https://designsystem.digital.gov/components/header/
 const testTitle = <a href="#testlink">Project Title</a>
 
 export const defaultTitle = (): React.ReactElement => (
-  <Title title={testTitle}></Title>
+  <Title text={true}>{testTitle}</Title>
 )

--- a/src/components/Title/Title.test.tsx
+++ b/src/components/Title/Title.test.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react'
+import React from 'react'
 import { render } from '@testing-library/react'
 
 import { Title } from './Title'

--- a/src/components/Title/Title.test.tsx
+++ b/src/components/Title/Title.test.tsx
@@ -1,13 +1,11 @@
-import React from 'react'
+import React, { Children } from 'react'
 import { render } from '@testing-library/react'
 
 import { Title } from './Title'
 
-const testTitle = 'Test Title'
-
 describe('Title component', () => {
   it('renders without errors', () => {
-    const { queryByText } = render(<Title title={testTitle}></Title>)
+    const { queryByText } = render(<Title>Test Title</Title>)
     expect(queryByText('Test Title')).toBeInTheDocument()
   })
 })

--- a/src/components/Title/Title.test.tsx
+++ b/src/components/Title/Title.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { Title } from './Title'
+
+const testTitle = 'Test Title'
+const testLink = '#testLinkOne'
+
+describe('Title component', () => {
+  it('renders without errors', () => {
+    const { queryByText } = render(
+      <Title title={testTitle} link={testLink}></Title>
+    )
+    expect(queryByText('Test Title')).toBeInTheDocument()
+  })
+})

--- a/src/components/Title/Title.test.tsx
+++ b/src/components/Title/Title.test.tsx
@@ -4,13 +4,10 @@ import { render } from '@testing-library/react'
 import { Title } from './Title'
 
 const testTitle = 'Test Title'
-const testLink = '#testLinkOne'
 
 describe('Title component', () => {
   it('renders without errors', () => {
-    const { queryByText } = render(
-      <Title title={testTitle} link={testLink}></Title>
-    )
+    const { queryByText } = render(<Title title={testTitle}></Title>)
     expect(queryByText('Test Title')).toBeInTheDocument()
   })
 })

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -3,13 +3,18 @@ import classnames from 'classnames'
 
 interface TitleProps {
   children: React.ReactNode
+  className?: string
 }
 
-export const Title = ({ children }: TitleProps): React.ReactElement => {
-  const classes = classnames('usa-logo')
+export const Title = ({
+  className,
+  children,
+  ...props
+}: TitleProps): React.ReactElement => {
+  const classes = classnames('usa-logo', className)
 
   return (
-    <div className={classes}>
+    <div className={classes} {...props}>
       <em className="usa-logo__text">{children}</em>
     </div>
   )

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -2,19 +2,18 @@ import React from 'react'
 import classnames from 'classnames'
 
 interface TitleProps {
-  children: React.ReactNode
   className?: string
+  children: React.ReactNode
 }
 
-export const Title = ({
-  className,
-  children,
-  ...props
-}: TitleProps): React.ReactElement => {
+export const Title = (
+  props: TitleProps & React.HTMLAttributes<HTMLDivElement>
+): React.ReactElement => {
+  const { className, children, ...divProps } = props
   const classes = classnames('usa-logo', className)
 
   return (
-    <div className={classes} {...props}>
+    <div className={classes} {...divProps}>
       <em className="usa-logo__text">{children}</em>
     </div>
   )

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import classnames from 'classnames'
 
 interface TitleProps {
-  className?: string
   children: React.ReactNode
 }
 

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import classnames from 'classnames'
+
+interface TitleProps {
+  title: React.ReactNode
+  link?: string
+}
+
+export const Title = ({ title, link }: TitleProps): React.ReactElement => {
+  const classes = classnames('usa-logo')
+
+  return (
+    <div className={classes}>
+      <em className="usa-logo__text">
+        <a href={link}>{title}</a>
+      </em>
+    </div>
+  )
+}
+
+export default Title

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -3,17 +3,14 @@ import classnames from 'classnames'
 
 interface TitleProps {
   title: React.ReactNode
-  link?: string
 }
 
-export const Title = ({ title, link }: TitleProps): React.ReactElement => {
+export const Title = ({ title }: TitleProps): React.ReactElement => {
   const classes = classnames('usa-logo')
 
   return (
     <div className={classes}>
-      <em className="usa-logo__text">
-        <a href={link}>{title}</a>
-      </em>
+      <h1 className="usa-logo__text">{title}</h1>
     </div>
   )
 }

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -3,20 +3,14 @@ import classnames from 'classnames'
 
 interface TitleProps {
   children: React.ReactNode
-  logo?: boolean
-  text?: boolean
 }
 
-export const Title = (props: TitleProps): React.ReactElement => {
-  const { children, logo, text } = props
-  const classes = classnames({
-    'usa-logo__logo': logo,
-    'usa-logo__text': text,
-  })
+export const Title = ({ children }: TitleProps): React.ReactElement => {
+  const classes = classnames('usa-logo')
 
   return (
-    <div className="usa-logo">
-      <em className={classes}>{children}</em>
+    <div className={classes}>
+      <em className="usa-logo__text">{children}</em>
     </div>
   )
 }

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -2,15 +2,21 @@ import React from 'react'
 import classnames from 'classnames'
 
 interface TitleProps {
-  title: React.ReactNode
+  children: React.ReactNode
+  logo?: boolean
+  text?: boolean
 }
 
-export const Title = ({ title }: TitleProps): React.ReactElement => {
-  const classes = classnames('usa-logo')
+export const Title = (props: TitleProps): React.ReactElement => {
+  const { children, logo, text } = props
+  const classes = classnames({
+    'usa-logo__logo': logo,
+    'usa-logo__text': text,
+  })
 
   return (
-    <div className={classes}>
-      <h1 className="usa-logo__text">{title}</h1>
+    <div className="usa-logo">
+      <em className={classes}>{children}</em>
     </div>
   )
 }


### PR DESCRIPTION
## PR Description
This PR adds the Title component. This component may be used through out an application, and is included in the USWDS Header Component: https://designsystem.digital.gov/components/header/

<img width="800" alt="Screen Shot 2020-04-24 at 2 01 30 PM" src="https://user-images.githubusercontent.com/56279459/80260340-27a88b80-8634-11ea-9c34-504cd4e1374c.png">

## For Reviewers
Should this component be composed in an alternate manner to make it more reuse-able?  

To test this component execute the following commands in the react-uswds repo:
```
yarn install
yarn storybook
```
Navigate to the Title component. 