### PR TITLE
feat(Search): add size enum prop, deprecate big,small boolean props

### DIFF
--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -21,9 +21,9 @@ export const defaultSearch = (): React.ReactElement => (
 )
 
 export const bigSearch = (): React.ReactElement => (
-  <Search big onSubmit={mockSubmit} />
+  <Search size="big" onSubmit={mockSubmit} />
 )
 
 export const smallSearch = (): React.ReactElement => (
-  <Search small onSubmit={mockSubmit} />
+  <Search size="small" onSubmit={mockSubmit} />
 )

--- a/src/components/Search/Search.test.tsx
+++ b/src/components/Search/Search.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
+jest.mock('../../deprecation')
+import { deprecationWarning } from '../../deprecation'
 import { Search } from './Search'
 
 describe('Search component', () => {
@@ -16,5 +18,39 @@ describe('Search component', () => {
 
     fireEvent.submit(getByTestId('textInput'))
     expect(mockSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  describe('renders size classes', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+    it.each([
+      ['big', 'usa-search--big'],
+      ['small', 'usa-search--small'],
+    ])('when size is %s should include class %s', (sizeString, uswdsClass) => {
+      const size = sizeString as 'big' | 'small'
+      const mockSubmit = jest.fn()
+      const { container } = render(<Search onSubmit={mockSubmit} size={size} />)
+      expect(container.querySelector('form')).toHaveClass(uswdsClass)
+      expect(deprecationWarning).toHaveBeenCalledTimes(0)
+    })
+
+    it.each([
+      ['big', 'small', 'usa-search--big'],
+      ['small', 'big', 'usa-search--small'],
+    ])(
+      'prefers size to deprecated %s',
+      (sizeString, deprecatedKey, uswdsClass) => {
+        const size = sizeString as 'big' | 'small'
+        const deprecatedProps: { [key: string]: boolean } = {}
+        deprecatedProps[`${deprecatedKey}`] = true
+        const mockSubmit = jest.fn()
+        const { container } = render(
+          <Search onSubmit={mockSubmit} size={size} {...deprecatedProps} />
+        )
+        expect(container.querySelector('form')).toHaveClass(uswdsClass)
+        expect(deprecationWarning).toHaveBeenCalledTimes(1)
+      }
+    )
   })
 })

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import { deprecationWarning } from '../../deprecation'
 
 import { Button } from '../Button/Button'
 import { Form } from '../forms/Form/Form'
@@ -10,7 +11,14 @@ interface SearchInputProps {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   inputId?: string
   inputName?: string
+  size?: 'big' | 'small'
+  /**
+   * @deprecated since 1.6.0, use size
+   */
   big?: boolean
+  /**
+   * @deprecated since 1.6.0, use size
+   */
   small?: boolean
   label?: React.ReactNode
   className?: string
@@ -23,17 +31,27 @@ export const Search = (
     onSubmit,
     inputId = 'search-field',
     inputName = 'search',
+    size,
     big,
     small,
     label = 'Search',
     className,
     ...formProps
   } = props
+  if (big) {
+    deprecationWarning('Search property big is deprecated.  Use size')
+  }
+  if (small) {
+    deprecationWarning('Search property big is deprecated.  Use size')
+  }
+
+  const isBig = size ? size === 'big' : big
+  const isSmall = size ? size === 'small' : small
   const classes = classnames(
     'usa-search',
     {
-      'usa-search--small': small,
-      'usa-search--big': big,
+      'usa-search--small': isSmall,
+      'usa-search--big': isBig,
     },
     className
   )
@@ -50,7 +68,7 @@ export const Search = (
       </Label>
       <TextInput id={inputId} type="search" name={inputName} />
       <Button type="submit">
-        <span className={small ? 'usa-sr-only' : 'usa-search__submit-text'}>
+        <span className={isSmall ? 'usa-sr-only' : 'usa-search__submit-text'}>
           Search
         </span>
       </Button>


### PR DESCRIPTION
# Summary

Convert to use `size` enum prop, deprecate `big` and `small` boolean props

## Related Issues or PRs

closes #266

