### PR TITLE
Limit Jest to 1 worker when running in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ jobs:
             - node_modules
           key: v1.0.0-dependencies-{{ checksum "package.json" }}
 
-      - run: yarn test
+      - run: yarn test -w 1
       - run: yarn lint
       - run: yarn danger ci --failOnErrors


### PR DESCRIPTION
**Fixes #103** 

Fix spurious CI failures due to not enough memory while running Jest tests, by limiting Jest to a single thread.

References:
- https://discuss.circleci.com/t/not-enough-memory-while-testing-a-node-js-appplication/12768
- https://blog.lysender.com/2019/08/jest-tests-failing-on-circleci-enomem-not-enough-memory/