### PR TITLE
fix:  Happo automation should skip dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: 'Happo'
-          command: '[[ ( "${CIRCLE_PR_USERNAME}" != "dependabot" ) && ( "${CIRCLE_PR_USERNAME}" != "dependabot-preview" ) ]] && yarn happo-ci'
+          command: '[[ ( "${CIRCLE_PR_USERNAME}" != "github" ) ]] && yarn happo-ci'
           environment:
             HAPPO_IS_ASYNC: 'true'
             BASE_BRANCH: 'origin/main'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: 'Happo'
-          command: '[[ -n "${CIRCLE_PR_USERNAME}" ]] && yarn happo-ci'
+          command: '[[ -n "${CIRCLE_USERNAME}" ]] && yarn happo-ci'
           environment:
             HAPPO_IS_ASYNC: 'true'
             BASE_BRANCH: 'origin/main'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: 'Happo'
-          command: '[[ ( "${CIRCLE_PR_USERNAME}" != "github" ) ]] && yarn happo-ci'
+          command: '[[ -n "${CIRCLE_PR_USERNAME}" ]] && yarn happo-ci'
           environment:
             HAPPO_IS_ASYNC: 'true'
             BASE_BRANCH: 'origin/main'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-      time: '6:00'
+      time: '06:00'
       timezone: PST8PDT
     pull-request-branch-name:
       separator: '-'
@@ -27,6 +27,15 @@ updates:
       - dependency-name: '@types/react-dom'
         versions:
           - '^16.10.0'
+      - dependency-name: '@storybook/react'
+        versions:
+          - '^6.0.12'
+      - dependency-name: '@storybook/addon-docs'
+        versions:
+          - '^6.0.12'
+      - dependency-name: '@storybook/addon-viewport'
+        versions:
+          - '^6.0.12'
 
   - package-ecosystem: npm
     directory: '/example/'


### PR DESCRIPTION
# Summary

Try again- this time only run Happo if the `CIRCLE_USERNAME` exists (is not empty).  Also add storybook to dependencies we ignore for dependabot and manually update.

## Related Issues or PRs
closes #450 

## How To Test

Have to merge to test
