### PR TITLE
ci: Use pull_request_target event for semantic PR workflow

### DIFF
--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, edited, synchronize]
     branches:
       - main
-      - sr-update-semantic-pr-config
 
 jobs:
   lint:

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, synchronize]
     branches:
       - main
+      - sr-update-semantic-pr-config
 
 jobs:
   lint:

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,7 +1,7 @@
 name: Lint PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
     branches:
       - main


### PR DESCRIPTION
# Summary

Use the [newly introduced `pull_request_target` event](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) to trigger the semantic PR workflow. This ensures semantic PR workflow is always run against the config in the base branch of a PR, allowing PRs from forks to run workflows without worrying that they are changing config. This should also fix an issue where Dependabot PRs are failing with the error: `Error: Resource not accessible by integration` ([source](https://github.com/amannn/action-semantic-pull-request/pull/24))

Note, I added this branch to the config in order to test that it [actually fixed the Dependabot issue](https://github.com/trussworks/react-uswds/pull/1013) (since `pull_request_target` means the base branch of a PR needs to include updated config). When this PR is approved I will remove it.