### PR TITLE
ci: Run Happo for every PR again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,7 @@ jobs:
 
       - run:
           name: 'Happo'
-          # Only run happo if CIRCLE_USERNAME is set.  This will skip
-          # dependabot PRs
-          command: '[[ -z "${CIRCLE_USERNAME}" ]] || yarn happo-ci'
+          command: 'yarn happo-ci'
           environment:
             HAPPO_IS_ASYNC: 'true'
             BASE_BRANCH: 'origin/main'


### PR DESCRIPTION
# Summary
Dependabot PRs are blocked up again due to Happo. I saw discussion of slack that we want try, instead, running happo for every PR again. In that case, removing conditional logic in circleci config about this.

## Related Issues or PRs

Related to #450 

## How To Test
Can be tested on merge.