### PR TITLE
Add new styles to Alert, add HTML props

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -45,6 +45,57 @@ export const info = (): React.ReactElement => (
   </Alert>
 )
 
+export const slim = (): React.ReactElement => (
+  <>
+    <Alert type="success" slim>
+      {testText}
+    </Alert>
+    <Alert type="warning" slim>
+      {testText}
+    </Alert>
+    <Alert type="error" slim>
+      {testText}
+    </Alert>
+    <Alert type="info" slim>
+      {testText}
+    </Alert>
+  </>
+)
+
+export const noIcon = (): React.ReactElement => (
+  <>
+    <Alert type="success" noIcon>
+      {testText}
+    </Alert>
+    <Alert type="warning" noIcon>
+      {testText}
+    </Alert>
+    <Alert type="error" noIcon>
+      {testText}
+    </Alert>
+    <Alert type="info" noIcon>
+      {testText}
+    </Alert>
+  </>
+)
+
+export const slimNoIcon = (): React.ReactElement => (
+  <>
+    <Alert type="success" slim noIcon>
+      {testText}
+    </Alert>
+    <Alert type="warning" slim noIcon>
+      {testText}
+    </Alert>
+    <Alert type="error" slim noIcon>
+      {testText}
+    </Alert>
+    <Alert type="info" slim noIcon>
+      {testText}
+    </Alert>
+  </>
+)
+
 export const withCTA = (): React.ReactElement => (
   <Alert
     type="warning"

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -9,6 +9,13 @@ describe('Alert component', () => {
     expect(queryByTestId('alert')).toBeInTheDocument()
   })
 
+  it('accepts className prop', () => {
+    const { queryByTestId } = render(
+      <Alert type="success" className="myClass" />
+    )
+    expect(queryByTestId('alert')).toHaveClass('myClass')
+  })
+
   describe('with a CTA', () => {
     it('renders the CTA', () => {
       const testCTA = <button type="button">Click Here</button>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -8,6 +8,8 @@ interface AlertProps {
   heading?: React.ReactNode
   children?: React.ReactNode
   cta?: React.ReactNode
+  slim?: boolean
+  noIcon?: boolean
 }
 
 export const Alert = ({
@@ -15,17 +17,27 @@ export const Alert = ({
   heading,
   cta,
   children,
-}: AlertProps): React.ReactElement => {
-  const classes = classnames('usa-alert', {
-    'usa-alert--success': type === 'success',
-    'usa-alert--warning': type === 'warning',
-    'usa-alert--error': type === 'error',
-    'usa-alert--info': type === 'info',
-    [styles.alertWithCTA]: !!cta,
-  })
+  slim,
+  noIcon,
+  className,
+  ...props
+}: AlertProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
+  const classes = classnames(
+    'usa-alert',
+    {
+      'usa-alert--success': type === 'success',
+      'usa-alert--warning': type === 'warning',
+      'usa-alert--error': type === 'error',
+      'usa-alert--info': type === 'info',
+      'usa-alert--slim': slim,
+      'usa-alert--no-icon': noIcon,
+      [styles.alertWithCTA]: !!cta,
+    },
+    className
+  )
 
   return (
-    <div className={classes} data-testid="alert">
+    <div className={classes} data-testid="alert" {...props}>
       <div className="usa-alert__body">
         {heading && <h3 className="usa-alert__heading">{heading}</h3>}
         {children && <p className="usa-alert__text">{children}</p>}


### PR DESCRIPTION
**Fixes #106** 

Adds support for new Alert styles (slim, no icon) as well as React HTML attributes such as `className`.

![image](https://user-images.githubusercontent.com/2723066/80422150-4791b680-88a3-11ea-93e4-ccb7e4107546.png)
