### PR TITLE
docs: Point users to react-fontawesome for icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ Also make sure to include the following in order to import the compiled CSS from
 
 **[More info about using USWDS CSS & SCSS](./docs/scss.md)**
 
+### Icons
+
+[USWDS recommends using Font Awesome](https://designsystem.digital.gov/components/icons/), and that project [provides a package for use with React](https://github.com/FortAwesome/react-fontawesome).
+
+To add this to your project, install react-font-awesome and at least one style of icon:
+
+```
+yarn add @fortawesome/fontawesome-svg-core \
+         @fortawesome/free-solid-svg-icons \
+         @fortawesome/react-fontawesome
+```
+
+You can then add Font Awesome icons to your projects using the `FontAwesome` component:
+
+
+```jsx
+import ReactDOM from 'react-dom'
+import { Button } from '@trussworks/react-uswds'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSave } from '@fortawesome/free-solid-svg-icons'
+
+const button = <Button type="button">
+  <FontAwesomeIcon icon={faSave} /> Save Changes
+</Button>;
+
+ReactDOM.render(button, document.body);
+```
+
+For more information on working with and configuring react-fontawesome, please see [that project's documentation](https://github.com/FortAwesome/react-fontawesome#installation). To find specific icons for your project, [search on the Font Awesome site](https://fontawesome.com/icons).
+
 ## Maintainers
 
 - [@suzubara](https://github.com/suzubara)

--- a/example/package.json
+++ b/example/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.30",
+    "@fortawesome/free-solid-svg-icons": "^5.14.0",
+    "@fortawesome/react-fontawesome": "^0.1.11",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",
     "@testing-library/user-event": "^12.0.11",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -21,6 +21,7 @@ import {
 import HomePage from './pages/Home'
 import ExamplePage from './pages/Example'
 import ModalsPage from './pages/Modals'
+import IconsPage from './pages/Icons'
 
 import './App.css'
 
@@ -29,11 +30,12 @@ const routes = {
   HOME_PAGE: '/',
   EXAMPLES_PAGE: '/examples',
   MODALS_PAGE: '/modals',
+  ICONS_PAGE: '/icons',
 }
 
 const App = () => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
-  const { HOME_PAGE, EXAMPLES_PAGE, MODALS_PAGE } = routes
+  const { HOME_PAGE, EXAMPLES_PAGE, MODALS_PAGE, ICONS_PAGE } = routes
 
   const toggleMobileNav = (): void => {
     setMobileNavOpen((prevOpen) => !prevOpen)
@@ -48,6 +50,9 @@ const App = () => {
     </NavLink>,
     <NavLink to={MODALS_PAGE} activeClassName="usa-current">
       Modals
+    </NavLink>,
+    <NavLink to={ICONS_PAGE} activeClassName="usa-current">
+      Icons
     </NavLink>,
   ]
 
@@ -84,6 +89,9 @@ const App = () => {
             </Route>
             <Route path={MODALS_PAGE}>
               <ModalsPage />
+            </Route>
+            <Route path={ICONS_PAGE}>
+              <IconsPage />
             </Route>
             <Route path={HOME_PAGE}>
               <HomePage />

--- a/example/src/pages/Icons.tsx
+++ b/example/src/pages/Icons.tsx
@@ -1,0 +1,20 @@
+
+import React from 'react'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUpload } from '@fortawesome/free-solid-svg-icons'
+
+const IconsPage = (): React.ReactElement => (
+  <section>
+    <h1>Icons</h1>
+
+    <p className="usa-intro">
+      We recommend using icons from <a href="https://www.google.com/search?client=safari&rls=en&q=react-fontawesome&ie=UTF-8&oe=UTF-8">react-fontawesome</a> for projects that need icons.
+    </p>
+
+    <FontAwesomeIcon icon={faUpload} /> Upload Image
+
+  </section>
+)
+
+export default IconsPage

--- a/example/src/pages/Icons.tsx
+++ b/example/src/pages/Icons.tsx
@@ -9,7 +9,7 @@ const IconsPage = (): React.ReactElement => (
     <h1>Icons</h1>
 
     <p className="usa-intro">
-      We recommend using icons from <a href="https://www.google.com/search?client=safari&rls=en&q=react-fontawesome&ie=UTF-8&oe=UTF-8">react-fontawesome</a> for projects that need icons.
+      We recommend using icons from <a href="https://github.com/FortAwesome/react-fontawesome">react-fontawesome</a> for projects that need icons.
     </p>
 
     <FontAwesomeIcon icon={faUpload} /> Upload Image

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1125,6 +1125,32 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@fortawesome/fontawesome-common-types@^0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz#2f1cc5b46bd76723be41d0013a8450c9ba92b777"
+  integrity sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.30":
+  version "1.2.30"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz#f56dc6791861fe5d1af04fb8abddb94658c576db"
+  integrity sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.30"
+
+"@fortawesome/free-solid-svg-icons@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz#970453f5e8c4915ad57856c3a0252ac63f6fec18"
+  integrity sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.30"
+
+"@fortawesome/react-fontawesome@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz#c1a95a2bdb6a18fa97b355a563832e248bf6ef4a"
+  integrity sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1495,7 +1521,7 @@
     "@babel/runtime" "^7.10.2"
 
 "@trussworks/react-uswds@file:./..":
-  version "1.7.0"
+  version "1.8.0"
   dependencies:
     classnames "^2.2.6"
     dotenv "^8.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14808,9 +14808,9 @@ ts-dedent@^1.1.0:
   integrity sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==
 
 ts-jest@^26.1.2:
-  version "26.1.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.1.3.tgz#aac928a05fdf13e3e6dfbc8caec3847442667894"
-  integrity sha512-beUTSvuqR9SmKQEylewqJdnXWMVGJRFqSz2M8wKJe7GBMmLZ5zw6XXKSJckbHNMxn+zdB3guN2eOucSw2gBMnw==
+  version "26.1.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.1.4.tgz#87d41a96016a8efe4b8cc14501d3785459af6fa6"
+  integrity sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"


### PR DESCRIPTION
# Summary

This PR adds documentation to the README that recommends the use of `react-fontawesome` for projects that need icons.

I'm not sure if/what should be added to the example app. I put a page in there to make sure that the icons worked, but I can take that out if it doesn't make sense to keep since it is testing an external dependency.

## Related Issues or PRs

closes #84 

## How To Test

* Read through the *Icons* section of the docs for clarity.
* Open the example app locally and look at the *Icons* page.

### Screenshots

Here is the new page in the example app:

<img width="961" alt="Screen Shot 2020-07-29 at 3 18 52 PM" src="https://user-images.githubusercontent.com/3331/88849088-fbf6ed80-d1ae-11ea-909a-10cff1352360.png">

## Checklist

- [ ] PR title conforms to conventional commits, e.g. feat: Button
- [ ] PR includes `yarn audit` output if dependencies changed
- [ ] Any new components are exported from `index.ts`