### PR TITLE
fix: extends header menu to accept list props for corresponding id

### DIFF
--- a/src/components/header/Header/Header.stories.tsx
+++ b/src/components/header/Header/Header.stories.tsx
@@ -59,7 +59,12 @@ export const BasicHeader = (): React.ReactElement => {
         label="Nav Label"
         isCurrent={true}
       />
-      <Menu key="one" items={testMenuItems} isOpen={isOpen[0]} />
+      <Menu
+        key="one"
+        items={testMenuItems}
+        isOpen={isOpen[0]}
+        id="testDropDownOne"
+      />
     </>,
     <a href="#two" key="two" className="usa-nav__link">
       <span>Parent link</span>
@@ -153,18 +158,28 @@ export const BasicHeaderWithMegaMenu = (): React.ReactElement => {
         label="Nav Label"
         isCurrent={true}
       />
-      <MegaMenu key="one" items={testItemsMegaOne} isOpen={isOpen[0]} />
+      <MegaMenu
+        key="one"
+        items={testItemsMegaOne}
+        isOpen={isOpen[0]}
+        id="testDropDownOne"
+      />
     </>,
     <>
       <NavDropDownButton
         onToggle={(): void => {
           onToggle(1)
         }}
-        menuId="testDropDownOne"
+        menuId="testDropDownTwo"
         isOpen={isOpen[1]}
         label="Nav Label"
       />
-      <MegaMenu key="one" items={testItemsMegaTwo} isOpen={isOpen[1]} />
+      <MegaMenu
+        key="one"
+        items={testItemsMegaTwo}
+        isOpen={isOpen[1]}
+        id="testDropDownTwo"
+      />
     </>,
     <a href="#two" key="two" className="usa-nav__link">
       <span>Parent link</span>
@@ -228,7 +243,12 @@ export const extendedHeader = (): React.ReactElement => {
         label="Nav Label"
         isCurrent={true}
       />
-      <Menu key="one" items={testMenuItems} isOpen={isOpen[0]} />
+      <Menu
+        key="one"
+        items={testMenuItems}
+        isOpen={isOpen[0]}
+        id="testDropDownOne"
+      />
     </>,
     <a href="#two" key="two" className="usa-nav__link">
       <span>Parent link</span>
@@ -310,7 +330,12 @@ export const extendedHeaderWithMegaMenu = (): React.ReactElement => {
         label="Nav Label"
         isCurrent={true}
       />
-      <MegaMenu key="one" items={testItemsMegaOne} isOpen={isOpen[0]} />
+      <MegaMenu
+        key="one"
+        items={testItemsMegaOne}
+        isOpen={isOpen[0]}
+        id="testDropDownOne"
+      />
     </>,
     <a href="#two" key="two" className="usa-nav__link">
       <span>Parent link</span>

--- a/src/components/header/MegaMenu/MegaMenu.tsx
+++ b/src/components/header/MegaMenu/MegaMenu.tsx
@@ -7,8 +7,10 @@ type MegaMenuProps = {
   isOpen: boolean
 }
 
-export const MegaMenu = (props: MegaMenuProps): React.ReactElement => {
-  const { items, isOpen } = props
+export const MegaMenu = (
+  props: MegaMenuProps & React.HTMLAttributes<HTMLUListElement>
+): React.ReactElement => {
+  const { items, isOpen, ...ulProps } = props
   return (
     <div
       className="usa-nav__submenu usa-megamenu"
@@ -17,7 +19,7 @@ export const MegaMenu = (props: MegaMenuProps): React.ReactElement => {
       <div className="grid-row grid-gap-4">
         {items.map((listItems, i) => (
           <div className="usa-col" key={`subnav_col_${i}`}>
-            <NavList items={listItems} megamenu={true} />
+            <NavList items={listItems} megamenu={true} {...ulProps} />
           </div>
         ))}
       </div>

--- a/src/components/header/Menu/Menu.tsx
+++ b/src/components/header/Menu/Menu.tsx
@@ -6,9 +6,11 @@ type MenuProps = {
   isOpen: boolean
 }
 
-export const Menu = (props: MenuProps): React.ReactElement => {
-  const { items, isOpen } = props
-  return <NavList items={items} subnav={true} hidden={!isOpen} />
+export const Menu = (
+  props: MenuProps & React.HTMLAttributes<HTMLUListElement>
+): React.ReactElement => {
+  const { items, isOpen, ...listProps } = props
+  return <NavList items={items} subnav={true} hidden={!isOpen} {...listProps} />
 }
 
 export default Menu


### PR DESCRIPTION
The NavDropDownButton has a `menuId` property configured but the Menu and MegaMenu components were not passing unordered list attributes to through to their NavList components so the id was not connected.

A header menu story had two NavDropDownButton components with the same `menuId` so I updated those to be unique.  If there are other tests or stories that make sense to add/update let me know.

fix #165