### PR TITLE
build(webpack): support browsers and node 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     filename: '[name].js',
     library: 'ReactUSWDS',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
   externals: {
     react: {


### PR DESCRIPTION
# Summary

Update webpack config to [support umd build for both browsers and node](https://webpack.js.org/configuration/output/#outputglobalobject)
## Related Issues or PRs

closes #380

## How To Test
Create the file `ssr.js` in the root of the `react-uswds` project
```js
const react = require('react')
const domServer = require('react-dom/server')
const uswds = require('./lib')

const TagFactory = react.createFactory(uswds.Tag)
const app = domServer.renderToString(TagFactory())
console.log(app)
```

1. `yarn build`
1. `NODE_ENV=production node ssr.js`

### Screenshots (optional)
