### PR TITLE
fix: Add delay for CharacterCount story in Happo

### DIFF
--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -54,7 +54,7 @@ export const textarea = (): React.ReactElement => (
   </Form>
 )
 
-export const withCustomCharacterCount = (): React.ReactElement => {
+const withCustomCharacterCount = (): React.ReactElement => {
   const customEmojiCharacterCount = (text: string): number => {
     const starCount = (text.match(/⭐️/g) || []).length
     return Array.from(text).length - starCount * 2
@@ -96,3 +96,6 @@ export const withCustomCharacterCount = (): React.ReactElement => {
     </Form>
   )
 }
+
+withCustomCharacterCount.parameters = { happo: { delay: 100 } }
+export { withCustomCharacterCount }


### PR DESCRIPTION
# Summary

I'm currently debugging a spurious issue with emojis sometimes not
showing up in the ios-safari target on happo.io. This is an example
of such a spurious diff:
https://happo.io/a/371/p/453/compare/e934ff76a58cdbc523eef0a3c496fe2d20c02c73/cf58cd0cc54d7da04ce184d380b6f73da64a439e

My attempts at isolating this issue and reproduce haven't played out.
I've tried rendering roughly the same html as in the CharacterCount
story but all my screenshots come back with visible emoji characters.
This makes me wonder if there is maybe a race condition where Safari on
iOS is doing some optimization where a first render isn't showing emoji
(but the second/nth render does). If that's the case, adding a short
delay before Happo takes the screenshot should help resolve this.

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

Run in CI and see if Happo reports spurious diffs

### Screenshots (optional)
