### PR TITLE
ci: Adjust default labels for dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,8 +6,8 @@ update_configs:
     update_schedule: "weekly"
     # Apply dependencies label to PRs
     default_labels:
-      - "dependencies"
-      - "automerge"
+      - "type: dependencies"
+      - "type: automerge"
     allowed_updates:
       # allow updates to development dependencies
       - match:


### PR DESCRIPTION
<!--
CHECKLIST
- [ ] PR title conforms to conventional commits, e.g. feat: Button
- [ ] PR includes `yarn audit` output if dependencies changed
- [ ] Any new components are exported from `index.ts`
-->

# Summary

<!-- Describe the changes and the scope. List any new components. -->
We recently renamed labels in our repo, should update dependabot config to reflect this.  

## Related Issues or PRs

#260 - example of dependabot PR warning that outdated default labels don't exist

## How To Test
n/a - next round of dependabot PRs shouldn't have the warning

