### PR TITLE
feat(rangeinput): creates form RangeInput component, test, and stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "Sara Bocciardi <sara@truss.works>",
     "Jeri Sommers <sojeri@truss.works>",
     "Emily Mahanna <emahanna@truss.works>",
-    "Hana Worku <hana@truss.works>"
+    "Hana Worku <hana@truss.works>",
+    "Duncan Spencer <duncan@truss.works>"
   ],
   "license": "Apache-2.0",
   "bugs": {

--- a/src/components/forms/RangeInput/RangeInput.stories.tsx
+++ b/src/components/forms/RangeInput/RangeInput.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { RangeInput } from './RangeInput'
-import Label from '../Label/Label'
 
 export default {
   title: 'Forms/RangeInput',
@@ -27,7 +26,7 @@ const labelChildren = (
 const labelHint = <>(Some hint)</>
 
 export const defaultRange = (): React.ReactElement => (
-  <RangeInput label="Range slider" />
+  <RangeInput id="range-slider" name="range" />
 )
 
 export const customRange = (): React.ReactElement => (
@@ -35,7 +34,6 @@ export const customRange = (): React.ReactElement => (
     id="custom-range-slider"
     name="rangeValue"
     className="dark-theme"
-    label="Range slider"
     min={1}
     max={11}
     step={2}
@@ -43,15 +41,12 @@ export const customRange = (): React.ReactElement => (
   />
 )
 
-export const richLabelRange = (): React.ReactElement => (
-  <RangeInput label={labelChildren} hint={labelHint} />
-)
-
 // Only tick marks are shown in Chrome but not with usa-range class currently because the appearance property is set to none
 export const dataListRange = (): React.ReactElement => (
   <>
     <RangeInput
-      label="Range from datalist"
+      id="range-slider"
+      name="range"
       min={0}
       max={4}
       defaultValue={2}

--- a/src/components/forms/RangeInput/RangeInput.stories.tsx
+++ b/src/components/forms/RangeInput/RangeInput.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { RangeInput } from './RangeInput'
+import { Label } from '../Label/Label'
 
 export default {
   title: 'Forms/RangeInput',
@@ -18,15 +19,20 @@ const labelChildren = (
       <span>Start:</span> <span>0</span>
     </div>
     <div>
-      <span>End:</span> <span>10</span>
+      <span>End:</span> <span>100</span>
     </div>
   </>
 )
 
-const labelHint = <>(Some hint)</>
+const labelHint = <>(drag to adjust or use arrow keys)</>
 
 export const defaultRange = (): React.ReactElement => (
-  <RangeInput id="range-slider" name="range" />
+  <>
+    <Label htmlFor="range-slider" hint={labelHint}>
+      {labelChildren}
+    </Label>
+    <RangeInput id="range-slider" name="range" />
+  </>
 )
 
 export const customRange = (): React.ReactElement => (

--- a/src/components/forms/RangeInput/RangeInput.stories.tsx
+++ b/src/components/forms/RangeInput/RangeInput.stories.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { RangeInput } from './RangeInput'
+import Label from '../Label/Label'
+
+export default {
+  title: 'Forms/RangeInput',
+  parameters: {
+    info: `
+USWDS 2.0 RangeInput component
+
+Source: https://designsystem.digital.gov/components/form-controls/#range
+`,
+  },
+}
+
+const labelChildren = (
+  <>
+    <div>
+      <span>Start:</span> <span>0</span>
+    </div>
+    <div>
+      <span>End:</span> <span>10</span>
+    </div>
+  </>
+)
+
+const labelHint = <>(Some hint)</>
+
+export const defaultRange = (): React.ReactElement => (
+  <RangeInput label="Range slider" />
+)
+
+export const customRange = (): React.ReactElement => (
+  <RangeInput
+    id="custom-range-slider"
+    name="rangeValue"
+    className="dark-theme"
+    label="Range slider"
+    min={1}
+    max={11}
+    step={2}
+    defaultValue={3}
+  />
+)
+
+export const richLabelRange = (): React.ReactElement => (
+  <RangeInput label={labelChildren} hint={labelHint} />
+)
+
+// Only tick marks are shown in Chrome but not with usa-range class currently because the appearance property is set to none
+export const dataListRange = (): React.ReactElement => (
+  <>
+    <RangeInput
+      label="Range from datalist"
+      min={0}
+      max={4}
+      defaultValue={2}
+      list="range-list-id"
+    />
+    <datalist id="range-list-id">
+      <option>0</option>
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+    </datalist>
+  </>
+)

--- a/src/components/forms/RangeInput/RangeInput.test.tsx
+++ b/src/components/forms/RangeInput/RangeInput.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, queryByText } from '@testing-library/react'
+
+import { RangeInput } from './RangeInput'
+
+describe('RangeInput component', () => {
+  it('renders without errors', () => {
+    const { queryByTestId } = render(
+      <RangeInput className="additional-class" />
+    )
+    const rangeElement = queryByTestId('range')
+
+    expect(rangeElement).toBeInTheDocument()
+    expect(rangeElement).toHaveAttribute('id', 'range-slider')
+    expect(rangeElement).toHaveAttribute('name', 'range')
+    expect(rangeElement).toHaveClass('usa-range')
+    expect(rangeElement).toHaveClass('additional-class')
+  })
+
+  it('renders with Label', () => {
+    const { queryByLabelText } = render(
+      <RangeInput id="range-input" name="range" label="Range Label" />
+    )
+    expect(queryByLabelText('Range Label')).toBeInTheDocument()
+  })
+
+  it('renders Label with hint', () => {
+    const { queryByLabelText } = render(
+      <RangeInput label="Range Label" hint="(hint text)" />
+    )
+    expect(queryByLabelText('Range Label(hint text)')).toBeInTheDocument()
+  })
+
+  it('renders with custom range values', () => {
+    const { queryByTestId } = render(
+      <RangeInput
+        label="minutes"
+        min={0}
+        max={60}
+        step={15}
+        defaultValue={45}
+      />
+    )
+    expect(queryByTestId('range')).toHaveAttribute('min', '0')
+    expect(queryByTestId('range')).toHaveAttribute('max', '60')
+    expect(queryByTestId('range')).toHaveAttribute('step', '15')
+    expect(queryByTestId('range')).toHaveAttribute('value', '45')
+  })
+
+  it('renders with any step attribute', () => {
+    const { queryByTestId } = render(
+      <RangeInput min={0} max={60} step="any" defaultValue={45} />
+    )
+    expect(queryByTestId('range')).toHaveAttribute('min', '0')
+    expect(queryByTestId('range')).toHaveAttribute('max', '60')
+    expect(queryByTestId('range')).toHaveAttribute('step', 'any')
+    expect(queryByTestId('range')).toHaveAttribute('value', '45')
+  })
+})

--- a/src/components/forms/RangeInput/RangeInput.test.tsx
+++ b/src/components/forms/RangeInput/RangeInput.test.tsx
@@ -6,35 +6,26 @@ import { RangeInput } from './RangeInput'
 describe('RangeInput component', () => {
   it('renders without errors', () => {
     const { queryByTestId } = render(
-      <RangeInput className="additional-class" />
+      <RangeInput
+        id="range-slider-id"
+        name="rangeName"
+        className="additional-class"
+      />
     )
     const rangeElement = queryByTestId('range')
 
     expect(rangeElement).toBeInTheDocument()
-    expect(rangeElement).toHaveAttribute('id', 'range-slider')
-    expect(rangeElement).toHaveAttribute('name', 'range')
+    expect(rangeElement).toHaveAttribute('id', 'range-slider-id')
+    expect(rangeElement).toHaveAttribute('name', 'rangeName')
     expect(rangeElement).toHaveClass('usa-range')
     expect(rangeElement).toHaveClass('additional-class')
-  })
-
-  it('renders with Label', () => {
-    const { queryByLabelText } = render(
-      <RangeInput id="range-input" name="range" label="Range Label" />
-    )
-    expect(queryByLabelText('Range Label')).toBeInTheDocument()
-  })
-
-  it('renders Label with hint', () => {
-    const { queryByLabelText } = render(
-      <RangeInput label="Range Label" hint="(hint text)" />
-    )
-    expect(queryByLabelText('Range Label(hint text)')).toBeInTheDocument()
   })
 
   it('renders with custom range values', () => {
     const { queryByTestId } = render(
       <RangeInput
-        label="minutes"
+        id="range-slider-id"
+        name="rangeName"
         min={0}
         max={60}
         step={15}
@@ -47,13 +38,30 @@ describe('RangeInput component', () => {
     expect(queryByTestId('range')).toHaveAttribute('value', '45')
   })
 
-  it('renders with any step attribute', () => {
+  it('renders with step attribute set to value any', () => {
     const { queryByTestId } = render(
-      <RangeInput min={0} max={60} step="any" defaultValue={45} />
+      <RangeInput id="range-slider-id" name="rangeName" step="any" />
     )
-    expect(queryByTestId('range')).toHaveAttribute('min', '0')
-    expect(queryByTestId('range')).toHaveAttribute('max', '60')
     expect(queryByTestId('range')).toHaveAttribute('step', 'any')
-    expect(queryByTestId('range')).toHaveAttribute('value', '45')
+  })
+
+  it('renders with specified datalist attribute', () => {
+    const { queryByTestId } = render(
+      <RangeInput
+        id="range-slider-id"
+        name="rangeName"
+        list="some-datalist-id"
+      />
+    )
+    expect(queryByTestId('range')).toHaveAttribute('list', 'some-datalist-id')
+  })
+
+  it('renders with attached ref', () => {
+    const rangeRef: React.RefObject<HTMLInputElement> = React.createRef()
+
+    const { queryByTestId } = render(
+      <RangeInput id="range-slider-id" name="rangeName" inputRef={rangeRef} />
+    )
+    expect(queryByTestId('range')).toEqual(rangeRef.current)
   })
 })

--- a/src/components/forms/RangeInput/RangeInput.tsx
+++ b/src/components/forms/RangeInput/RangeInput.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import { Label } from '../Label/Label'
+
+interface RangeInputProps {
+  id?: string
+  name?: string
+  className?: string
+  label?: React.ReactNode
+  hint?: React.ReactNode
+  min?: number
+  max?: number
+  step?: number | 'any'
+  list?: string
+  inputRef?:
+    | string
+    | ((instance: HTMLInputElement | null) => void)
+    | React.RefObject<HTMLInputElement>
+    | null
+    | undefined
+}
+
+export const RangeInput = (
+  props: RangeInputProps & React.InputHTMLAttributes<HTMLInputElement>
+): React.ReactElement => {
+  // Range defaults to min = 0, max = 10, step = 1, and value = (max/2) if not specified.
+  const {
+    id = 'range-slider',
+    name = 'range',
+    className,
+    label,
+    hint,
+    min,
+    max,
+    step,
+    list,
+    inputRef,
+    ...inputProps
+  } = props
+
+  const classes = classnames('usa-range', className)
+
+  return (
+    <>
+      {label && (
+        <Label htmlFor={id} hint={hint}>
+          {label}
+        </Label>
+      )}
+      <input
+        id={id}
+        data-testid="range"
+        name={name}
+        className={classes}
+        ref={inputRef}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        list={list}
+        {...inputProps}
+      />
+    </>
+  )
+}
+
+export default RangeInput

--- a/src/components/forms/RangeInput/RangeInput.tsx
+++ b/src/components/forms/RangeInput/RangeInput.tsx
@@ -4,10 +4,8 @@ import classnames from 'classnames'
 import { Label } from '../Label/Label'
 
 interface RangeInputProps {
-  id?: string
-  className?: string
-  label?: React.ReactNode
-  hint?: React.ReactNode
+  id: string
+  name: string
   inputRef?:
     | string
     | ((instance: HTMLInputElement | null) => void)
@@ -20,43 +18,18 @@ export const RangeInput = (
   props: RangeInputProps & React.InputHTMLAttributes<HTMLInputElement>
 ): React.ReactElement => {
   // Range defaults to min = 0, max = 100, step = 1, and value = (max/2) if not specified.
-  const {
-    id = 'range-slider',
-    name = 'range',
-    className,
-    label,
-    hint,
-    min,
-    max,
-    step,
-    list,
-    inputRef,
-    ...inputProps
-  } = props
+  const { className, inputRef, ...inputProps } = props
 
   const classes = classnames('usa-range', className)
 
   return (
-    <>
-      {label && (
-        <Label htmlFor={id} hint={hint}>
-          {label}
-        </Label>
-      )}
-      <input
-        id={id}
-        data-testid="range"
-        name={name}
-        className={classes}
-        ref={inputRef}
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        list={list}
-        {...inputProps}
-      />
-    </>
+    <input
+      data-testid="range"
+      className={classes}
+      ref={inputRef}
+      type="range"
+      {...inputProps}
+    />
   )
 }
 

--- a/src/components/forms/RangeInput/RangeInput.tsx
+++ b/src/components/forms/RangeInput/RangeInput.tsx
@@ -5,14 +5,9 @@ import { Label } from '../Label/Label'
 
 interface RangeInputProps {
   id?: string
-  name?: string
   className?: string
   label?: React.ReactNode
   hint?: React.ReactNode
-  min?: number
-  max?: number
-  step?: number | 'any'
-  list?: string
   inputRef?:
     | string
     | ((instance: HTMLInputElement | null) => void)
@@ -24,7 +19,7 @@ interface RangeInputProps {
 export const RangeInput = (
   props: RangeInputProps & React.InputHTMLAttributes<HTMLInputElement>
 ): React.ReactElement => {
-  // Range defaults to min = 0, max = 10, step = 1, and value = (max/2) if not specified.
+  // Range defaults to min = 0, max = 100, step = 1, and value = (max/2) if not specified.
   const {
     id = 'range-slider',
     name = 'range',

--- a/src/components/forms/RangeInput/RangeInput.tsx
+++ b/src/components/forms/RangeInput/RangeInput.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { Label } from '../Label/Label'
-
 interface RangeInputProps {
   id: string
   name: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { Form } from './components/forms/Form/Form'
 export { FormGroup } from './components/forms/FormGroup/FormGroup'
 export { Label } from './components/forms/Label/Label'
 export { Radio } from './components/forms/Radio/Radio'
+export { RangeInput } from './components/forms/RangeInput/RangeInput'
 export { Textarea } from './components/forms/Textarea/Textarea'
 export { TextInput } from './components/forms/TextInput/TextInput'
 


### PR DESCRIPTION
## Description

This PR adds the [USWDS Range](https://designsystem.digital.gov/components/form-controls/#range) component to the available form inputs.

The component renders as an input of type range and an optional Label.

The min, max, step, and value fields are optional and default to:
**min**: 0
**max**: 100
**step**: 1
**value**: max/2

I copied the ref code from somewhere else but don't know entirely why it's necessary or all of the possible types it could be.  I think I remember there is an old deprecated way to do refs from the official tutorial.

![Screen Shot 2020-05-21 at 6 09 42 PM](https://user-images.githubusercontent.com/52669884/82611395-74797680-9b8e-11ea-9818-2ff1b4852368.png)


## Open Questions
- Should the label be excluded all together from the component or passed whole instead of built out of label and hint attributes?
- The USWDS guidance recommends that you label the min and max ends, should we offer that functionality?
- Should the component accept any event listeners?
- I added the list prop to support linking to a datalist element.  This has next to no browser visual support (ticks in chrome if the `usa-range` class isn't applied) at the moment.
- Similar to the start and end labels should there be an `<output>` field that displays the slider value or would that be handled externally by something that uses an event listener?
- Firefox accepts an orient="vertical" attribute but everyone else just uses CSS so I omitted it

[MDN input range element documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range)

#81 