### PR TITLE
fix: Require Typescript 3.8+

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "stylelint-prettier": "^1.1.1",
     "stylelint-scss": "^3.17.1",
     "ts-jest": "^26.1.2",
-    "typescript": "^3.6.3",
+    "typescript": "^3.8.0",
     "url-loader": "^4.0.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:coverage": "jest --coverage",
     "storybook": "start-storybook -p 9009",
     "storybook:deploy": "storybook-to-ghpages",
-    "build": "webpack -p",
+    "build": "webpack --progress",
     "build:watch": "webpack --watch",
     "lint": "tsc --noEmit && eslint --ext js,jsx,ts,tsx src && stylelint \"src/**/*.{css,scss}\"",
     "release": "standard-version -t ''",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13989,7 +13989,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.3:
+typescript@^3.8.0:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
# Summary
- adjust typescript minimum version and fix `yarn build`

## Related Issues or PRs

resolves #520 

## How To Test
- clearing out `node_modules`, `yarn` and then `yarn build` should all run without bugs. 
- Tests and Happo should pass.


