### PR TITLE
fix(standard-version): use -t flag correctly, autocommit 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "webpack -p",
     "build:watch": "webpack --watch",
     "lint": "tsc --noEmit && eslint --ext js,jsx,ts,tsx src && stylelint \"src/**/*.{css,scss}\"",
-    "release": "standard-version -t",
+    "release": "standard-version -t ''",
     "prepublishOnly": "yarn build",
     "happo": "happo",
     "happo-ci": "happo-ci-circleci",
@@ -153,8 +153,7 @@
   },
   "standard-version": {
     "skip": {
-      "tag": true,
-      "commit": true
+      "tag": true
     },
     "types": [
       {


### PR DESCRIPTION
# Summary
Adjust `standard-version` config.

- `-t` is not a boolean flag- needs the empty string to understand git tags correctly
- auto committing the changelog and version bump will make our commits more standardized and speed up releases.  We can continue to manually add tags in GH for now since we are also still adjusting our git flow

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->
#287 

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->
- Pull down branch, rebase against master and run `yarn release --dry-run`. Only the latest changes should show up in changelog. This change along with moving to a single branching flow (#216) should resolve our changelog issues.


