### PR TITLE
fix: update gov banner to new version

### DIFF
--- a/src/components/GovBanner/GovBanner.stories.tsx
+++ b/src/components/GovBanner/GovBanner.stories.tsx
@@ -3,4 +3,6 @@ import { GovBanner } from './GovBanner'
 
 export default { title: 'GovBanner', component: GovBanner }
 
-export const govBanner = (): React.ReactElement => <GovBanner />
+export const govBanner = (): React.ReactElement => (
+  <GovBanner aria-label="Official government website" />
+)

--- a/src/components/GovBanner/GovBanner.test.tsx
+++ b/src/components/GovBanner/GovBanner.test.tsx
@@ -8,4 +8,11 @@ describe('GovBanner component', () => {
     const { queryByTestId } = render(<GovBanner />)
     expect(queryByTestId('govBanner')).toBeInTheDocument()
   })
+
+  it('renders section attributes passed in through props', () => {
+    const { queryByTestId } = render(
+      <GovBanner aria-label="Official government website" />
+    )
+    expect(queryByTestId('govBanner')).toHaveAttribute('aria-label')
+  })
 })

--- a/src/components/GovBanner/GovBanner.tsx
+++ b/src/components/GovBanner/GovBanner.tsx
@@ -1,15 +1,21 @@
 import React, { useState } from 'react'
+import classnames from 'classnames'
 
 // assets
 import flagImg from 'uswds/src/img/us_flag_small.png'
 import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
 import httpsIcon from 'uswds/src/img/icon-https.svg'
 
-export const GovBanner = (): React.ReactElement => {
+export const GovBanner = (
+  props: React.HTMLAttributes<HTMLElement>
+): React.ReactElement => {
+  const { className, ...sectionProps } = props
   const [isOpen, setOpenState] = useState(false)
 
+  const classes = classnames('usa-banner', className)
+
   return (
-    <div className="usa-banner" data-testid="govBanner">
+    <section className={classes} data-testid="govBanner" {...sectionProps}>
       <div className="usa-accordion">
         <header className="usa-banner__header">
           <div className="usa-banner__inner">
@@ -82,7 +88,7 @@ export const GovBanner = (): React.ReactElement => {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## PR Description 
This was only a minor change of a div element to a section element. Additionally, I added props to the section element so html attributes like an aria-label could be passed into the component. 

## For Reviewers 
Please let me know if adding the html attributes is over kill. I mainly added them so an aria label could be passed through. When I was comparing the guidance markup and our component markup the lack of the label was the only difference I saw after updating the div to a section. 
