### PR TITLE
feat(charactercount): creates the character count form component

### DIFF
--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -23,6 +23,17 @@ export const textInputCharacterCount = (): React.ReactElement => (
     }></CharacterCount>
 )
 
+export const textInputWithDefault = (): React.ReactElement => (
+  <CharacterCount
+    id="character-count-id"
+    name="characterCount"
+    defaultValue="Over the maximum"
+    maxLength={10}
+    label={
+      <Label htmlFor="character-count-id">Text Input</Label>
+    }></CharacterCount>
+)
+
 export const textareaCharacterCount = (): React.ReactElement => (
   <CharacterCount
     id="character-count-id"

--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { CharacterCount } from './CharacterCount'
+import { Label } from '../Label/Label'
+
+export default {
+  title: 'Forms/CharacterCount',
+  parameters: {
+    info: `
+USWDS 2.0 Character count component
+
+Source: https://designsystem.digital.gov/components/form-controls/#character-count
+`,
+  },
+}
+
+export const textInputCharacterCount = (): React.ReactElement => (
+  <CharacterCount
+    id="character-count-id"
+    name="characterCount"
+    maxLength={10}
+    label={
+      <Label htmlFor="character-count-id">Text Input</Label>
+    }></CharacterCount>
+)
+
+export const textareaCharacterCount = (): React.ReactElement => (
+  <CharacterCount
+    id="character-count-id"
+    name="characterCount"
+    maxLength={10}
+    isTextArea={true}
+    rows={10}
+    label={
+      <Label htmlFor="character-count-id">Textarea</Label>
+    }></CharacterCount>
+)

--- a/src/components/forms/CharacterCount/CharacterCount.test.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.test.tsx
@@ -121,6 +121,8 @@ describe('CharacterCount component', () => {
       target: { value: 'abcde' },
     })
 
+    fireEvent.blur(getByTestId('characterCountInput'))
+
     expect(getByTestId('characterCountInput')).toBeValid()
   })
 })

