### PR TITLE
fix: set CombBox focusMode to BLUR when focus is outside of the component

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { ComboBox } from './ComboBox'
 import { Form } from '../Form/Form'
 import { Label } from '../Label/Label'
-
+import { TextInput } from '../TextInput/TextInput'
 import { fruits } from './fruits'
 
 export default {
@@ -89,6 +89,28 @@ export const disabled = (): React.ReactElement => {
         onChange={noop}
         disabled
       />
+    </Form>
+  )
+}
+
+export const withOtherFields = (): React.ReactElement => {
+  const fruitList = Object.entries(fruits).map(([value, key]) => ({
+    value: value,
+    label: key,
+  }))
+
+  return (
+    <Form onSubmit={noop}>
+      <Label htmlFor="fruit">Select a Fruit</Label>
+      <ComboBox
+        id="fruit"
+        name="fruit"
+        options={fruitList}
+        onChange={noop}
+        defaultValue="avocado"
+      />
+      <Label htmlFor="fruitDescription">Description</Label>
+      <TextInput id="fruitDescription" name="fruitDescription" type="text" />
     </Form>
   )
 }

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { ComboBox } from './ComboBox'
+import { TextInput } from '../TextInput/TextInput'
 import { fruits } from './fruits'
 
 /*
@@ -835,6 +836,38 @@ describe('ComboBox component', () => {
 
       expect(getByTestId('combo-box-clear-button')).not.toBeVisible()
       expect(getByTestId('combo-box-option-list').children.length).toEqual(1)
+    })
+
+    it('does not hijack focus while tabbing when another field has focus', () => {
+      const { getByTestId } = render(
+        <>
+          <ComboBox
+            id="favorite-fruit"
+            name="favorite-fruit"
+            options={fruitOptions}
+            onChange={jest.fn()}
+          />
+          <TextInput
+            id="input-Text"
+            name="input-Text"
+            type="text"
+            data-testid="input-Text"
+          />
+        </>
+      )
+      const comboBoxInput = getByTestId('combo-box-input')
+      const textInput = getByTestId('input-Text')
+
+      // Fill ComboBox
+      userEvent.type(comboBoxInput, 'Apple{enter}')
+
+      // Tab to next field (Text Input)
+      userEvent.tab()
+
+      // Fill text input
+      userEvent.type(textInput, 'Test 123')
+
+      expect(textInput).toHaveValue('Test 123')
     })
 
     xit('focuses the input when an option is focused and shift-tab is pressed', () => {

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -120,6 +120,18 @@ export const ComboBox = (props: ComboBoxProps): React.ReactElement => {
     }
   })
 
+  // If the focused element (activeElement) is outside of the combo box,
+  // make sure the focusMode is BLUR
+  useEffect(() => {
+    if (state.focusMode !== FocusMode.None) {
+      if (!containerRef.current?.contains(window.document.activeElement)) {
+        dispatch({
+          type: ActionTypes.BLUR,
+        })
+      }
+    }
+  })
+
   const handleInputKeyDown = (event: KeyboardEvent): void => {
     if (event.key === 'Escape') {
       dispatch({ type: ActionTypes.CLOSE_LIST })


### PR DESCRIPTION
# Summary
In #901, we ensured that the combo box's `focusMode` was set to `BLUR` when a user **clicked** outside of the component. This is not sufficient for keyboard shortcuts, such as tabbing. When a user tabs through input fields, the focus on the combo box isn't reset.

*I also added an additional story that puts a text input next to the combo box to make it easier for folks to test. Since we've had some issues surrounding focus, I think it'd be good to have for testing.

## Related Issues or PRs 
#901 
#902

## How To Test
The form must have at least 2 elements to interact with. I used the combo box and a text input.
1. Fill in the combo box (e.g. type value, select from dropdown, etc.)
2. Use `tab` to focus the next field
3. Type in the text field

Prior to the fix, the user's focus would be shifted back to the combo box.
After the fix, the user is able to continue typing in the text input
