### PR TITLE
fix: ComboBox "keyboard trap" and misc bugs

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -102,13 +102,7 @@ export const withOtherFields = (): React.ReactElement => {
   return (
     <Form onSubmit={noop}>
       <Label htmlFor="fruit">Select a Fruit</Label>
-      <ComboBox
-        id="fruit"
-        name="fruit"
-        options={fruitList}
-        onChange={noop}
-        defaultValue="avocado"
-      />
+      <ComboBox id="fruit" name="fruit" options={fruitList} onChange={noop} />
       <Label htmlFor="fruitDescription">Description</Label>
       <TextInput id="fruitDescription" name="fruitDescription" type="text" />
     </Form>

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -887,6 +887,36 @@ describe('ComboBox component', () => {
       expect(textInput).toHaveValue('Test 123')
     })
 
+    it('clears out the input when options list is closed and no matching options is selected', () => {
+      const { getByTestId } = render(
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={fruitOptions}
+          onChange={jest.fn()}
+        />
+      )
+
+      const comboBoxInput = getByTestId('combo-box-input')
+      userEvent.type(comboBoxInput, 'a{enter}')
+      expect(comboBoxInput).toHaveValue('')
+    })
+
+    it('selected option if the input matches 100% of the label characters (case insensitive)', () => {
+      const { getByTestId } = render(
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={fruitOptions}
+          onChange={jest.fn()}
+        />
+      )
+
+      const comboBoxInput = getByTestId('combo-box-input')
+      userEvent.type(comboBoxInput, 'aPpLe{enter}')
+      expect(comboBoxInput).toHaveValue('Apple')
+    })
+
     xit('focuses the input when an option is focused and shift-tab is pressed', () => {
       const { getByTestId } = render(
         <ComboBox

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -615,6 +615,23 @@ describe('ComboBox component', () => {
       expect(onChange).toHaveBeenLastCalledWith('mango')
     })
 
+    it('switches focus when there are no filtered options', () => {
+      const { getByTestId } = render(
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={fruitOptions}
+          onChange={jest.fn()}
+        />
+      )
+
+      const comboBoxInput = getByTestId('combo-box-input')
+      userEvent.type(comboBoxInput, 'zzz')
+      userEvent.tab()
+
+      expect(comboBoxInput).not.toHaveFocus()
+    })
+
     it('selects the focused option with enter', () => {
       const onChange = jest.fn()
       const { getByTestId } = render(

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -152,7 +152,17 @@ export const ComboBox = (props: ComboBoxProps): React.ReactElement => {
             type: ActionTypes.FOCUS_OPTION,
             option: state.filteredOptions[0],
           })
+        } else {
+          dispatch({
+            type: ActionTypes.BLUR,
+          })
         }
+      }
+
+      if (!state.isOpen && state.selectedOption) {
+        dispatch({
+          type: ActionTypes.BLUR,
+        })
       }
     } else if (event.key === 'Enter' && state.inputValue !== '') {
       event.preventDefault()

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -164,9 +164,20 @@ export const ComboBox = (props: ComboBoxProps): React.ReactElement => {
           type: ActionTypes.BLUR,
         })
       }
-    } else if (event.key === 'Enter' && state.inputValue !== '') {
+    } else if (event.key === 'Enter' && !state.selectedOption) {
       event.preventDefault()
-      dispatch({ type: ActionTypes.CLOSE_LIST })
+      const selectedOption = state.filteredOptions.find(
+        (option) =>
+          option.label.toLowerCase() === state.inputValue.toLowerCase()
+      )
+      if (selectedOption) {
+        dispatch({
+          type: ActionTypes.SELECT_OPTION,
+          option: selectedOption,
+        })
+      } else {
+        dispatch({ type: ActionTypes.CLEAR })
+      }
     }
   }
 

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -144,11 +144,15 @@ export const ComboBox = (props: ComboBoxProps): React.ReactElement => {
     } else if (event.key === 'Tab') {
       // Clear button is not visible in this case so manually handle focus
       if (state.isOpen && !state.selectedOption) {
-        event.preventDefault()
-        dispatch({
-          type: ActionTypes.FOCUS_OPTION,
-          option: state.filteredOptions[0],
-        })
+        // If there are filtered options, prevent default
+        // If there are "No Results Found", tab over to prevent a keyboard trap
+        if (state.filteredOptions.length > 0) {
+          event.preventDefault()
+          dispatch({
+            type: ActionTypes.FOCUS_OPTION,
+            option: state.filteredOptions[0],
+          })
+        }
       }
     } else if (event.key === 'Enter' && state.inputValue !== '') {
       event.preventDefault()

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -118,7 +118,7 @@ export const ComboBox = (props: ComboBoxProps): React.ReactElement => {
     ) {
       itemRef.current.focus()
     }
-  })
+  }, [state.focusMode, state.focusedOption])
 
   // If the focused element (activeElement) is outside of the combo box,
   // make sure the focusMode is BLUR


### PR DESCRIPTION
# Summary

[ReactUSWDS Storybook](https://trussworks.github.io/react-uswds)
[USWDS](https://designsystem.digital.gov/form-controls/03-combo-box/)

This PR fixes a "keyboard trap" issue as well as other miscellaneous bugs.

1. When the user has no matching options, the user can't tab out.
2. When the user types input, no option is focused, and hits "tab", the input should clear and switch focus
3. When the user types input, and the text perfectly matches an option (case insensitive), the input should select/fill combo box with the correct option.