### PR TITLE
feat: Add Modal deprecation warnings (non-breaking deprecation)

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -2,18 +2,24 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { renderHook, act } from '@testing-library/react-hooks'
 
+jest.mock('../../deprecation')
+import { deprecationWarning } from '../../deprecation'
 import { Modal, connectModal, useModal } from './Modal'
 
 describe('Modal component', () => {
   it('renders without errors', () => {
     const { queryByTestId } = render(<Modal>My Modal</Modal>)
     expect(queryByTestId('modal')).toBeInTheDocument()
+    expect(deprecationWarning).toHaveBeenCalledTimes(1)
   })
 })
 
 const TestModal = (): React.ReactElement => <div>My Modal</div>
 
 describe('connectModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
   const mockClose = jest.fn()
 
   describe('if isOpen is false', () => {
@@ -23,6 +29,7 @@ describe('connectModal', () => {
         <TestConnectedModal isOpen={false} onClose={mockClose} />
       )
       expect(queryByText('My Modal')).not.toBeInTheDocument()
+      expect(deprecationWarning).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -33,13 +40,19 @@ describe('connectModal', () => {
         <TestConnectedModal isOpen={true} onClose={mockClose} />
       )
       expect(queryByText('My Modal')).toBeInTheDocument()
+      expect(deprecationWarning).toHaveBeenCalledTimes(2)
     })
   })
 })
 
 describe('useModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('provides state and functions for opening/closing a modal', () => {
     const { result } = renderHook(() => useModal())
+    expect(deprecationWarning).toHaveBeenCalledTimes(1)
     expect(result.current.isOpen).toEqual(false)
     expect(typeof result.current.openModal).toBe('function')
     expect(typeof result.current.closeModal).toBe('function')
@@ -49,11 +62,13 @@ describe('useModal', () => {
     })
 
     expect(result.current.isOpen).toEqual(true)
+    expect(deprecationWarning).toHaveBeenCalledTimes(2)
 
     act(() => {
       result.current.closeModal()
     })
 
     expect(result.current.isOpen).toEqual(false)
+    expect(deprecationWarning).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import classnames from 'classnames'
 
 import styles from './Modal.module.scss'
+import { deprecationWarning } from '../../deprecation'
 
 type ModalProps = {
   title?: React.ReactNode
@@ -18,6 +19,10 @@ export const Modal = ({
   className,
 }: ModalProps): React.ReactElement => {
   const classes = classnames(styles.modal, className)
+
+  deprecationWarning(
+    'Modal is deprecated.  Modal will be removed from react-uswds alongside all other Modal related components and functions in the next major release.'
+  )
 
   return (
     <div data-testid="modal" className={classes}>
@@ -38,9 +43,13 @@ export const ModalContainer = ({
   children,
 }: {
   children: React.ReactNode
-}): React.ReactElement => (
-  <div className={styles.modalContainer}>{children}</div>
-)
+}): React.ReactElement => {
+  deprecationWarning(
+    'Modal is deprecated. ModalContainer will be removed from react-uswds alongside all other Modal related components and functions in the next major release.'
+  )
+
+  return <div className={styles.modalContainer}>{children}</div>
+}
 
 /** connectModal and useModal package the logic & state of opening/closing a modal */
 export interface ConnectedModalProps {
@@ -55,6 +64,10 @@ export const connectModal = function <P extends ConnectedModalProps>(
     isOpen,
     ...props
   }: P): React.ReactElement | null => {
+    deprecationWarning(
+      "Modal is deprecated. 'connectModal' will be removed from react-uswds alongside all other Modal related components and functions in the next major release."
+    )
+
     if (!isOpen) return null
     return (
       <>
@@ -76,6 +89,10 @@ export type ModalHook = {
 }
 
 export const useModal = (): ModalHook => {
+  deprecationWarning(
+    'Modal is deprecated. The useModal hook will be removed from react-uswds alongside all other Modal related components and functions in the next major release.'
+  )
+
   const [isOpen, setIsOpen] = useState(false)
 
   const openModal = (): void => {


### PR DESCRIPTION
# Summary

Adds deprecation warnings to Modal components and functions/hooks in preparation for official removal from this library

## Related Issues or PRs

closes #786 

(I'm now realizing this issue was still under "Needs Requirements". I figured it'd be some low-hanging-fruit to get a warning out to consumers of this library as early as possible. Whenever we're ready, this branch exists to be merged (or updated then merged) pending any requirement changes)

## How To Test

```
> git fetch
> git checkout bl-modal-deprecation-warning-786

> yarn storybook
```

Then preview any Modal story and take note of the console warnings (screenshots below as well)

### Screenshots (optional)

Any single export will show a deprecation warning as follows:
![image](https://user-images.githubusercontent.com/15805554/105873996-12e59380-5fca-11eb-9169-e0e4593b28eb.png)

---

Multiple exports will each show specific deprecation warnings
![image](https://user-images.githubusercontent.com/15805554/105875035-4f65bf00-5fcb-11eb-8041-b1bc379e9704.png)

---