### PR TITLE
chore: Update bl dependency to resolve security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,8 +124,9 @@
     "webpack-cli": "^3.3.9"
   },
   "resolutions": {
-    "webpack/acorn": "^6.4.1",
-    "acorn-globals/acorn": "^6.4.1"
+    "bl": "^4.0.3",
+    "acorn-globals/acorn": "^6.4.1",
+    "webpack/acorn": "^6.4.1"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4231,10 +4231,10 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
-  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+bl@^4.0.1, bl@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"


### PR DESCRIPTION
# Summary

Uses the `resolutions` key in `package.json` to resolve the `bl` dependency to `^4.0.3` in order to fix a high severity vulnerability.

## Related Issues or PRs

none

## How To Test

`yarn audit` on the main branch:
```
10:50:28 in truss-uswds-react on  main is 📦 v1.9.1 suz⬢ 12.16.2 
➜ yarn audit
yarn audit v1.22.4
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Remote Memory Exposure                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ bl                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.3 <2.0.0 || >=2.2.1 <3.0.0 || >=3.0.1 <4.0.0 ||        │
│               │ >=4.0.3                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ happo.io                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ happo.io > archiver > tar-stream > bl                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1555                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Remote Memory Exposure                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ bl                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.3 <2.0.0 || >=2.2.1 <3.0.0 || >=3.0.1 <4.0.0 ||        │
│               │ >=4.0.3                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ happo-plugin-storybook                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ happo-plugin-storybook > archiver > tar-stream > bl          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1555                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
2 vulnerabilities found - Packages audited: 2247
Severity: 2 High
✨  Done in 1.46s.
```

`yarn audit` on this branch:
```
10:55:11 in truss-uswds-react on  sr-update-bl-security is 📦 v1.9.1 suz⬢ 12.16.2 
➜ yarn audit
yarn audit v1.22.4
0 vulnerabilities found - Packages audited: 2247
✨  Done in 1.46s.
```