### PR TITLE
Feat: Include @storybook/addon-viewport

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -56,7 +56,7 @@ const webpackConfig = (config) => {
 
 module.exports = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
-  addons: ['@storybook/addon-docs'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-viewport'],
   webpackFinal: async (config) => {
     return webpackConfig(config)
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,14 @@
-import 'happo-plugin-storybook/register';
+import 'happo-plugin-storybook/register'
 
 import 'uswds/dist/css/uswds.css'
 import '../src/styles/index.scss'
 import './custom-styles.scss'
+
+import { addParameters } from '@storybook/client-api'
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+
+addParameters({
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@babel/core": "^7.10.5",
     "@babel/preset-react": "^7.10.4",
     "@storybook/addon-docs": "^5.3.19",
+    "@storybook/addon-viewport": "^5.3.19",
     "@storybook/react": "^5.3.19",
     "@storybook/storybook-deployer": "^2.8.6",
     "@testing-library/jest-dom": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,6 +2272,23 @@
     vue-docgen-api "^4.1.0"
     vue-docgen-loader "^1.3.0-beta.0"
 
+"@storybook/addon-viewport@^5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-5.3.19.tgz#adeaae497d943d2b740109d9f7a6ccd27a512cde"
+  integrity sha512-/+9pN9yR/Dnwj/JEOwfnmERxDvh9alaFg7snnbiHSuycbPc+xy3CziqGUE9ofRxrYqOrd4aHhJ/5sxkZvewlAg==
+  dependencies:
+    "@storybook/addons" "5.3.19"
+    "@storybook/api" "5.3.19"
+    "@storybook/client-logger" "5.3.19"
+    "@storybook/components" "5.3.19"
+    "@storybook/core-events" "5.3.19"
+    "@storybook/theming" "5.3.19"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/addons@5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.19.tgz#3a7010697afd6df9a41b8c8a7351d9a06ff490a4"


### PR DESCRIPTION

<!--
CHECKLIST
- [ ] PR title conforms to conventional commits, e.g. feat: Button
- [ ] PR includes `yarn audit` output if dependencies changed
- [ ] Any new components are exported from `index.ts`
-->

# Summary

<!-- Describe the changes and the scope. List any new components. -->
This change adds the [Viewport](https://github.com/storybookjs/storybook/tree/master/addons/viewport) addon and sets up storybook to allow users to test their stories using alternate viewport sizes.  I added a global configuration so that all stories have access to the same default set of viewports, but additional customization per-story is possible if required.

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->
Implements https://github.com/trussworks/react-uswds/issues/253

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->
In the toolbar above the canvas area, a new icon exists.  Clicking this icon will open a dropdown menu with a number of viewport options.  Selecting a viewport should will the story canvas size, and also allow you to change the orientation of the simulated view.



### Screenshots (optional)
![Screen Shot 2020-08-03 at 8 43 23 AM](https://user-images.githubusercontent.com/54035677/89200969-a7b08c80-d565-11ea-9bec-7355d0cbd1d3.png)
![Screen Shot 2020-08-03 at 8 40 28 AM](https://user-images.githubusercontent.com/54035677/89200956-a4b59c00-d565-11ea-8361-c21047344b08.png)
![Screen Shot 2020-08-03 at 8 40 42 AM](https://user-images.githubusercontent.com/54035677/89200965-a67f5f80-d565-11ea-918c-d726930bb641.png)
![Screen Shot 2020-08-03 at 8 56 37 AM](https://user-images.githubusercontent.com/54035677/89202069-45f12200-d567-11ea-8ab1-7b72426cd4b2.png)

