### PR TITLE
ci(dependabot): Adjust config to merge earlier in day, ignore react dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-      time: '10:00'
+      time: '6:00'
       timezone: PST8PDT
     pull-request-branch-name:
       separator: '-'
@@ -41,3 +41,16 @@ updates:
       - 'type: example'
     allow:
       - dependency-type: development
+    ignore:
+      - dependency-name: react
+        versions:
+          - '^16.11.0'
+      - dependency-name: react-dom
+        versions:
+          - '^16.11.0'
+      - dependency-name: '@types/react'
+        versions:
+          - '^16.10.0'
+      - dependency-name: '@types/react-dom'
+        versions:
+          - '^16.10.0'


### PR DESCRIPTION

# Summary

<!-- Describe the changes and the scope. List any new components. -->
Adjust config to merge earlier in day to avoid conflicts during releases.  Also, ignore react dependencies in `/example` (like we already do in the root level config). 

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->
Related to #325 