### PR TITLE
fix: form control urls

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3182,11 +3182,11 @@ ansi-colors@^4.1.1:
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
-  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
-    type-fest "^0.11.0"
+    type-fest "^0.21.3"
 
 ansi-html@0.0.7, ansi-html@^0.0.7:
   version "0.0.7"
@@ -11743,15 +11743,15 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
-  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
-
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.3.1:
   version "0.3.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^16.x || ^17.x",
     "react-dom": "^16.x || ^17.x",
-    "uswds": "2.9.0"
+    "uswds": "2.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -126,7 +126,7 @@
     "ts-jest": "^26.1.2",
     "typescript": "^3.8.0",
     "url-loader": "^4.0.0",
-    "uswds": "2.9.0",
+    "uswds": "2.10.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^4.0.0"
   },

--- a/src/components/Footer/Address/Address.stories.tsx
+++ b/src/components/Footer/Address/Address.stories.tsx
@@ -10,7 +10,7 @@ export default {
         component: `
 Display address items (most likely links or simple text) in a row, wrapped in address tag.  Used in USWDS 2.0 Footer component.
 
-Source: https://designsystem.digital.gov/components/form-controls/#footer
+Source: https://designsystem.digital.gov/components/footer
 `,
       },
     },

--- a/src/components/Footer/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer/Footer.stories.tsx
@@ -23,7 +23,7 @@ export default {
         component: `
 ### USWDS 2.0 Footer component
 
-Source: https://designsystem.digital.gov/components/form-controls/#footer
+Source: https://designsystem.digital.gov/components/footer
 `,
       },
     },

--- a/src/components/Footer/FooterNav/FooterNav.stories.tsx
+++ b/src/components/Footer/FooterNav/FooterNav.stories.tsx
@@ -13,7 +13,7 @@ export default {
         component: `
 Display single list of nav items, or grouped nav items in an extended nav. Used in USWDS 2.0 Footer component.
 
-Source: https://designsystem.digital.gov/components/form-controls/#footer
+Source: https://designsystem.digital.gov/components/footer
 `,
       },
     },

--- a/src/components/Footer/Logo/Logo.stories.tsx
+++ b/src/components/Footer/Logo/Logo.stories.tsx
@@ -14,7 +14,7 @@ export default {
         component: `
 Display logo image with optional heading.  Used in USWDS 2.0 Footer component.
 
-Source: https://designsystem.digital.gov/components/form-controls/#footer
+Source: https://designsystem.digital.gov/components/footer
 `,
       },
     },

--- a/src/components/Footer/SocialLinks/SocialLinks.stories.tsx
+++ b/src/components/Footer/SocialLinks/SocialLinks.stories.tsx
@@ -11,7 +11,7 @@ export default {
         component: `
 Display social links in styled row. Used in USWDS 2.0 Footer component.
 
-Source: https://designsystem.digital.gov/components/form-controls/#footer
+Source: https://designsystem.digital.gov/components/footer
 `,
       },
     },

