### PR TITLE
feat: Update to USWDS 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^16.x || ^17.x",
     "react-dom": "^16.x || ^17.x",
-    "uswds": "2.8.1"
+    "uswds": "2.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -126,7 +126,7 @@
     "ts-jest": "^26.1.2",
     "typescript": "^3.8.0",
     "url-loader": "^4.0.0",
-    "uswds": "2.8.1",
+    "uswds": "2.9.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^4.0.0"
   },

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -27,8 +27,14 @@ export const secondary = (): React.ReactElement => (
   </Button>
 )
 
-export const accent = (): React.ReactElement => (
-  <Button type="button" accent>
+export const accentCool = (): React.ReactElement => (
+  <Button type="button" accentStyle='cool'>
+    Click Me
+  </Button>
+)
+
+export const accentWarm = (): React.ReactElement => (
+  <Button type="button" accentStyle='warm'>
     Click Me
   </Button>
 )

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -28,13 +28,13 @@ export const secondary = (): React.ReactElement => (
 )
 
 export const accentCool = (): React.ReactElement => (
-  <Button type="button" accentStyle='cool'>
+  <Button type="button" accentStyle="cool">
     Click Me
   </Button>
 )
 
 export const accentWarm = (): React.ReactElement => (
-  <Button type="button" accentStyle='warm'>
+  <Button type="button" accentStyle="warm">
     Click Me
   </Button>
 )

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -53,6 +53,27 @@ describe('Button component', () => {
       expect(queryByTestId('button')).toHaveClass('usa-button--big')
       expect(deprecationWarning).toHaveBeenCalledTimes(0)
     })
+
+    it('renders uswds class for cool accent style', () => {
+      const { queryByTestId } = render(
+        <Button type="button" accentStyle="cool">
+          Click Me
+        </Button>
+      )
+      expect(queryByTestId('button')).toHaveClass('usa-button--accent-cool')
+      expect(deprecationWarning).toHaveBeenCalledTimes(0)
+    })
+
+    it('renders uswds class for warm accent style', () => {
+      const { queryByTestId } = render(
+        <Button type="button" accentStyle="warm">
+          Click Me
+        </Button>
+      )
+      expect(queryByTestId('button')).toHaveClass('usa-button--accent-warm')
+      expect(deprecationWarning).toHaveBeenCalledTimes(0)
+    })
+
   })
 
   it('implements an onClick handler', () => {
@@ -65,6 +86,17 @@ describe('Button component', () => {
 
     fireEvent.click(getByText('Click Me'))
     expect(onClickFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a deprecation warning for prop \'accent\'', () => {
+    const onClickFn = jest.fn()
+    const { getByText } = render(
+      <Button type="button" accent>
+        Click Me
+      </Button>
+    )
+
+    expect(deprecationWarning).toHaveBeenCalledTimes(1)
   })
 
   it('accepts additional custom class names', () => {

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -74,7 +74,7 @@ describe('Button component', () => {
       expect(deprecationWarning).toHaveBeenCalledTimes(0)
     })
 
-    it('shows a deprecation warning for prop \'accent\'', () => {
+    it("shows a deprecation warning for prop 'accent'", () => {
       const { queryByTestId } = render(
         <Button type="button" accent>
           Click Me
@@ -83,7 +83,6 @@ describe('Button component', () => {
       expect(queryByTestId('button')).toHaveClass('usa-button--accent-cool')
       expect(deprecationWarning).toHaveBeenCalledTimes(1)
     })
-
   })
 
   it('implements an onClick handler', () => {

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -74,6 +74,16 @@ describe('Button component', () => {
       expect(deprecationWarning).toHaveBeenCalledTimes(0)
     })
 
+    it('shows a deprecation warning for prop \'accent\'', () => {
+      const { queryByTestId } = render(
+        <Button type="button" accent>
+          Click Me
+        </Button>
+      )
+      expect(queryByTestId('button')).toHaveClass('usa-button--accent-cool')
+      expect(deprecationWarning).toHaveBeenCalledTimes(1)
+    })
+
   })
 
   it('implements an onClick handler', () => {
@@ -86,17 +96,6 @@ describe('Button component', () => {
 
     fireEvent.click(getByText('Click Me'))
     expect(onClickFn).toHaveBeenCalledTimes(1)
-  })
-
-  it('shows a deprecation warning for prop \'accent\'', () => {
-    const onClickFn = jest.fn()
-    const { getByText } = render(
-      <Button type="button" accent>
-        Click Me
-      </Button>
-    )
-
-    expect(deprecationWarning).toHaveBeenCalledTimes(1)
   })
 
   it('accepts additional custom class names', () => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,7 +7,11 @@ interface ButtonProps {
   children: React.ReactNode
   secondary?: boolean
   base?: boolean
+  /**
+   * @deprecated since 1.14.0, use accentStyle
+   */
   accent?: boolean
+  accentStyle?: 'none' | 'cool' | 'warm'
   outline?: boolean
   inverse?: boolean
   size?: 'big' | 'small' // small is deprecated
@@ -32,6 +36,7 @@ export const Button = ({
     secondary,
     base,
     accent,
+    accentStyle = 'none',
     outline,
     inverse,
     size,
@@ -45,11 +50,15 @@ export const Button = ({
   }: ButtonProps & JSX.IntrinsicElements['button']): React.ReactElement => {
 
   if (big) {
-    deprecationWarning('Button property big is deprecated.  Use size')
+    deprecationWarning('Button property big is deprecated.  Use size.')
   }
 
   if (icon) {
     deprecationWarning('Button property icon is deprecated.')
+  }
+
+  if (accent) {
+    deprecationWarning('Button property accent is deprecated. Use accentStyle.')
   }
 
   const isBig = size ? size === 'big' : big
@@ -66,7 +75,8 @@ export const Button = ({
     {
       'usa-button--secondary': secondary,
       'usa-button--base': base,
-      'usa-button--accent-cool': accent,
+      'usa-button--accent-cool': accent || accentStyle === 'cool',
+      'usa-button--accent-warm': accentStyle === 'warm',
       'usa-button--outline': outline,
       'usa-button--inverse': inverse,
       'usa-button--big': isBig,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,7 +11,7 @@ interface ButtonProps {
    * @deprecated since 1.15.0, use accentStyle
    */
   accent?: boolean
-  accentStyle?: 'none' | 'cool' | 'warm'
+  accentStyle?: 'cool' | 'warm'
   outline?: boolean
   inverse?: boolean
   size?: 'big' | 'small' // small is deprecated
@@ -36,7 +36,7 @@ export const Button = ({
   secondary,
   base,
   accent,
-  accentStyle = 'none',
+  accentStyle,
   outline,
   inverse,
   size,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ interface ButtonProps {
   secondary?: boolean
   base?: boolean
   /**
-   * @deprecated since 1.14.0, use accentStyle
+   * @deprecated since 1.15.0, use accentStyle
    */
   accent?: boolean
   accentStyle?: 'none' | 'cool' | 'warm'

--- a/src/components/forms/Fieldset/Fieldset.stories.tsx
+++ b/src/components/forms/Fieldset/Fieldset.stories.tsx
@@ -40,7 +40,7 @@ export const nameFieldset = (): React.ReactElement => (
 )
 
 export const checkboxFieldset = (): React.ReactElement => (
-  <Fieldset legend="Historical figures 1" legendStyle='srOnly'>
+  <Fieldset legend="Historical figures 1" legendStyle="srOnly">
     <Checkbox
       id="truth"
       name="historical-figures-1"
@@ -100,7 +100,7 @@ export const checkboxFieldsetWithDefaultLegend = (): React.ReactElement => (
 )
 
 export const radioFieldset = (): React.ReactElement => (
-  <Fieldset legend="Historical figures 2" legendStyle='srOnly'>
+  <Fieldset legend="Historical figures 2" legendStyle="srOnly">
     <Radio
       id="stanton"
       name="historical-figures-2"

--- a/src/components/forms/Fieldset/Fieldset.stories.tsx
+++ b/src/components/forms/Fieldset/Fieldset.stories.tsx
@@ -23,7 +23,7 @@ Source: https://designsystem.digital.gov/components/form-controls/
 }
 
 export const nameFieldset = (): React.ReactElement => (
-  <Fieldset legend="Name">
+  <Fieldset legend="Name" legendStyle="large">
     <Label htmlFor="title" hint=" (optional)">
       Title
     </Label>
@@ -40,7 +40,37 @@ export const nameFieldset = (): React.ReactElement => (
 )
 
 export const checkboxFieldset = (): React.ReactElement => (
-  <Fieldset legend="Historical figures 1" legendSrOnly>
+  <Fieldset legend="Historical figures 1" legendStyle='srOnly'>
+    <Checkbox
+      id="truth"
+      name="historical-figures-1"
+      value="truth"
+      defaultChecked
+      label="Sojourner Truth"
+    />
+    <Checkbox
+      id="douglass"
+      name="historical-figures-1"
+      value="douglass"
+      label="Frederick Douglass"
+    />
+    <Checkbox
+      id="washington"
+      name="historical-figures-1"
+      value="washington"
+      label="Booker T. Washington"
+    />
+    <Checkbox
+      id="carver"
+      name="historical-figures-1"
+      label="George Washington Carver"
+      disabled
+    />
+  </Fieldset>
+)
+
+export const checkboxFieldsetWithDefaultLegend = (): React.ReactElement => (
+  <Fieldset legend="Historical figures 1">
     <Checkbox
       id="truth"
       name="historical-figures-1"
@@ -70,7 +100,38 @@ export const checkboxFieldset = (): React.ReactElement => (
 )
 
 export const radioFieldset = (): React.ReactElement => (
-  <Fieldset legend="Historical figures 2" legendSrOnly>
+  <Fieldset legend="Historical figures 2" legendStyle='srOnly'>
+    <Radio
+      id="stanton"
+      name="historical-figures-2"
+      defaultChecked
+      label="Elizabeth Cady Stanton"
+      value="stanton"
+    />
+    <Radio
+      id="anthony"
+      name="historical-figures-2"
+      label="Susan B. Anthony"
+      value="anthony"
+    />
+    <Radio
+      id="tubman"
+      name="historical-figures-2"
+      label="Harriet Tubman"
+      value="tubman"
+    />
+    <Radio
+      id="invalid"
+      name="historical-figures-2"
+      label="Invalid option"
+      value="invalid"
+      disabled
+    />
+  </Fieldset>
+)
+
+export const radioFieldsetWithDefaultLegend = (): React.ReactElement => (
+  <Fieldset legend="Historical figures 2">
     <Radio
       id="stanton"
       name="historical-figures-2"

--- a/src/components/forms/Fieldset/Fieldset.test.tsx
+++ b/src/components/forms/Fieldset/Fieldset.test.tsx
@@ -19,41 +19,41 @@ describe('Fieldset component', () => {
   describe('renders uswds classes', () => {
     it('renders legend with class usa-legend by default', () => {
       const { queryByTestId, getByText } = render(
-        <Fieldset legend="Legend">
-          My Fieldset
-        </Fieldset>
+        <Fieldset legend="Legend">My Fieldset</Fieldset>
       )
       expect(queryByTestId('fieldset')).toBeInTheDocument()
       expect(getByText('Legend')).toHaveClass('usa-legend')
     })
-  
+
     it('renders legend with class usa-legend--large when specified', () => {
       const { queryByTestId, getByText } = render(
-        <Fieldset legend="Legend" legendStyle='large'>
+        <Fieldset legend="Legend" legendStyle="large">
           My Fieldset
         </Fieldset>
       )
       expect(queryByTestId('fieldset')).toBeInTheDocument()
       expect(getByText('Legend')).toHaveClass('usa-legend--large')
     })
-  
+
     it('renders legend with class usa-sr-only when specified', () => {
       const { queryByTestId, getByText } = render(
-        <Fieldset legend="Legend" legendStyle='srOnly'>
+        <Fieldset legend="Legend" legendStyle="srOnly">
           My Fieldset
         </Fieldset>
       )
       expect(queryByTestId('fieldset')).toBeInTheDocument()
       expect(getByText('Legend')).toHaveClass('usa-sr-only')
     })
-    
+
     it('shows a deprecation warning when using deprecated legendSrOnly prop', () => {
-      const { queryByTestId, getByText } = render(<Fieldset legend="Legend" legendSrOnly>My Fieldset</Fieldset>)
+      const { queryByTestId, getByText } = render(
+        <Fieldset legend="Legend" legendSrOnly>
+          My Fieldset
+        </Fieldset>
+      )
       expect(queryByTestId('fieldset')).toBeInTheDocument()
       expect(getByText('Legend')).toHaveClass('usa-sr-only')
       expect(deprecationWarning).toBeCalledTimes(1)
     })
-
   })
-
 })

--- a/src/components/forms/Fieldset/Fieldset.test.tsx
+++ b/src/components/forms/Fieldset/Fieldset.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
+jest.mock('../../../deprecation')
 import { Fieldset } from './Fieldset'
+import { deprecationWarning } from '../../../deprecation'
 
 describe('Fieldset component', () => {
   it('renders without errors', () => {
@@ -13,4 +15,45 @@ describe('Fieldset component', () => {
     const { queryByText } = render(<Fieldset>My Fieldset</Fieldset>)
     expect(queryByText('My Fieldset')).toBeInTheDocument()
   })
+
+  describe('renders uswds classes', () => {
+    it('renders legend with class usa-legend by default', () => {
+      const { queryByTestId, getByText } = render(
+        <Fieldset legend="Legend">
+          My Fieldset
+        </Fieldset>
+      )
+      expect(queryByTestId('fieldset')).toBeInTheDocument()
+      expect(getByText('Legend')).toHaveClass('usa-legend')
+    })
+  
+    it('renders legend with class usa-legend--large when specified', () => {
+      const { queryByTestId, getByText } = render(
+        <Fieldset legend="Legend" legendStyle='large'>
+          My Fieldset
+        </Fieldset>
+      )
+      expect(queryByTestId('fieldset')).toBeInTheDocument()
+      expect(getByText('Legend')).toHaveClass('usa-legend--large')
+    })
+  
+    it('renders legend with class usa-sr-only when specified', () => {
+      const { queryByTestId, getByText } = render(
+        <Fieldset legend="Legend" legendStyle='srOnly'>
+          My Fieldset
+        </Fieldset>
+      )
+      expect(queryByTestId('fieldset')).toBeInTheDocument()
+      expect(getByText('Legend')).toHaveClass('usa-sr-only')
+    })
+    
+    it('shows a deprecation warning when using deprecated legendSrOnly prop', () => {
+      const { queryByTestId, getByText } = render(<Fieldset legend="Legend" legendSrOnly>My Fieldset</Fieldset>)
+      expect(queryByTestId('fieldset')).toBeInTheDocument()
+      expect(getByText('Legend')).toHaveClass('usa-sr-only')
+      expect(deprecationWarning).toBeCalledTimes(1)
+    })
+
+  })
+
 })

--- a/src/components/forms/Fieldset/Fieldset.tsx
+++ b/src/components/forms/Fieldset/Fieldset.tsx
@@ -1,20 +1,31 @@
 import React from 'react'
 import classnames from 'classnames'
+import { deprecationWarning } from '../../../deprecation'
 
 interface FieldsetProps {
   children: React.ReactNode
   legend?: React.ReactNode
+  /**
+   * @deprecated since 1.15.0, use legendStyle
+   */
   legendSrOnly?: boolean
+  legendStyle?: 'default' | 'large' | 'srOnly'
   className?: string
 }
 
 export const Fieldset = ({ 
-  children, legend, className, legendSrOnly 
+  children, legend, legendStyle='default', className, legendSrOnly 
 }: FieldsetProps): React.ReactElement => {
   const classes = classnames('usa-fieldset', className)
 
-  const legendClasses = classnames('usa-legend', {
-    'usa-sr-only': legendSrOnly,
+  if (legendSrOnly) {
+    deprecationWarning('Fieldset property legendSrOnly is deprecated. Use legendStyle = \'srOnly\'.')
+  }
+
+  const legendClasses = classnames({
+    'usa-legend': legendStyle === 'default',
+    'usa-legend--large': legendStyle === 'large',
+    'usa-sr-only': legendStyle === 'srOnly' || legendSrOnly,
   })
 
   return (

--- a/src/components/forms/Form/Form.stories.tsx
+++ b/src/components/forms/Form/Form.stories.tsx
@@ -78,7 +78,7 @@ export const textInputForm = (): React.ReactElement => (
 
 export const nameForm = (): React.ReactElement => (
   <Form onSubmit={mockSubmit}>
-    <Fieldset legend="Name">
+    <Fieldset legend="Name" legendStyle="large">
       <Label htmlFor="title" hint=" (optional)">
         Title
       </Label>
@@ -97,7 +97,7 @@ export const nameForm = (): React.ReactElement => (
 
 export const addressForm = (): React.ReactElement => (
   <Form onSubmit={mockSubmit} large>
-    <Fieldset legend="Mailing address">
+    <Fieldset legend="Mailing address" legendStyle="large">
       <Label htmlFor="mailing-address-1">Street address 1</Label>
       <TextInput id="mailing-address-1" name="mailing-address-1" type="text" />
 
@@ -193,7 +193,7 @@ export const signInForm = (): React.ReactElement => {
 
   return (
     <Form onSubmit={mockSubmit} large>
-      <Fieldset legend="Sign In">
+      <Fieldset legend="Sign In" legendStyle="large">
         <span>
           or <a href="javascript:void(0);">create an account</a>
         </span>
@@ -244,7 +244,7 @@ export const passwordResetForm = (): React.ReactElement => {
 
   return (
     <Form onSubmit={mockSubmit} large>
-      <Fieldset legend="Reset password">
+      <Fieldset legend="Reset password" legendStyle="large">
         <span>Please enter your new password</span>
         <Alert type="info" heading="Password information">
           Length requirements

--- a/yarn.lock
+++ b/yarn.lock
@@ -13939,10 +13939,10 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.8.1.tgz#937505ad8f7be4c131e6d4e01d0128cf0995a49c"
-  integrity sha512-x7RkaVFVuRxptsuUZka6Mc+wUUL98keorOUFVxrBIgd3KV18upuF5V7osm9sN/q6bGvwh2zJyfONETLUU8Eemg==
+uswds@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.9.0.tgz#002089d74582960099b0ee836f89f043cdf6d0bc"
+  integrity sha512-5IMVgMCUUlgWVFrB7Wf1qTvv5L3oDDlSsAgvJ02+/sV2uh4JzO9YPm3493RTaMuHTc+feRCuYyEIloXsEQY0Pg==
   dependencies:
     classlist-polyfill "^1.0.3"
     del "^5.1.0"


### PR DESCRIPTION
# Summary

Bumps USWDS dependency. Additionally makes react-uswds changes to mimic [2.9.0 bugfixes and improvements](https://github.com/uswds/uswds/releases/tag/v2.9.0) 

## Related Issues or PRs

closes: https://github.com/trussworks/react-uswds/issues/1046

## How To Test

Storybook and unit tests are the best bet for testing this.

Specifically, take note of the warm and cool button accent stories

Additionally, changes to Legend styles can be seen in the Fieldset stories. Old legend styles are preserved with the legendStyle="large" prop. (https://github.com/uswds/uswds/pull/3465). See note below regarding Happo

### Other
- Note: Several negligible Happo diffs due to font smoothing on buttons ,etc with 2.9.0 will be expected. One that is potentially more concerning is due to the changes to legend classes. By default, legends now render with smaller styles as the "old"/large legends are not recommended by uswds:
![image](https://user-images.githubusercontent.com/15805554/112651530-de078880-8e22-11eb-8ece-dd37cede3b16.png)
Not also that this now matches the USWDS component preview: 
![image](https://user-images.githubusercontent.com/15805554/112651695-05f6ec00-8e23-11eb-95c1-b2a1f28fe1e8.png)


- Should these changes be approved, I will add issues for removing deprecated Button and Fieldset props in the V2 milestone.
