### PR TITLE
fix: Only run happo if GITHUB_USERNAME is set to fix dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ jobs:
 
       - run:
           name: 'Happo'
-          command: '[[ -n "${CIRCLE_USERNAME}" ]] && yarn happo-ci'
+          # Only run happo if CIRCLE_USERNAME is set.  This will skip
+          # dependabot PRs
+          command: '[[ -z "${CIRCLE_USERNAME}" ]] || yarn happo-ci'
           environment:
             HAPPO_IS_ASYNC: 'true'
             BASE_BRANCH: 'origin/main'


### PR DESCRIPTION
# Summary

Only run happo if GITHUB_USERNAME is set to fix dependabot

## Related Issues or PRs

fixes #450

## How To Test

Watch dependabot PRs after merge