--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -5,7 +5,7 @@ import { FormGroup } from '../FormGroup/FormGroup'
 import { Label } from '../Label/Label'
 
 export default {
-  title: 'Components/Form controls/CharacterCount',
+  title: 'Components/CharacterCount',
   parameters: {
     docs: {
       description: {

--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -12,7 +12,7 @@ export default {
         component: `
 ### USWDS 2.0 Character count component
 
-Source: https://designsystem.digital.gov/components/form-controls/#character-count
+Source: https://designsystem.digital.gov/components/character-count
 `,
       },
     },

--- a/src/components/forms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/forms/Checkbox/Checkbox.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Checkbox } from './Checkbox'
 
 export default {
-  title: 'Components/Form controls/Checkbox',
+  title: 'Components/Checkbox',
   component: Checkbox,
   parameters: {
     docs: {

--- a/src/components/forms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/forms/Checkbox/Checkbox.stories.tsx
@@ -10,7 +10,7 @@ export default {
         component: `
 ### USWDS 2.0 Checkbox component
 
-Source: https://designsystem.digital.gov/components/form-controls/#checkbox
+Source: https://designsystem.digital.gov/components/checkbox
 `,
       },
     },

--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -7,7 +7,7 @@ import { TextInput } from '../TextInput/TextInput'
 import { fruits } from './fruits'
 
 export default {
-  title: 'Components/Form controls/Combo box',
+  title: 'Components/Combo box',
   component: ComboBox,
   parameters: {
     docs: {

--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -15,7 +15,7 @@ export default {
         component: `
 ### USWDS 2.0 ComboBox component
 
-Source: https://designsystem.digital.gov/components/form-controls/#ComboBox
+Source: https://designsystem.digital.gov/components/combo-box
 `,
       },
     },

--- a/src/components/forms/DateInput/DateInput.stories.tsx
+++ b/src/components/forms/DateInput/DateInput.stories.tsx
@@ -12,7 +12,7 @@ export default {
         component: `
 ### USWDS 2.0 DateInput component
 
-Source: https://designsystem.digital.gov/components/form-controls/#date-input
+Source: https://designsystem.digital.gov/components/date-input
 `,
       },
     },

--- a/src/components/forms/DateInput/DateInput.stories.tsx
+++ b/src/components/forms/DateInput/DateInput.stories.tsx
@@ -4,7 +4,7 @@ import { DateInputGroup } from '../DateInputGroup/DateInputGroup'
 import { Fieldset } from '../Fieldset/Fieldset'
 
 export default {
-  title: 'Components/Form controls/Date input',
+  title: 'Components/Date input',
   component: DateInput,
   parameters: {
     docs: {

--- a/src/components/forms/DatePicker/Calendar.stories.tsx
+++ b/src/components/forms/DatePicker/Calendar.stories.tsx
@@ -8,7 +8,7 @@ import { parseDateString } from './utils'
 // THIS STORY FOR INTERNAL DEVELOPMENT ONLY
 
 export default {
-  title: 'Components/Form controls/Date picker/Calendar',
+  title: 'Components/Date picker/Calendar',
   component: Calendar,
   argTypes: {
     handleSelectDate: { action: 'select date' },

--- a/src/components/forms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/forms/DatePicker/DatePicker.stories.tsx
@@ -19,7 +19,7 @@ export default {
         component: `
 ### USWDS 2.0 DatePicker component
 
-Source: https://designsystem.digital.gov/components/form-controls/#DatePicker
+Source: https://designsystem.digital.gov/components/date-picker
 
 **Note:** There is one small difference in functionality between this component and the USWDS implementation, related to validating the input. The USWDS implementation validates when:
 - setting the initial value based on the default value passed in

--- a/src/components/forms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/forms/DatePicker/DatePicker.stories.tsx
@@ -7,7 +7,7 @@ import { Label } from '../Label/Label'
 import { TextInput } from '../TextInput/TextInput'
 
 export default {
-  title: 'Components/Form controls/Date picker',
+  title: 'Components/Date picker',
   component: DatePicker,
   argTypes: {
     onSubmit: { action: 'submitted' },

--- a/src/components/forms/DatePicker/Day.stories.tsx
+++ b/src/components/forms/DatePicker/Day.stories.tsx
@@ -5,7 +5,7 @@ import { Day } from './Day'
 /*
 // THIS STORY FOR INTERNAL DEVELOPMENT ONLY
 export default {
-  title: 'Components/Form controls/Date picker/Day',
+  title: 'Components/Date picker/Day',
   component: Day,
   argTypes: {
     onClick: { action: 'on click' },

--- a/src/components/forms/DatePicker/MonthPicker.stories.tsx
+++ b/src/components/forms/DatePicker/MonthPicker.stories.tsx
@@ -7,7 +7,7 @@ import { parseDateString } from './utils'
 // THIS STORY FOR INTERNAL DEVELOPMENT ONLY
 
 export default {
-  title: 'Components/Form controls/Date picker/Month picker',
+  title: 'Components/Date picker/Month picker',
   component: MonthPicker,
   argTypes: { handleSelectMonth: { action: 'handle select month' } },
 }

--- a/src/components/forms/DatePicker/YearPicker.stories.tsx
+++ b/src/components/forms/DatePicker/YearPicker.stories.tsx
@@ -7,7 +7,7 @@ import { parseDateString } from './utils'
 // THIS STORY FOR INTERNAL DEVELOPMENT ONLY
 
 export default {
-  title: 'Components/Form controls/Date picker/Year picker',
+  title: 'Components/Date picker/Year picker',
   component: YearPicker,
   argTypes: {
     handleSelectYear: { action: 'handle select year' },

--- a/src/components/forms/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.stories.tsx
@@ -5,7 +5,7 @@ import { Form } from '../Form/Form'
 import { addDays, formatDate } from '../DatePicker/utils'
 
 export default {
-  title: 'Components/Form controls/Date range picker',
+  title: 'Components/Date range picker',
   component: DateRangePicker,
   argTypes: {
     onSubmit: {

--- a/src/components/forms/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component: `
   ### USWDS 2.0 Date Range Picker component
-  Source: https://designsystem.digital.gov/components/form-controls/#date-range-picker
+  Source: https://designsystem.digital.gov/components/date-range-picker
         `,
       },
     },

--- a/src/components/forms/Dropdown/Dropdown.stories.tsx
+++ b/src/components/forms/Dropdown/Dropdown.stories.tsx
@@ -12,7 +12,7 @@ export default {
         component: `
 ### USWDS 2.0 Dropdown component
 
-Source: https://designsystem.digital.gov/components/form-controls/#dropdown
+Source: https://designsystem.digital.gov/components/dropdown
 `,
       },
     },

--- a/src/components/forms/Dropdown/Dropdown.stories.tsx
+++ b/src/components/forms/Dropdown/Dropdown.stories.tsx
@@ -4,7 +4,7 @@ import { Dropdown } from './Dropdown'
 import { Label } from '../Label/Label'
 
 export default {
-  title: 'Components/Form controls/Dropdown',
+  title: 'Components/Dropdown',
   component: Dropdown,
   parameters: {
     docs: {

--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -6,7 +6,7 @@ import { Label } from '../Label/Label'
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage'
 
 export default {
-  title: 'Components/Form controls/File input',
+  title: 'Components/File input',
   component: FileInput,
   argTypes: {
     onChange: { action: 'changed' },

--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -17,7 +17,7 @@ export default {
       description: {
         component: `
 ### USWDS 2.0 FileInput component
-Source: https://designsystem.digital.gov/components/form-controls/#file-input
+Source: https://designsystem.digital.gov/components/file-input
 `,
       },
     },

--- a/src/components/forms/FileInput/FilePreview.stories.tsx
+++ b/src/components/forms/FileInput/FilePreview.stories.tsx
@@ -13,7 +13,7 @@ import {
 /*
 // THIS STORY FOR INTERNAL DEVELOPMENT ONLY
 export default {
-  title: 'Components/Form controls/File input/File preview',
+  title: 'Components/File input/File preview',
   component: FilePreview,
 }
 */

--- a/src/components/forms/Radio/Radio.stories.tsx
+++ b/src/components/forms/Radio/Radio.stories.tsx
@@ -33,3 +33,7 @@ export const selected = (): React.ReactElement => (
 export const disabled = (): React.ReactElement => (
   <Radio id="input-radio" name="input-radio" label="My Radio Button" disabled />
 )
+
+export const tile = (): React.ReactElement => (
+  <Radio id="input-radio" name="input-radio" label="My Radio Button" tile />
+)

--- a/src/components/forms/Radio/Radio.stories.tsx
+++ b/src/components/forms/Radio/Radio.stories.tsx
@@ -34,6 +34,25 @@ export const disabled = (): React.ReactElement => (
   <Radio id="input-radio" name="input-radio" label="My Radio Button" disabled />
 )
 
+export const WithLabelDescription = (): React.ReactElement => (
+  <Radio
+    id="input-radio"
+    name="input-radio"
+    label="My Radio Button"
+    labelDescription="Optional label description"
+  />
+)
+
 export const tile = (): React.ReactElement => (
   <Radio id="input-radio" name="input-radio" label="My Radio Button" tile />
+)
+
+export const tileWithLabelDescription = (): React.ReactElement => (
+  <Radio
+    id="input-radio"
+    name="input-radio"
+    label="My Radio Button"
+    labelDescription="Optional label description"
+    tile
+  />
 )

--- a/src/components/forms/Radio/Radio.stories.tsx
+++ b/src/components/forms/Radio/Radio.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Radio } from './Radio'
 
 export default {
-  title: 'Components/Form controls/Radio buttons',
+  title: 'Components/Radio buttons',
   component: Radio,
   parameters: {
     docs: {

--- a/src/components/forms/Radio/Radio.stories.tsx
+++ b/src/components/forms/Radio/Radio.stories.tsx
@@ -10,7 +10,7 @@ export default {
         component: `
 ### USWDS 2.0 Radio component
 
-Source: https://designsystem.digital.gov/components/form-controls/#radio-buttons
+Source: https://designsystem.digital.gov/components/radio-buttons
 `,
       },
     },

--- a/src/components/forms/Radio/Radio.test.tsx
+++ b/src/components/forms/Radio/Radio.test.tsx
@@ -10,4 +10,13 @@ describe('Radio component', () => {
     )
     expect(queryByTestId('radio')).toBeInTheDocument()
   })
+
+  it('renders tiled radio buttons', () => {
+    const { queryByLabelText } = render(
+      <Radio id="input-radio" name="input-radio" label="My radio button" tile />
+    )
+    expect(queryByLabelText('My radio button')).toHaveClass(
+      'usa-radio__input usa-radio__input--tile'
+    )
+  })
 })

--- a/src/components/forms/Radio/Radio.test.tsx
+++ b/src/components/forms/Radio/Radio.test.tsx
@@ -19,4 +19,19 @@ describe('Radio component', () => {
       'usa-radio__input usa-radio__input--tile'
     )
   })
+
+  it('renders label description', () => {
+    const { queryByText } = render(
+      <Radio
+        id="input-radio"
+        name="input-radio"
+        label="My radio button"
+        labelDescription="Label description"
+        tile
+      />
+    )
+    expect(queryByText('Label description')).toHaveClass(
+      'usa-checkbox__label-description'
+    )
+  })
 })

--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -12,6 +12,7 @@ interface RadioProps {
     | React.RefObject<HTMLInputElement>
     | null
     | undefined
+  tile?: boolean
 }
 
 export const Radio = ({
@@ -20,14 +21,18 @@ export const Radio = ({
   className,
   label,
   inputRef,
+  tile,
   ...inputProps
 }: RadioProps & JSX.IntrinsicElements['input']): React.ReactElement => {
   const classes = classnames('usa-radio', className)
+  const radioClass = classnames('usa-radio__input', {
+    'usa-radio__input--tile': tile,
+  })
 
   return (
     <div data-testid="radio" className={classes}>
       <input
-        className="usa-radio__input"
+        className={radioClass}
         id={id}
         type="radio"
         name={name}

--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -25,14 +25,14 @@ export const Radio = ({
   ...inputProps
 }: RadioProps & JSX.IntrinsicElements['input']): React.ReactElement => {
   const classes = classnames('usa-radio', className)
-  const radioClass = classnames('usa-radio__input', {
+  const radioClasses = classnames('usa-radio__input', {
     'usa-radio__input--tile': tile,
   })
 
   return (
     <div data-testid="radio" className={classes}>
       <input
-        className={radioClass}
+        className={radioClasses}
         id={id}
         type="radio"
         name={name}

--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -13,6 +13,7 @@ interface RadioProps {
     | null
     | undefined
   tile?: boolean
+  labelDescription?: React.ReactNode
 }
 
 export const Radio = ({
@@ -22,12 +23,19 @@ export const Radio = ({
   label,
   inputRef,
   tile,
+  labelDescription,
   ...inputProps
 }: RadioProps & JSX.IntrinsicElements['input']): React.ReactElement => {
   const classes = classnames('usa-radio', className)
   const radioClasses = classnames('usa-radio__input', {
     'usa-radio__input--tile': tile,
   })
+  const description =
+    labelDescription != null ? (
+      <span className="usa-checkbox__label-description">
+        {labelDescription}
+      </span>
+    ) : null
 
   return (
     <div data-testid="radio" className={classes}>
@@ -41,6 +49,7 @@ export const Radio = ({
       />
       <label className="usa-radio__label" htmlFor={id}>
         {label}
+        {description}
       </label>
     </div>
   )

--- a/src/components/forms/RangeInput/RangeInput.stories.tsx
+++ b/src/components/forms/RangeInput/RangeInput.stories.tsx
@@ -3,7 +3,7 @@ import { RangeInput } from './RangeInput'
 import { Label } from '../Label/Label'
 
 export default {
-  title: 'Components/Form controls/Range slider',
+  title: 'Components/Range slider',
   component: RangeInput,
   parameters: {
     docs: {

--- a/src/components/forms/RangeInput/RangeInput.stories.tsx
+++ b/src/components/forms/RangeInput/RangeInput.stories.tsx
@@ -11,7 +11,7 @@ export default {
         component: `
 ### USWDS 2.0 RangeInput component
 
-Source: https://designsystem.digital.gov/components/form-controls/#range
+Source: https://designsystem.digital.gov/components/range-slider
 `,
       },
     },

--- a/src/components/forms/TextInput/TextInput.stories.tsx
+++ b/src/components/forms/TextInput/TextInput.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { TextInput } from './TextInput'
 
 export default {
-  title: 'Components/Form controls/Text input',
+  title: 'Components/Text input',
   component: TextInput,
   parameters: {
     docs: {

--- a/src/components/forms/TextInput/TextInput.stories.tsx
+++ b/src/components/forms/TextInput/TextInput.stories.tsx
@@ -10,7 +10,7 @@ export default {
         component: `
 ### USWDS 2.0 TextInput component
 
-Source: https://designsystem.digital.gov/components/form-controls/#text-input
+Source: https://designsystem.digital.gov/components/text-input
 `,
       },
     },

--- a/src/components/forms/Textarea/Textarea.stories.tsx
+++ b/src/components/forms/Textarea/Textarea.stories.tsx
@@ -10,7 +10,7 @@ export default {
         component: `
 ### USWDS 2.0 Textarea component
 
-Source: https://designsystem.digital.gov/components/form-controls/#text-input
+Source: https://designsystem.digital.gov/components/text-input
 `,
       },
     },

--- a/src/components/forms/Textarea/Textarea.stories.tsx
+++ b/src/components/forms/Textarea/Textarea.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Textarea } from './Textarea'
 
 export default {
-  title: 'Components/Form controls/Textarea',
+  title: 'Components/Textarea',
   component: Textarea,
   parameters: {
     docs: {

--- a/src/components/forms/Validation/Validation.stories.tsx
+++ b/src/components/forms/Validation/Validation.stories.tsx
@@ -9,7 +9,7 @@ import { ValidationChecklist } from './ValidationChecklist'
 import { ValidationItem } from './ValidationItem'
 
 export default {
-  title: 'Components/Form controls/Validation',
+  title: 'Components/Validation',
   component: ValidationChecklist,
   subcomponents: { ValidationItem },
   parameters: {

--- a/src/components/forms/Validation/Validation.stories.tsx
+++ b/src/components/forms/Validation/Validation.stories.tsx
@@ -18,7 +18,7 @@ export default {
         component: `
 ### USWDS 2.0 Validation component
 
-Source: https://designsystem.digital.gov/components/form-controls/#validation
+Source: https://designsystem.digital.gov/components/validation
 `,
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5389,18 +5389,18 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
-  integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
+del@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
+  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
   dependencies:
-    globby "^10.0.1"
-    graceful-fs "^4.2.2"
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
     is-glob "^4.0.1"
     is-path-cwd "^2.2.0"
-    is-path-inside "^3.0.1"
-    p-map "^3.0.0"
-    rimraf "^3.0.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
     slash "^3.0.0"
 
 delayed-stream@~1.0.0:
@@ -6450,7 +6450,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.5:
+fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
@@ -7192,18 +7192,16 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^10.0.1:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
-  integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
+globby@^11.0.1:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
   dependencies:
-    "@types/glob" "^7.1.1"
     array-union "^2.1.0"
     dir-glob "^3.0.1"
-    fast-glob "^3.0.3"
-    glob "^7.1.3"
-    ignore "^5.1.1"
-    merge2 "^1.2.3"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
     slash "^3.0.0"
 
 globby@^11.0.2:
@@ -7251,7 +7249,7 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -7740,7 +7738,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
+ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -8187,10 +8185,10 @@ is-path-cwd@^2.2.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
-is-path-inside@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
-  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -13947,13 +13945,13 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.9.0.tgz#002089d74582960099b0ee836f89f043cdf6d0bc"
-  integrity sha512-5IMVgMCUUlgWVFrB7Wf1qTvv5L3oDDlSsAgvJ02+/sV2uh4JzO9YPm3493RTaMuHTc+feRCuYyEIloXsEQY0Pg==
+uswds@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.10.0.tgz#c7ecb779c82302fa189b36ca3eefe59dfde7f782"
+  integrity sha512-A6HjL42ryf9pdfbm6JrGxZywKzCZraHO4v3Ve21uFDqoA3ijoNjiSYME+3SG86CIgC6zRasrbQVuI3bvd3Xv2w==
   dependencies:
     classlist-polyfill "^1.0.3"
-    del "^5.1.0"
+    del "^6.0.0"
     domready "^1.0.8"
     elem-dataset "^2.0.0"
     lodash.debounce "^4.0.7"


### PR DESCRIPTION
# Summary
Fixes the form control URLs in our storybook docs (e.g. DatePicker: Source: https://designsystem.digital.gov/components/form-controls/#DatePicker) to point to the structure USWDS is currently using.

## Related Issues or PRs
Closes [#1072 ](https://github.com/trussworks/react-uswds/issues/1072)


## How To Test
`yarn storybook`  
DatePicker > Docs > Click on Source link (https://designsystem.digital.gov/components/date-picker)
urls changed: address, footer, footernav, logo, social links, character count, checkbox, combobox, date input, datepicker, date range picker, dropdown, file input, radio buttons, range input, text input, text area, validation
