### PR TITLE
fix: Use functional state update

### DIFF
--- a/src/components/GovBanner/GovBanner.tsx
+++ b/src/components/GovBanner/GovBanner.tsx
@@ -140,7 +140,7 @@ export const GovBanner = (
               aria-expanded={isOpen}
               aria-controls="gov-banner"
               onClick={(): void => {
-                setOpenState(!isOpen)
+                setOpenState((isOpen) => !isOpen)
               }}>
               <span className="usa-banner__button-text">
                 {copy.headerAction}

--- a/src/components/forms/Form/Form.stories.tsx
+++ b/src/components/forms/Form/Form.stories.tsx
@@ -213,7 +213,9 @@ export const signInForm = (): React.ReactElement => {
             href="javascript:void(0);"
             className="usa-show-password"
             aria-controls="password-sign-in"
-            onClick={(): void => setShowPassword(!showPassword)}>
+            onClick={(): void =>
+              setShowPassword((showPassword) => !showPassword)
+            }>
             {showPassword ? 'Hide password' : 'Show password'}
           </a>
         </p>
@@ -264,7 +266,9 @@ export const passwordResetForm = (): React.ReactElement => {
             href="javascript:void(0);"
             className="usa-show-multipassword"
             aria-controls="newPassword confirmPassword"
-            onClick={(): void => setShowPassword(!showPassword)}>
+            onClick={(): void =>
+              setShowPassword((showPassword) => !showPassword)
+            }>
             {showPassword ? 'Hide my typing' : 'Show my typing'}
           </a>
         </p>


### PR DESCRIPTION
# Summary

Update several state updates to use a functional update where the updated value depends on the previous value

## Related Issues or PRs

closes #844 

## How To Test

Component behavior should remain unchanged by this PR.
Jest tests should still pass.
Storybook functionality (e.g. Expanding/Collapsing GovBanner or Password Reset Form, toggle `showPassword`) should still behave as expected