### PR TITLE
feat: add Grid components #86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added yarn audit check to dangerfile (on package change)
 - Added search component
+- Added Grid, GridContainer components
 
 ## [1.2.0] - 2020-04-30
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -22,7 +22,7 @@ if (hasCodeChanges && !hasTestChanges) {
 const hasNewComponents = danger.git.created_files.some(
   (p) => !!p.match(/src\/components\/.*\.[jt]sx/)
 )
-const hasEntrypointChanges = includes(allFiles, 'index.ts')
+const hasEntrypointChanges = includes(allFiles, 'src/index.ts')
 if (hasNewComponents && !hasEntrypointChanges) {
   const message = `It looks like there are new component (JSX/TSX) files, but the entrypoint (index.ts) has not changed.`
   const idea = `Did you forget to export new components from the library entrypoint?`

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -24,7 +24,7 @@ const hasNewComponents = danger.git.created_files.some(
 )
 const hasEntrypointChanges = includes(allFiles, 'index.ts')
 if (hasNewComponents && !hasEntrypointChanges) {
-  const message = `It looks like there are new component (TSX) files, but the entrypoint (index.ts) has not changed.`
+  const message = `It looks like there are new component (JSX/TSX) files, but the entrypoint (index.ts) has not changed.`
   const idea = `Did you forget to export new components from the library entrypoint?`
   warn(`${message} - <em>${idea}</em>`)
 }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,47 +1,67 @@
-import { includes } from 'lodash';
-import { danger, warn, fail } from 'danger';
+import { includes } from 'lodash'
+import { danger, warn } from 'danger'
 
 // No PR is too small to include a description of why you made a change
 if (danger.github && danger.github.pr.body.length < 10) {
-  warn('Please include a description of your PR changes.');
+  warn('Please include a description of your PR changes.')
 }
 
 // Load all modified and new files
-const allFiles = danger.git.modified_files.concat(danger.git.created_files);
+const allFiles = danger.git.modified_files.concat(danger.git.created_files)
 
 // Request changes to package source code to also include changes to tests.
-const hasCodeChanges = allFiles.some(p => !!p.match(/src\/.*\.[jt]sx?/));
-const hasTestChanges = allFiles.some(p => !!p.match(/src\/.*\.test\.[jt]sx?/));
+const hasCodeChanges = allFiles.some((p) => !!p.match(/src\/.*\.[jt]sx?/))
+const hasTestChanges = allFiles.some((p) => !!p.match(/src\/.*\.test\.[jt]sx?/))
 if (hasCodeChanges && !hasTestChanges) {
-  warn('This PR does not include changes to tests, even though it affects source code.');
+  warn(
+    'This PR does not include changes to tests, even though it affects source code.'
+  )
+}
+
+// Make sure to export new components (src/components/*.[jt]sx)
+const hasNewComponents = danger.git.created_files.some(
+  (p) => !!p.match(/src\/components\/.*\.[jt]sx/)
+)
+const hasEntrypointChanges = includes(allFiles, 'index.ts')
+if (hasNewComponents && !hasEntrypointChanges) {
+  const message = `It looks like there are new component (TSX) files, but the entrypoint (index.ts) has not changed.`
+  const idea = `Did you forget to export new components from the library entrypoint?`
+  warn(`${message} - <em>${idea}</em>`)
 }
 
 // Require new src/components files to include changes to storybook
-const hasStorybookChanges = allFiles.some(p => !!p.match(/src\/.*\.stories\.[jt]sx?/));
+const hasStorybookChanges = allFiles.some(
+  (p) => !!p.match(/src\/.*\.stories\.[jt]sx?/)
+)
 
 if (hasCodeChanges && !hasStorybookChanges) {
-  warn('This PR does not include changes to storybook, even though it affects component code.');
+  warn(
+    'This PR does not include changes to storybook, even though it affects component code.'
+  )
 }
 
 // Request update of yarn.lock if package.json changed but yarn.lock isn't
-const packageChanged = includes(allFiles, 'package.json');
-const lockfileChanged = includes(allFiles, 'yarn.lock');
+const packageChanged = includes(allFiles, 'package.json')
+const lockfileChanged = includes(allFiles, 'yarn.lock')
 if (packageChanged && !lockfileChanged) {
-  const message = 'Changes were made to package.json, but not to yarn.lock';
-  const idea = 'Perhaps you need to run `yarn install`?';
-  warn(`${message} - <i>${idea}</i>`);
+  const message = 'Changes were made to package.json, but not to yarn.lock'
+  const idea = 'Perhaps you need to run `yarn install`?'
+  warn(`${message} - <i>${idea}</i>`)
 }
 
 // Ensure we have access to github for these checks
-let isTrivial = false;
-let isYarnAuditMissing = false;
+let isTrivial = false
+let isYarnAuditMissing = false
 if (danger.github) {
-  let prBody = danger.github.pr.body
-  
-  isTrivial = includes((prBody + danger.github.pr.title), '#trivial')
-    
+  const prBody = danger.github.pr.body
+
+  isTrivial = includes(prBody + danger.github.pr.title, '#trivial')
+
   if (lockfileChanged && danger.github.pr.user.type == 'User') {
-    isYarnAuditMissing = !(includes(prBody, 'vulnerabilities found:') && includes(prBody, 'Packages audited:'));
+    isYarnAuditMissing = !(
+      includes(prBody, 'vulnerabilities found:') &&
+      includes(prBody, 'Packages audited:')
+    )
   }
 }
 
@@ -54,7 +74,9 @@ if (!hasChangelog && !isTrivial) {
 
 // Encourage adding `yarn audit` output on package change
 if (isYarnAuditMissing) {
-  const message = 'Changes were made to yarn.lock, but no plain text yarn audit output was found in PR description.'
-  const idea = 'Can you run `yarn audit` in your branch and paste the results inside a markdown code block?'
-  warn(`${ message } - <i>${idea}</i>`)
+  const message =
+    'Changes were made to yarn.lock, but no plain text yarn audit output was found in PR description.'
+  const idea =
+    'Can you run `yarn audit` in your branch and paste the results inside a markdown code block?'
+  warn(`${message} - <i>${idea}</i>`)
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "storybook": "start-storybook",
+    "storybook": "start-storybook -p 9009",
     "storybook:deploy": "storybook-to-ghpages",
     "build": "webpack",
     "build:watch": "webpack --watch",

--- a/src/components/grid/Grid.stories.tsx
+++ b/src/components/grid/Grid.stories.tsx
@@ -25,9 +25,9 @@ const testContent = <div style={exampleStyles}>Content</div>
 export const defaultContainer = (): React.ReactElement => (
   <GridContainer>
     <Grid row>
-      <Grid col>{testContent}</Grid>
-      <Grid col>{testContent}</Grid>
-      <Grid col>{testContent}</Grid>
+      <Grid tablet={{ col: true }}>{testContent}</Grid>
+      <Grid tablet={{ col: true }}>{testContent}</Grid>
+      <Grid tablet={{ col: true }}>{testContent}</Grid>
     </Grid>
   </GridContainer>
 )
@@ -105,14 +105,255 @@ export const autoLayoutColumns = (): React.ReactElement => (
   </GridContainer>
 )
 
+export const responsive = (): React.ReactElement => (
+  <>
+    <h2>Same at all breakpoints</h2>
+    <GridContainer>
+      <Grid row>
+        <Grid col={1}>{testContent}</Grid>
+        <Grid col={2}>{testContent}</Grid>
+        <Grid col={3}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={2}>{testContent}</Grid>
+      </Grid>
+      <Grid row>
+        <Grid col={8}>{testContent}</Grid>
+        <Grid col={2}>{testContent}</Grid>
+        <Grid col={2}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>Stacked columns at narrow widths</h2>
+    <GridContainer>
+      <Grid row>
+        <Grid tablet={{ col: true }}>{testContent}</Grid>
+        <Grid tablet={{ col: true }}>{testContent}</Grid>
+        <Grid tablet={{ col: true }}>{testContent}</Grid>
+      </Grid>
+      <Grid row>
+        <Grid tablet={{ col: 4 }}>{testContent}</Grid>
+        <Grid tablet={{ col: 8 }}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>Mix and match</h2>
+    <GridContainer>
+      <Grid row>
+        <Grid tablet={{ col: 8 }}>{testContent}</Grid>
+        <Grid col={6} tablet={{ col: 4 }}>
+          {testContent}
+        </Grid>
+      </Grid>
+      <Grid row>
+        <Grid col={6} tablet={{ col: 4 }}>
+          {testContent}
+        </Grid>
+        <Grid col={6} tablet={{ col: 4 }}>
+          {testContent}
+        </Grid>
+        <Grid col={6} tablet={{ col: 4 }}>
+          {testContent}
+        </Grid>
+      </Grid>
+      <Grid row>
+        <Grid col={6}>{testContent}</Grid>
+        <Grid col={6}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+  </>
+)
+
 export const offsetColumns = (): React.ReactElement => (
   <GridContainer>
+    <Grid row>
+      <Grid col>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={1}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={2}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={3}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={4}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={5}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={6}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={7}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={8}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={9}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={10}>
+        {testContent}
+      </Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1} offset={11}>
+        {testContent}
+      </Grid>
+    </Grid>
     <Grid row>
       <Grid col={8} offset={4}>
         {testContent}
       </Grid>
     </Grid>
   </GridContainer>
+)
+
+export const columnWrapping = (): React.ReactElement => (
+  <GridContainer>
+    <Grid row>
+      <Grid col={8}>{testContent}</Grid>
+      <Grid col={3}>{testContent}</Grid>
+      <Grid col={5}>{testContent}</Grid>
+    </Grid>
+  </GridContainer>
+)
+
+export const gutters = (): React.ReactElement => (
+  <>
+    <h2>Default gutter</h2>
+    <GridContainer>
+      <Grid row gap>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>Small gutter</h2>
+    <GridContainer>
+      <Grid row gap="sm">
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>Medium gutter</h2>
+    <GridContainer>
+      <Grid row gap="md">
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>Large gutter</h2>
+    <GridContainer>
+      <Grid row gap="lg">
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>2px gutter</h2>
+    <GridContainer>
+      <Grid row gap="2px">
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>05 gutter</h2>
+    <GridContainer>
+      <Grid row gap="05">
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>1 gutter</h2>
+    <GridContainer>
+      <Grid row gap={1}>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>2 gutter</h2>
+    <GridContainer>
+      <Grid row gap={2}>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>3 gutter</h2>
+    <GridContainer>
+      <Grid row gap={3}>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>4 gutter</h2>
+    <GridContainer>
+      <Grid row gap={4}>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>5 gutter</h2>
+    <GridContainer>
+      <Grid row gap={5}>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+
+    <h2>6 gutter</h2>
+    <GridContainer>
+      <Grid row gap={6}>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+        <Grid col={4}>{testContent}</Grid>
+      </Grid>
+    </GridContainer>
+  </>
 )
 
 export const mobileContainer = (): React.ReactElement => (
@@ -141,4 +382,45 @@ export const desktopLgContainer = (): React.ReactElement => (
 
 export const widescreenContainer = (): React.ReactElement => (
   <GridContainer containerSize="widescreen">{testContent}</GridContainer>
+)
+
+export const footerLayout = (): React.ReactElement => (
+  <GridContainer>
+    <Grid row gap>
+      <Grid tablet={{ col: 8 }}>
+        <Grid row gap={4}>
+          <Grid mobileLg={{ col: 6 }} desktop={{ col: 3 }}>
+            Secondary nav
+          </Grid>
+          <Grid mobileLg={{ col: 6 }} desktop={{ col: 3 }}>
+            Secondary nav
+          </Grid>
+          <Grid mobileLg={{ col: 6 }} desktop={{ col: 3 }}>
+            Secondary nav
+          </Grid>
+          <Grid mobileLg={{ col: 6 }} desktop={{ col: 3 }}>
+            Secondary nav
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid tablet={{ col: 4 }}>Sign up form</Grid>
+    </Grid>
+    <Grid row gap>
+      <Grid row mobileLg={{ col: 6, gap: 2 }}>
+        <Grid mobileLg={{ col: 'auto' }}>Logo</Grid>
+        <Grid mobileLg={{ col: 'auto' }}>Name of Agency</Grid>
+      </Grid>
+      <Grid mobileLg={{ col: 6 }}>
+        <Grid row gap={1}>
+          <Grid col="auto">Social</Grid>
+          <Grid col="auto">Social</Grid>
+          <Grid col="auto">Social</Grid>
+          <Grid col="auto">Social</Grid>
+        </Grid>
+        <Grid row gap>
+          Contact Info
+        </Grid>
+      </Grid>
+    </Grid>
+  </GridContainer>
 )

--- a/src/components/grid/Grid.stories.tsx
+++ b/src/components/grid/Grid.stories.tsx
@@ -356,6 +356,14 @@ export const gutters = (): React.ReactElement => (
   </>
 )
 
+export const cardContainer = (): React.ReactElement => (
+  <GridContainer containerSize="card">{testContent}</GridContainer>
+)
+
+export const cardLgContainer = (): React.ReactElement => (
+  <GridContainer containerSize="card-lg">{testContent}</GridContainer>
+)
+
 export const mobileContainer = (): React.ReactElement => (
   <GridContainer containerSize="mobile">{testContent}</GridContainer>
 )

--- a/src/components/grid/Grid.stories.tsx
+++ b/src/components/grid/Grid.stories.tsx
@@ -1,0 +1,144 @@
+import React from 'react'
+
+import { GridContainer } from './GridContainer/GridContainer'
+import { Grid } from './Grid/Grid'
+
+export default {
+  title: 'Grid',
+  parameters: {
+    info: `
+USWDS 2.0 Grid components
+
+Source: https://designsystem.digital.gov/utilities/layout-grid/
+`,
+  },
+}
+
+const exampleStyles = {
+  border: '1px solid',
+  padding: '1rem',
+  backgroundColor: '#e1e7f1',
+}
+
+const testContent = <div style={exampleStyles}>Content</div>
+
+export const defaultContainer = (): React.ReactElement => (
+  <GridContainer>
+    <Grid row>
+      <Grid col>{testContent}</Grid>
+      <Grid col>{testContent}</Grid>
+      <Grid col>{testContent}</Grid>
+    </Grid>
+  </GridContainer>
+)
+
+export const columnSpans = (): React.ReactElement => (
+  <GridContainer>
+    <Grid row>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={11}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={2}>{testContent}</Grid>
+      <Grid col={10}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={3}>{testContent}</Grid>
+      <Grid col={9}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={4}>{testContent}</Grid>
+      <Grid col={8}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={5}>{testContent}</Grid>
+      <Grid col={7}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={6}>{testContent}</Grid>
+      <Grid col={6}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+      <Grid col={1}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={2}>{testContent}</Grid>
+      <Grid col={2}>{testContent}</Grid>
+      <Grid col={2}>{testContent}</Grid>
+      <Grid col={2}>{testContent}</Grid>
+      <Grid col={2}>{testContent}</Grid>
+      <Grid col={2}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={3}>{testContent}</Grid>
+      <Grid col={3}>{testContent}</Grid>
+      <Grid col={3}>{testContent}</Grid>
+      <Grid col={3}>{testContent}</Grid>
+    </Grid>
+    <Grid row>
+      <Grid col={4}>{testContent}</Grid>
+      <Grid col={4}>{testContent}</Grid>
+      <Grid col={4}>{testContent}</Grid>
+    </Grid>
+  </GridContainer>
+)
+
+export const autoLayoutColumns = (): React.ReactElement => (
+  <GridContainer>
+    <Grid row>
+      <Grid col="auto">{testContent}</Grid>
+      <Grid col="fill">{testContent}</Grid>
+      <Grid col="fill">{testContent}</Grid>
+      <Grid col="auto">{testContent}</Grid>
+    </Grid>
+  </GridContainer>
+)
+
+export const offsetColumns = (): React.ReactElement => (
+  <GridContainer>
+    <Grid row>
+      <Grid col={8} offset={4}>
+        {testContent}
+      </Grid>
+    </Grid>
+  </GridContainer>
+)
+
+export const mobileContainer = (): React.ReactElement => (
+  <GridContainer containerSize="mobile">{testContent}</GridContainer>
+)
+
+export const mobileLgContainer = (): React.ReactElement => (
+  <GridContainer containerSize="mobile-lg">{testContent}</GridContainer>
+)
+
+export const tabletContainer = (): React.ReactElement => (
+  <GridContainer containerSize="tablet">{testContent}</GridContainer>
+)
+
+export const tabletLgContainer = (): React.ReactElement => (
+  <GridContainer containerSize="tablet-lg">{testContent}</GridContainer>
+)
+
+export const desktopContainer = (): React.ReactElement => (
+  <GridContainer containerSize="desktop">{testContent}</GridContainer>
+)
+
+export const desktopLgContainer = (): React.ReactElement => (
+  <GridContainer containerSize="desktop-lg">{testContent}</GridContainer>
+)
+
+export const widescreenContainer = (): React.ReactElement => (
+  <GridContainer containerSize="widescreen">{testContent}</GridContainer>
+)

--- a/src/components/grid/Grid/Grid.test.tsx
+++ b/src/components/grid/Grid/Grid.test.tsx
@@ -1,7 +1,46 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import { Grid } from './Grid'
+import { Grid, getGridClasses } from './Grid'
+
+describe('getGridClasses', () => {
+  it('returns the classes with no breakpoint', () => {
+    expect(
+      getGridClasses({
+        col: 3,
+        offset: 5,
+      })
+    ).toEqual('grid-col-3 grid-offset-5')
+
+    expect(getGridClasses({ col: true })).toEqual('grid-col')
+
+    expect(getGridClasses({ col: 'auto' })).toEqual('grid-col-auto')
+    expect(getGridClasses({ col: 'fill' })).toEqual('grid-col-fill')
+
+    expect(getGridClasses({ row: true })).toEqual('grid-row')
+    expect(getGridClasses({ row: true, gap: true })).toEqual(
+      'grid-row grid-gap'
+    )
+
+    expect(
+      getGridClasses({
+        row: true,
+        gap: 'sm',
+      })
+    ).toEqual('grid-row grid-gap-sm')
+  })
+
+  it('returns the classes with a given breakpoint', () => {
+    expect(getGridClasses({ col: true }, 'tablet')).toEqual('tablet:grid-col')
+    expect(getGridClasses({ col: 4 }, 'tablet')).toEqual('tablet:grid-col-4')
+    expect(getGridClasses({ gap: 2, col: 6 }, 'mobileLg')).toContain(
+      'mobile-lg:grid-col-6'
+    )
+    expect(getGridClasses({ gap: 2, col: 6 }, 'mobileLg')).toContain(
+      'mobile-lg:grid-gap-2'
+    )
+  })
+})
 
 describe('Grid component', () => {
   it('renders without errors', () => {
@@ -47,5 +86,10 @@ describe('Grid component', () => {
   it('implements the gap size prop', () => {
     const { getByTestId } = render(<Grid gap="sm">My Content</Grid>)
     expect(getByTestId('grid')).toHaveClass('grid-gap-sm')
+  })
+
+  it('implements breakpoint props', () => {
+    const { getByTestId } = render(<Grid tablet={{ col: 8 }}>My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('tablet:grid-col-8')
   })
 })

--- a/src/components/grid/Grid/Grid.test.tsx
+++ b/src/components/grid/Grid/Grid.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { Grid } from './Grid'
+
+describe('Grid component', () => {
+  it('renders without errors', () => {
+    const { queryByTestId } = render(<Grid />)
+    expect(queryByTestId('grid')).toBeInTheDocument()
+  })
+
+  it('renders its children', () => {
+    const { queryByText } = render(<Grid>My Content</Grid>)
+    expect(queryByText('My Content')).toBeInTheDocument()
+  })
+
+  it('implements the col prop', () => {
+    const { getByTestId } = render(<Grid col={5}>My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-col-5')
+  })
+
+  it('implements the col auto prop', () => {
+    const { getByTestId } = render(<Grid col="auto">My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-col-auto')
+  })
+
+  it('implements the col fill prop', () => {
+    const { getByTestId } = render(<Grid col="fill">My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-col-fill')
+  })
+
+  it('implements the offset prop', () => {
+    const { getByTestId } = render(<Grid offset={4}>My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-offset-4')
+  })
+
+  it('implements the row prop', () => {
+    const { getByTestId } = render(<Grid row>My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-row')
+  })
+
+  it('implements the gap prop', () => {
+    const { getByTestId } = render(<Grid gap>My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-gap')
+  })
+
+  it('implements the gap size prop', () => {
+    const { getByTestId } = render(<Grid gap="sm">My Content</Grid>)
+    expect(getByTestId('grid')).toHaveClass('grid-gap-sm')
+  })
+})

--- a/src/components/grid/Grid/Grid.tsx
+++ b/src/components/grid/Grid/Grid.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import { ColumnSizes, GapSizes, ColumnOffsets } from '../types'
+
+interface GridColProps {
+  row?: boolean
+  col?: ColumnSizes
+  gap?: GapSizes
+  offset?: ColumnOffsets
+}
+
+interface GridProps extends GridColProps {
+  // breakpoints
+  mobile?: GridColProps
+  mobileLg?: GridColProps
+  tablet?: GridColProps
+  // etc.
+}
+
+export const Grid = ({
+  row,
+  col,
+  gap,
+  offset,
+  children,
+  ...props
+}: GridProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
+  const classes = classnames({
+    'grid-row': row,
+    'grid-gap': gap === true,
+    [`grid-gap-${gap}`]: !!gap,
+    'grid-col': col === true,
+    [`grid-col-${col}`]: !!col,
+    [`grid-offset-${offset}`]: !!offset,
+  })
+
+  return (
+    <div className={classes} data-testid="grid" {...props}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/grid/Grid/Grid.tsx
+++ b/src/components/grid/Grid/Grid.tsx
@@ -56,7 +56,6 @@ export const Grid = ({
   Object.keys(breakpoints).forEach((b) => {
     const bp = b as BreakpointKeys
     if (Object.prototype.hasOwnProperty.call(props, bp)) {
-      console.log('grid has breakpoint props', bp)
       const bpProps = props[bp] as GridItemProps
       classes = classnames(classes, getGridClasses(bpProps, bp))
     }

--- a/src/components/grid/Grid/Grid.tsx
+++ b/src/components/grid/Grid/Grid.tsx
@@ -30,6 +30,7 @@ export const getGridClasses = (
 
 export const Grid = ({
   children,
+  className,
   ...props
 }: GridProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
   const {
@@ -60,6 +61,9 @@ export const Grid = ({
       classes = classnames(classes, getGridClasses(bpProps, bp))
     }
   })
+
+  // Pass in any custom classes
+  classes = classnames(classes, className)
 
   return (
     <div className={classes} data-testid="grid" {...otherProps}>

--- a/src/components/grid/GridContainer/GridContainer.test.tsx
+++ b/src/components/grid/GridContainer/GridContainer.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { GridContainer } from './GridContainer'
+
+describe('GridContainer component', () => {
+  it('renders without errors', () => {
+    const { queryByTestId } = render(<GridContainer />)
+    expect(queryByTestId('gridContainer')).toBeInTheDocument()
+  })
+
+  it('renders its children', () => {
+    const { queryByText } = render(<GridContainer>My Content</GridContainer>)
+    expect(queryByText('My Content')).toBeInTheDocument()
+  })
+
+  it('implements the containerSize prop', () => {
+    const { getByTestId } = render(
+      <GridContainer containerSize="tablet-lg">My Content</GridContainer>
+    )
+    expect(getByTestId('gridContainer')).toHaveClass('grid-container-tablet-lg')
+  })
+})

--- a/src/components/grid/GridContainer/GridContainer.tsx
+++ b/src/components/grid/GridContainer/GridContainer.tsx
@@ -10,13 +10,17 @@ type GridContainerProps = {
 export const GridContainer = ({
   children,
   containerSize,
+  className,
   ...props
 }: GridContainerProps &
   React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
-  const classes = classnames({
-    'grid-container': !containerSize,
-    [`grid-container-${containerSize}`]: !!containerSize,
-  })
+  const classes = classnames(
+    {
+      'grid-container': !containerSize,
+      [`grid-container-${containerSize}`]: !!containerSize,
+    },
+    className
+  )
 
   return (
     <div className={classes} data-testid="gridContainer" {...props}>

--- a/src/components/grid/GridContainer/GridContainer.tsx
+++ b/src/components/grid/GridContainer/GridContainer.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import { ContainerSizes } from '../types'
+
+type GridContainerProps = {
+  containerSize?: ContainerSizes
+}
+
+export const GridContainer = ({
+  children,
+  containerSize,
+  ...props
+}: GridContainerProps &
+  React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
+  const classes = classnames({
+    'grid-container': !containerSize,
+    [`grid-container-${containerSize}`]: !!containerSize,
+  })
+
+  return (
+    <div className={classes} data-testid="gridContainer" {...props}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/grid/types.ts
+++ b/src/components/grid/types.ts
@@ -8,20 +8,11 @@ export const breakpoints = {
   widescreen: 'widescreen',
 }
 
-export type Breakpoints =
-  | 'card'
-  | 'card-lg'
-  | 'mobile'
-  | 'mobile-lg'
-  | 'tablet'
-  | 'tablet-lg'
-  | 'desktop'
-  | 'desktop-lg'
-  | 'widescreen'
-
 export type BreakpointKeys = keyof typeof breakpoints
 
 export type ContainerSizes =
+  | 'card'
+  | 'card-lg'
   | 'mobile'
   | 'mobile-lg'
   | 'tablet'

--- a/src/components/grid/types.ts
+++ b/src/components/grid/types.ts
@@ -1,0 +1,52 @@
+export type Breakpoints =
+  | 'card'
+  | 'card-lg'
+  | 'mobile'
+  | 'mobile-lg'
+  | 'tablet'
+  | 'tablet-lg'
+  | 'desktop'
+  | 'desktop-lg'
+  | 'widescreen'
+
+export type ContainerSizes =
+  | 'mobile'
+  | 'mobile-lg'
+  | 'tablet'
+  | 'tablet-lg'
+  | 'desktop'
+  | 'desktop-lg'
+  | 'widescreen'
+
+export type GapSizes =
+  | true
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | '2px'
+  | '05'
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+
+export type ColumnSizes =
+  | true
+  | 'auto'
+  | 'fill'
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+
+export type ColumnOffsets = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11

--- a/src/components/grid/types.ts
+++ b/src/components/grid/types.ts
@@ -1,3 +1,13 @@
+export const breakpoints = {
+  mobile: 'mobile',
+  mobileLg: 'mobile-lg',
+  tablet: 'tablet',
+  tabletLg: 'tablet-lg',
+  desktop: 'desktop',
+  desktopLg: 'desktop-lg',
+  widescreen: 'widescreen',
+}
+
 export type Breakpoints =
   | 'card'
   | 'card-lg'
@@ -8,6 +18,8 @@ export type Breakpoints =
   | 'desktop'
   | 'desktop-lg'
   | 'widescreen'
+
+export type BreakpointKeys = keyof typeof breakpoints
 
 export type ContainerSizes =
   | 'mobile'
@@ -50,3 +62,10 @@ export type ColumnSizes =
   | 12
 
 export type ColumnOffsets = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
+
+export interface GridItemProps {
+  row?: boolean
+  col?: ColumnSizes
+  gap?: GapSizes
+  offset?: ColumnOffsets
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ export { Table } from './components/Table/Table'
 export { Tag } from './components/Tag/Tag'
 export { SideNav } from './components/SideNav/SideNav'
 
+/** Grid components */
+export { GridContainer } from './components/grid/GridContainer/GridContainer'
+export { Grid } from './components/grid/Grid/Grid'
+
 /** Form components */
 export { Checkbox } from './components/forms/Checkbox/Checkbox'
 export { Dropdown } from './components/forms/Dropdown/Dropdown'


### PR DESCRIPTION
## USWDS Grid Components

This PR adds some components to help render content within the [USWDS grid layout](https://designsystem.digital.gov/utilities/layout-grid/), along with Storybook stories to demonstrate how they can be used.

**GridContainer** -- Renders children inside a `<div>` and implements a grid container size which can be also specified via props.

**Grid** -- Renders children inside a `<div>` and accepts props to help determine how the div should layout within the grid container. A set of these props (`GridItemProps = row, col, gap, offset`) can be passed in directly to the `Grid` component, and/or they can also be passed in as an object to a breakpoint size prop to assign those classes to be applied at that breakpoint and above. See examples below.

### Example usage:

```
// Two cells spanning 3 and 9 columns within one row
<GridContainer>
  <Grid row>
    <Grid col={3}>{testContent}</Grid>
    <Grid col={9}>{testContent}</Grid>
  </Grid>
</GridContainer>

// Three cells that are stacked vertically below the tablet breakpoint, and take up equal width of one row at tablet and above
<GridContainer>
  <Grid row>
    <Grid tablet={{ col: true }}>{testContent}</Grid>
    <Grid tablet={{ col: true }}>{testContent}</Grid>
    <Grid tablet={{ col: true }}>{testContent}</Grid>
  </Grid>
</GridContainer>
```

![image](https://user-images.githubusercontent.com/2723066/81728317-e0056a80-944f-11ea-8b46-fcec6070ddc2.png)

![image](https://user-images.githubusercontent.com/2723066/81728367-f4e1fe00-944f-11ea-8d0e-66b0215a412e.png)
