### PR TITLE
fix: removes the usa-search class name from the form component

### DIFF
--- a/src/components/forms/Form/Form.tsx
+++ b/src/components/forms/Form/Form.tsx
@@ -17,7 +17,6 @@ export const Form = (
   const classes = classnames(
     {
       'usa-form': !search,
-      'usa-search': search,
       'usa-form--large': large,
     },
     className


### PR DESCRIPTION
The `usa-search` class was being added twice when using the Search component because it was also being defined on the Form component.

This leaves the class on the Search component in favor of removing it from the Form component.

fix #163