### PR TITLE
feat(danger): Block PR if yarn audit has high or critical, do not run on dependabot, no warn on version

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,6 +1,5 @@
 import * as child from 'child_process'
 
-import { includes, replace } from 'lodash'
 import { danger, warn } from 'danger'
 
 // Load all modified and new files
@@ -35,7 +34,7 @@ const checkYarnAudit: () => void = () => {
               `Package ${audit.data.advisory.module_name}\n` +
               `Patched in ${audit.data.advisory.patched_versions}\n` +
               `Dependency of ${audit.data.resolution.path.split('>')[0]}\n` +
-              `Path ${replace(audit.data.resolution.path, />/g, ' > ')}\n` +
+              `Path ${audit.data.resolution.path.replace(/>/g, ' > ')}\n` +
               `More info ${audit.data.advisory.url}\n\n`
           }
         } catch {
@@ -75,7 +74,7 @@ const checkCodeChanges: () => void = () => {
   const hasNewComponents = danger.git.created_files.some(
     (p) => !!p.match(/src\/components\/.*\.[jt]sx/)
   )
-  const hasEntrypointChanges = includes(allFiles, 'src/index.ts')
+  const hasEntrypointChanges = allFiles.includes('src/index.ts')
   if (hasNewComponents && !hasEntrypointChanges) {
     const message = `It looks like there are new component (JSX/TSX) files, but the entrypoint (index.ts) has not changed.`
     const idea = `Did you forget to export new components from the library entrypoint?`
@@ -96,8 +95,8 @@ const checkCodeChanges: () => void = () => {
 
 const checkDependencyChanges: () => void = () => {
   // Request update of yarn.lock if package.json changed but yarn.lock isn't
-  const packageChanged = includes(allFiles, 'package.json')
-  const lockfileChanged = includes(allFiles, 'yarn.lock')
+  const packageChanged = allFiles.includes('package.json')
+  const lockfileChanged = allFiles.includes('yarn.lock')
   if (packageChanged && !lockfileChanged) {
     danger.git
       .structuredDiffForFile('package.json')

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -126,11 +126,9 @@ const checkDependencyChanges: () => void = () => {
   }
 }
 
-// skip these checks if PR is by dependabot, if we don't have a github object let it run also since we are local
-if (
-  !danger.github ||
-  (danger.github && danger.github.pr.user.login !== 'dependabot-preview[bot]')
-) {
+// skip these checks if PR is by any bot (e.g. dependabot), if we
+// don't have a github object let it run also since we are local
+if (!danger.github || (danger.github && danger.github.pr.user.type !== 'Bot')) {
   checkYarnAudit()
   checkPrDescription()
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,7 +70,9 @@ Because this project exports a library that will be used by other projects, it i
   - Changes to package source code should include changes to tests.
   - New `src/components` files should include changes to storybook.
   - New `src/components` files should be exported from the package entrypoint.
-  - Package dependency changes should include `yarn.lock` updates and `yarn audit` outputs in PR description.
+  - Package dependency changes should include `yarn.lock` updates and
+    `yarn audit` will be run by danger to ensure no high or critical
+    vulnerabilities are found
 - All [Jest tests](https://jestjs.io/) will be run in CI and must pass before the branch can be merged
 - [Happo.io visual regression tests](https://docs.happo.io/docs/reviewing-diffs) will be run in CI and all diffs must be approved before the branch can be merged. Developers must have access to the Happo.io account to approve/reject diffs. If you work at Truss, log into Happo.io with your gmail and you will be able to approve/reject changes. Navigate to the happo link for instructions on how to review and approve diffs.
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "tsc --noEmit && lint-staged",
-      "pre-push": "yarn danger local --failOnErrors"
+      "pre-push": "yarn danger local -b main --failOnErrors"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
# Summary

Update danger config to run `yarn audit` and block if high or critical issues are found.
Do not run danger on dependabot PRs
Do not warn if the only changes the `package.json` is the version

## Related Issues or PRs

closes #324

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

### Screenshots (optional)
