### PR TITLE
ci: Make dependabot updates at the same time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-      time: '06:00'
-      timezone: PST8PDT
     pull-request-branch-name:
       separator: '-'
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Summary
Make updates to the library and the `/example` app node dependencies at the same time. By using the [default](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#scheduletime) updates will happen before work starts on Mondays. 