--- a/src/components/forms/CharacterCount/CharacterCount.test.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import { CharacterCount } from './CharacterCount'
+import { Label } from '../Label/Label'
+
+describe('CharacterCount component', () => {
+  it('renders without errors', () => {
+    const { queryByTestId } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={10}
+      />
+    )
+    expect(queryByTestId('characterCountInput')).toBeInTheDocument()
+  })
+
+  it('renders with label component prop', () => {
+    const { queryByLabelText } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={10}
+        label={
+          <Label htmlFor="character-count-id">Text input character count</Label>
+        }
+      />
+    )
+    expect(queryByLabelText('Text input character count')).toBeInTheDocument()
+  })
+
+  it('renders with Textarea component', () => {
+    const { container } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={10}
+        isTextArea={true}
+      />
+    )
+    expect(container.querySelector('textarea')).toBeInTheDocument()
+  })
+
+  it('displays initial empty state message', () => {
+    const { queryByText } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={20}
+      />
+    )
+    expect(queryByText('20 characters allowed')).toBeInTheDocument()
+  })
+
+  it('updates message field less than limit', () => {
+    const { getByTestId, queryByText } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={5}
+      />
+    )
+
+    fireEvent.change(getByTestId('characterCountInput'), {
+      target: { value: 'a' },
+    })
+
+    expect(queryByText('4 characters left')).toBeInTheDocument()
+
+    fireEvent.change(getByTestId('characterCountInput'), {
+      target: { value: 'abcd' },
+    })
+
+    expect(queryByText('1 character left')).toBeInTheDocument()
+  })
+
+  it('updates message field over the limit with invalid class', () => {
+    const { getByTestId, queryByText } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={5}
+      />
+    )
+
+    fireEvent.change(getByTestId('characterCountInput'), {
+      target: { value: 'abcdef' },
+    })
+
+    expect(queryByText('1 character over limit')).toBeInTheDocument()
+    expect(queryByText('1 character over limit')).toHaveClass(
+      'usa-character-count__message--invalid'
+    )
+
+    fireEvent.change(getByTestId('characterCountInput'), {
+      target: { value: 'abcdefg' },
+    })
+
+    expect(queryByText('2 characters over limit')).toBeInTheDocument()
+  })
+
+  it('sets validity on focus event', () => {
+    const { getByTestId, queryByText } = render(
+      <CharacterCount
+        id="character-count-id"
+        name="characterCount"
+        maxLength={5}
+      />
+    )
+
+    fireEvent.change(getByTestId('characterCountInput'), {
+      target: { value: 'abcdef' },
+    })
+
+    fireEvent.blur(getByTestId('characterCountInput'))
+
+    expect(getByTestId('characterCountInput')).toBeInvalid()
+
+    fireEvent.change(getByTestId('characterCountInput'), {
+      target: { value: 'abcde' },
+    })
+
+    expect(getByTestId('characterCountInput')).toBeValid()
+  })
+})

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -42,7 +42,6 @@ export const CharacterCount = (
   const maxNum = maxLength === undefined ? 0 : maxLength
 
   /* Ideally defined as i18n translation strings */
-  const messageContent = `You can enter up to ${maxLength} characters`
   const emptyMessageFormat = `${maxLength} characters allowed`
   const remainingPluralFormat = '$0 characters left'
   const remainingSingularFormat = '$0 character left'
@@ -148,7 +147,6 @@ export const CharacterCount = (
           {label}
           {inputComponent}
         </FormGroup>
-        <noscript>{messageContent}</noscript>
         <span id={messageId} className={messageClasses} aria-live="polite">
           {state.limitMessage}
         </span>

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react'
+import classnames from 'classnames'
+
+import { TextInput, TextInputRef } from '../TextInput/TextInput'
+import { Textarea, TextareaRef } from '../Textarea/Textarea'
+import { FormGroup } from '../FormGroup/FormGroup'
+
+interface CharacterCountProps {
+  id: string
+  name: string
+  maxLength: number
+  className?: string
+  label?: React.ReactNode
+  isTextArea?: boolean
+  textRef?: // currently getting an error when adding this as ref
+  | string
+    | ((instance: HTMLInputElement | null) => void)
+    | ((instance: HTMLTextAreaElement | null) => void)
+    | React.RefObject<HTMLInputElement>
+    | React.RefObject<HTMLTextAreaElement>
+    | null
+    | undefined
+}
+
+export const CharacterCount = (
+  props: CharacterCountProps &
+    React.InputHTMLAttributes<HTMLInputElement> &
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>
+): React.ReactElement => {
+  const {
+    id,
+    name,
+    className,
+    label,
+    maxLength,
+    isTextArea,
+    textRef,
+    type, // Conflicts with type attribute already set on TextInput component
+    ...inputProps
+  } = props
+
+  const maxNum = maxLength === undefined ? 0 : maxLength
+
+  /* Ideally defined as i18n translation strings */
+  const messageContent = `You can enter up to ${maxLength} characters`
+  const emptyMessageFormat = `${maxLength} characters allowed`
+  const remainingPluralFormat = '$0 characters left'
+  const remainingSingularFormat = '$0 character left'
+  const overSingularFormat = '$0 character over limit'
+  const overPluralFormat = '$0 characters over limit'
+
+  const limitMessage = (len: number): string => {
+    let limitMessage
+    if (len === 0) {
+      return emptyMessageFormat
+    } else if (len <= maxNum) {
+      switch (maxNum - len) {
+        case 1:
+          return remainingSingularFormat.replace('$0', '1')
+        default:
+          return remainingPluralFormat.replace('$0', (maxNum - len).toString())
+      }
+    } else {
+      switch (len - maxNum) {
+        case 1:
+          return overSingularFormat.replace('$0', '1')
+        default:
+          return overPluralFormat.replace('$0', (len - maxNum).toString())
+      }
+    }
+  }
+
+  const [state, setState] = useState({
+    characterLength: 0,
+    limitMessage: emptyMessageFormat,
+    invalidMessage: false,
+  })
+
+  const classes = classnames('usa-character-count__field', className)
+  const messageClasses = classnames(
+    'usa-hint',
+    'usa-character-count__message',
+    { 'usa-character-count__message--invalid': state.invalidMessage }
+  )
+
+  const messageId = id + '-info'
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement> &
+      React.ChangeEvent<HTMLTextAreaElement>
+  ): void => {
+    const len = e.target.value.length
+    setState({
+      characterLength: len,
+      limitMessage: limitMessage(len),
+      invalidMessage: len > maxLength,
+    })
+  }
+
+  const handleBlur = (
+    e: React.FocusEvent<HTMLInputElement> &
+      React.FocusEvent<HTMLTextAreaElement>
+  ): void => {
+    const validationMessage = state.invalidMessage
+      ? 'The content is too long.'
+      : ''
+    e.target.setCustomValidity(validationMessage)
+  }
+
+  let inputComponent
+  if (isTextArea) {
+    const ref = textRef as TextareaRef
+    // How will we know if the label or hint has an id value should we add it to the describedby?
+    inputComponent = (
+      <Textarea
+        id={id}
+        data-testid="characterCountInput"
+        name={name}
+        className={classes}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        aria-describedby={messageId}
+        inputRef={ref}
+        {...inputProps}></Textarea>
+    )
+  } else {
+    const ref = textRef as TextInputRef
+    inputComponent = (
+      <TextInput
+        id={id}
+        data-testid="characterCountInput"
+        name={name}
+        type="text"
+        className={classes}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        inputRef={ref}
+        {...inputProps}
+      />
+    )
+  }
+
+  return (
+    <>
+      {/* Moves maxlength attribute off of input so it is not a hard entry limit */}
+      <div className="usa-character-count" data-maxlength={maxLength}>
+        <FormGroup>
+          {label}
+          {inputComponent}
+        </FormGroup>
+        <noscript>{messageContent}</noscript>
+        <span id={messageId} className={messageClasses} aria-live="polite">
+          {state.limitMessage}
+        </span>
+      </div>
+    </>
+  )
+}
+
+export default CharacterCount

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -33,12 +33,15 @@ export const CharacterCount = (
     className,
     label,
     maxLength,
+    defaultValue,
     isTextArea,
     textRef,
     type, // Conflicts with type attribute already set on TextInput component
     ...inputProps
   } = props
 
+  const defaultLength =
+    defaultValue === undefined ? 0 : defaultValue.toString().length
   const maxNum = maxLength === undefined ? 0 : maxLength
 
   /* Ideally defined as i18n translation strings */
@@ -70,9 +73,9 @@ export const CharacterCount = (
   }
 
   const [state, setState] = useState({
-    characterLength: 0,
-    limitMessage: emptyMessageFormat,
-    invalidMessage: false,
+    characterLength: defaultLength,
+    limitMessage: limitMessage(defaultLength),
+    invalidMessage: defaultLength > maxNum,
   })
 
   const classes = classnames('usa-character-count__field', className)
@@ -116,11 +119,13 @@ export const CharacterCount = (
         data-testid="characterCountInput"
         name={name}
         className={classes}
+        defaultValue={defaultValue}
         onChange={handleChange}
         onBlur={handleBlur}
         aria-describedby={messageId}
         inputRef={ref}
-        {...inputProps}></Textarea>
+        {...inputProps}
+      />
     )
   } else {
     const ref = textRef as TextInputRef
@@ -131,8 +136,10 @@ export const CharacterCount = (
         name={name}
         type="text"
         className={classes}
+        defaultValue={defaultValue}
         onChange={handleChange}
         onBlur={handleBlur}
+        aria-describedby={messageId}
         inputRef={ref}
         {...inputProps}
       />

--- a/src/components/forms/TextInput/TextInput.tsx
+++ b/src/components/forms/TextInput/TextInput.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import classnames from 'classnames'
 
+export type TextInputRef =
+  | string
+  | ((instance: HTMLInputElement | null) => void)
+  | React.RefObject<HTMLInputElement>
+  | null
+  | undefined
+
 interface TextInputProps {
   id: string
   name: string
@@ -10,12 +17,7 @@ interface TextInputProps {
   success?: boolean
   small?: boolean
   medium?: boolean
-  inputRef?:
-    | string
-    | ((instance: HTMLInputElement | null) => void)
-    | React.RefObject<HTMLInputElement>
-    | null
-    | undefined
+  inputRef?: TextInputRef
 }
 
 export const TextInput = (

--- a/src/components/forms/Textarea/Textarea.tsx
+++ b/src/components/forms/Textarea/Textarea.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import classnames from 'classnames'
 
+export type TextareaRef =
+  | string
+  | string
+  | ((instance: HTMLTextAreaElement | null) => void)
+  | React.RefObject<HTMLTextAreaElement>
+  | null
+  | undefined
+
 interface TextareaProps {
   id: string
   name: string
@@ -8,12 +16,7 @@ interface TextareaProps {
   error?: boolean
   success?: boolean
   children?: React.ReactNode
-  inputRef?:
-    | string
-    | ((instance: HTMLTextAreaElement | null) => void)
-    | React.RefObject<HTMLTextAreaElement>
-    | null
-    | undefined
+  inputRef?: TextareaRef
 }
 
 export const Textarea = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { GridContainer } from './components/grid/GridContainer/GridContainer'
 export { Grid } from './components/grid/Grid/Grid'
 
 /** Form components */
+export { CharacterCount } from './components/forms/CharacterCount/CharacterCount'
 export { Checkbox } from './components/forms/Checkbox/Checkbox'
 export { DateInput } from './components/forms/DateInput/DateInput'
 export { DateInputGroup } from './components/forms/DateInputGroup/DateInputGroup'


### PR DESCRIPTION
This creates a new component CharacterCount as part of the `forms/` group.  The requirements are laid out in the [issue](#169) so I won't recopy them all here.

https://designsystem.digital.gov/components/form-controls/#character-count
https://github.com/uswds/uswds/blob/develop/src/js/components/character-count.js

Please give me feedback on the use of state/hooks as I haven't done those before.  Similarly if you feel strongly about how template strings are handled which we discussed a bit on Slack and @haworku's [previously closed issue](https://github.com/trussworks/react-uswds/issues/124) may be worth revisiting.

I also noticed that we (and uswds) aren't using the validity api anywhere else.  Is this because there will usually be a form library used with their own validation functionality?

I had to add type definitions for an inputRef for TextInput and TextArea to make it easier to cast from the prop to the specific type needed for each component.

I did modify it to work with a defaultValue which seems important because we only listen for the onChange event to update the message.

fix #169 