### PR TITLE
docs: Add fields for USWDS versions to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,41 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[fix]"
-labels: "type: bug"
+title: '[fix]'
+labels: 'type: bug'
 assignees: ''
-
 ---
 
+**ReactUSWDS Version & USWDS Version:**
+
+<!-- Please note what versions of both ReactUSWDS and USWDS this bug pertains to. -->
+
 **Describe the bug**
+
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 **Expected behavior**
+
 <!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
+
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
+
 <!-- Add any other context about the problem here. -->
 
 **Device and Browser Information (please complete the following information if describing a UI bug):**
+
  <!-- - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22] -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,23 +1,31 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[feat]"
-labels: "type: feature"
+title: '[feat]'
+labels: 'type: feature'
 assignees: ''
-
 ---
 
 **Does your feature request relate to a specific USWDS component?**
+
 <!-- If your feature request relates to a USWDS component, please name and link it here. -->
 
+**What USWDS Version is this feature present in?**
+
+<!-- If this feature relates to a specific feature in USWDS, please note what version it was introduced in. -->
+
 **Is your feature request related to a problem? Please describe.**
+
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
+
 <!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
+
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
- **Additional context**
+**Additional context**
+
 <!-- Add any other context or screenshots about the feature request here.  -->

--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -1,32 +1,38 @@
 ---
 name: New USWDS Component
 about: Add a new component based on USWDS spec
-title: "New Component: "
-labels: "type: feature"
-
+title: 'New Component: '
+labels: 'type: feature'
 ---
 
 # [Component Name](https://designsystem.digital.gov/components/##)
 
+## USWDS Version
+
+<!-- If this feature relates to a specific feature in USWDS, please note what version it was introduced in. -->
 
 ## Description
 
-
 ## Requirements (proposed)
+
 **Prop Interface**
-``` JSX
+
+```JSX
 Props = {
 }
 ```
 
 ## Example Implementation (proposed)
-``` JSX
+
+```JSX
 return (
 )
 ```
 
 **More Details**
-  -   `<div>`root element
+
+- `<div>`root element
 
 ## Other Considerations
--  
+
+-

--- a/.github/ISSUE_TEMPLATE/request_for_implementation.md
+++ b/.github/ISSUE_TEMPLATE/request_for_implementation.md
@@ -1,16 +1,19 @@
 ---
-name: Request for Implementation 
-about: Suggest a new component for the library based on an existing example from your codebase 
+name: Request for Implementation
+about: Suggest a new component for the library based on an existing example from your codebase
 title: ''
 labels: 'type: request for implementation'
 assignees: ''
-
 ---
 
 **Which USWDS component(s) does this relate to?**
 
+**What USWDS Version was this component introduced by?**
+
 **Code snippet**
+
 <!-- Paste code, a gist, or code pen of the working component code. Make sure to remove any identifying information. Use https://gist.github.com/ to make a new gist. -->
 
 **Further detail**
+
 <!-- Any additional context or description about the implementation. -->


### PR DESCRIPTION
# Summary

This adds questions/fields to our issue templates asking for USWDS version where relevant. I'm hoping this will make it easier for us to determine priority of issues and map them to USWDS version milestones.