### PR TITLE
docs: Add example implementation to new_component.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -14,10 +14,17 @@ labels: "type: feature"
 
 ## Requirements (proposed)
 **Prop Interface**
-``` 
+``` JSX
 Props = {
 }
 ```
+
+## Example Implementation (proposed)
+``` JSX
+return (
+)
+```
+
 **More Details**
   -   `<div>`root element
 


### PR DESCRIPTION
# Summary
This is something we started filling in manually to new component issues see #487. Lets just add it to the template
