### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.5.0 (2020-06-03)
+
+### Bug Fixes
+
+- expand required node version range to 10.x - 12.x ([#215](https://github.com/trussworks/react-uswds/issues/215)) ([0be79d3](https://github.com/trussworks/react-uswds/commit/0be79d340f993b5be3b3b41512bdfa94cc02e9da))
+
+### Documentation & Examples
+
+- **example-app:** add create-react-app example app ([#206](https://github.com/trussworks/react-uswds/issues/206)) ([cf28086](https://github.com/trussworks/react-uswds/commit/cf28086ac5c5b29452b04e0b96ceb62b923345e9))
+
 ## 1.4.0 (2020-05-28)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trussworks/react-uswds",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "React USWDS 2.0 component library",
   "keywords": [
     "react",
@@ -151,7 +151,42 @@
   },
   "standard-version": {
     "skip": {
-      "tag": true
-    }
+      "tag": true,
+      "commit": true
+    },
+    "types": [
+      {
+        "type": "feat",
+        "section": "Features"
+      },
+      {
+        "type": "fix",
+        "section": "Bug Fixes"
+      },
+      {
+        "type": "chore",
+        "hidden": true
+      },
+      {
+        "type": "docs",
+        "section": "Documentation & Examples"
+      },
+      {
+        "type": "style",
+        "hidden": true
+      },
+      {
+        "type": "refactor",
+        "hidden": true
+      },
+      {
+        "type": "perf",
+        "hidden": true
+      },
+      {
+        "type": "test",
+        "hidden": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
## 1.5.0 (2020-06-03)

### Bug Fixes

- expand required node version range to 10.x - 12.x ([#215](https://github.com/trussworks/react-uswds/issues/215)) ([0be79d3](https://github.com/trussworks/react-uswds/commit/0be79d340f993b5be3b3b41512bdfa94cc02e9da))

### Documentation & Examples

- **example-app:** add create-react-app example app ([#206](https://github.com/trussworks/react-uswds/issues/206)) ([cf28086](https://github.com/trussworks/react-uswds/commit/cf28086ac5c5b29452b04e0b96ceb62b923345e9))

----

Also updates standard-version configuration to skip the `commit` step, and to include `docs` changes in the changelog. This felt appropriate since as a library, updates to docs & examples can be substantial.