### PR TITLE
docs: Update license to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2019, TrussWorks, Inc.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An example application, built with React-USWDS, can be found in the `/example` f
   - [Background](#background)
     - [Non-Goals](#non-goals)
   - [Install](#install)
+    - [Pre-Release](#pre-release)
   - [Usage](#usage)
   - [Maintainers](#maintainers)
   - [Contributing](#contributing)
@@ -106,7 +107,7 @@ This repository is governed by the [Contributor Covenant](./CODE_OF_CONDUCT.md)
 
 ## License
 
-[Copyright 2019, TrussWorks, Inc.](../LICENSE)
+[Copyright 2021, TrussWorks, Inc.](../LICENSE)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This repository is governed by the [Contributor Covenant](./CODE_OF_CONDUCT.md)
 
 ## License
 
-[Copyright 2021, TrussWorks, Inc.](../LICENSE)
+[Copyright 2021, TrussWorks, Inc.](./LICENSE)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We are glad you are interested to contribute to this project! Please make sure you've seen the README and license for this project before continuing further. If you work for Truss, check out the [guide for Trussels](./docs/for_trussels.md) as well.
+We are glad you are interested to contribute to this project! Please make sure you've seen the README and license for this project before continuing further. If you work for Truss, check out the [guide for Trussels](./for_trussels.md) as well.
 
 We welcome contributions in the form of comments, issues, or pull requests with code changes. If you see an error, have a question, or want to share feedback open an issue to discuss. This repository is governed by the [Contributor Covenant](../CODE_OF_CONDUCT.md)
 
@@ -101,4 +101,4 @@ Because this project exports a library that will be used by other projects, it i
     _strongly_ recommended you familiarize yourself with [conventional commits](https://www.conventionalcommits.org).
   - The **[WIP]** prefix can be used to indicate a pull request is still work in progress. In this case, the PR title is not validated and the pull request lint check remains pending.
 
-Having issues? See [FAQs](./docs/faqs.md).
+Having issues? See [FAQs](./faqs.md).

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -2,7 +2,7 @@
 
 - How come my components are not loading with the proper styles?
 
-  - Make sure you are importing the needed CSS before trying to use any of the React components. See styles and assets [documentation](./docs/styles_and_assets.md) for more detail. If something is unclear or seems broken, please file an issue.
+  - Make sure you are importing the needed CSS before trying to use any of the React components. See styles and assets [documentation](./styles_and_assets.md) for more detail. If something is unclear or seems broken, please file an issue.
 
 - How do I use a component from this library?
 

--- a/docs/for_trussels.md
+++ b/docs/for_trussels.md
@@ -20,7 +20,7 @@ Regardless of whether you are on client work or Reserve, it is _up to each indiv
 - Watch [USWDS](https://github.com/uswds/uswds) updates, and create new issues needed to help this project stay up-to-date with them
 - Participate in PR reviews, issue discussion, and project roadmap planning
 - Address any security alerts that come up promptly (see below)
-- Shepherd library releases forward and publish to npm. See [releasing documentation](./docs/for_trussels.md).
+- Shepherd library releases forward and publish to npm. See [releasing documentation](./for_trussels.md).
 - Maintain the project board.
 - Prevent PRs and issues from becoming stale, and clean up the ones that do.
 - Moderate discussions to keep alignment with [Truss values](https://truss.works/values)


### PR DESCRIPTION
# Summary
It's a new year. Also there were a bunch of broken links 🤕 from an earlier refactor.