### PR TITLE
ci: Use yarn cache in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1.0.0-dependencies-{{ checksum "package.json" }}
-            - v1.0.0-dependencies-
+            - v1-yarn-{{ checksum "yarn.lock" }}
+            - v1-yarn-
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
 
       - save_cache:
           paths:
-            - node_modules
-          key: v1.0.0-dependencies-{{ checksum "package.json" }}
+            - ~/.cache/yarn
+          key: v1-yarn-{{ checksum "yarn.lock" }}
 
       - run: yarn test -w 1
 


### PR DESCRIPTION
# Summary

Use the [CircleCI Approved pattern for caching yarn](https://circleci.com/docs/2.0/yarn/#caching) (and not node_modules)

## Related Issues or PRs

closes #731 

## How To Test

If CircleCI passes, we're good

### Screenshots (optional)
