### PR TITLE
fix: refactor menu, megamenu to use current props;  removes deprecation warnings from tests

### DIFF
--- a/src/components/header/MegaMenu/MegaMenu.tsx
+++ b/src/components/header/MegaMenu/MegaMenu.tsx
@@ -19,7 +19,7 @@ export const MegaMenu = (
       <div className="grid-row grid-gap-4">
         {items.map((listItems, i) => (
           <div className="usa-col" key={`subnav_col_${i}`}>
-            <NavList items={listItems} megamenu {...navListProps} />
+            <NavList items={listItems} type="megamenu" {...navListProps} />
           </div>
         ))}
       </div>

--- a/src/components/header/Menu/Menu.tsx
+++ b/src/components/header/Menu/Menu.tsx
@@ -8,7 +8,9 @@ type MenuProps = {
 
 export const Menu = (props: MenuProps & NavListProps): React.ReactElement => {
   const { items, isOpen, ...navListProps } = props
-  return <NavList items={items} subnav hidden={!isOpen} {...navListProps} />
+  return (
+    <NavList items={items} type="subnav" hidden={!isOpen} {...navListProps} />
+  )
 }
 
 export default Menu


### PR DESCRIPTION
<!--
CHECKLIST
- [ ] PR title conforms to conventional commits, e.g. feat: Button
- [ ] PR includes `yarn audit` output if dependencies changed
- [ ] Any new components are exported from `index.ts`
-->

# Summary

<!-- Describe the changes and the scope. List any new components. -->
Quick cleanup before next release (1.7.0).
## Related Issues or PRs
cleanup from #267 
<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->
- `yarn test -w` has no warnings 
