### PR TITLE
fix: Export NavDropDownButton

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export { Menu } from './components/header/Menu/Menu'
 export { NavCloseButton } from './components/header/NavCloseButton/NavCloseButton'
 export { NavList } from './components/header/NavList/NavList'
 export { NavMenuButton } from './components/header/NavMenuButton/NavMenuButton'
+export { NavDropDownButton } from './components/header/NavDropDownButton/NavDropDownButton'
 export { PrimaryNav } from './components/header/PrimaryNav/PrimaryNav'
 export { Title } from './components/header/Title/Title'
 


### PR DESCRIPTION
# Summary

It appears that NavDropDownButton cannot be used as it is not exported (following code samples from https://trussworks.github.io/react-uswds/?path=/story/header-navdropdownbutton--default-drop-down-menu). This PR exports NavDropDownButton so that it can be used.