### PR TITLE
feat: Implement Identifier subcomponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^16.x || ^17.x",
     "react-dom": "^16.x || ^17.x",
-    "uswds": "2.10.0"
+    "uswds": "2.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -126,7 +126,7 @@
     "ts-jest": "^26.1.2",
     "typescript": "^3.8.0",
     "url-loader": "^4.0.0",
-    "uswds": "2.10.0",
+    "uswds": "2.9.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^16.x || ^17.x",
     "react-dom": "^16.x || ^17.x",
-    "uswds": "2.9.0"
+    "uswds": "2.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -126,7 +126,7 @@
     "ts-jest": "^26.1.2",
     "typescript": "^3.8.0",
     "url-loader": "^4.0.0",
-    "uswds": "2.9.0",
+    "uswds": "2.10.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^4.0.0"
   },

--- a/src/components/Identifier/Identifier/Identifier.stories.tsx
+++ b/src/components/Identifier/Identifier/Identifier.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { Identifier } from './Identifier'
 import { IdentifierMasthead } from '../IdentifierMasthead/IdentifierMasthead'
+import { IdentifierIdentity } from '../IdentifierIdentity/IdentifierIdentity'
 import { IdentifierLinks } from '../IdentifierLinks/IdentifierLinks'
 import { IdentifierGov } from '../IdentifierGov/IdentifierGov'
 import { IdentifierLinkItem } from '../IdentifierLinkItem/IdentifierLinkItem'
@@ -94,16 +95,11 @@ const testLinksSpanish = [
 
 const testIdentifierGovContent = [
   <>
-    <div
-      data-testid="identifierGov-description"
-      className="usa-identifier__usagov-description">
+    <div className="usa-identifier__usagov-description">
       Looking for U.S. government information and services?
     </div>
     &nbsp;
-    <a
-      data-testid="identifierGov-link"
-      href="https://www.usa.gov/"
-      className="usa-link">
+    <a href="https://www.usa.gov/" className="usa-link">
       Visit USA.gov
     </a>
   </>,
@@ -111,16 +107,11 @@ const testIdentifierGovContent = [
 
 const testIdentifierGovContentSpanish = [
   <>
-    <div
-      data-testid="identifierGov-description"
-      className="usa-identifier__usagov-description">
+    <div className="usa-identifier__usagov-description">
       ¿Necesita información y servicios del Gobierno?
     </div>
     &nbsp;
-    <a
-      data-testid="identifierGov-link"
-      href="https://www.usa.gov/espanol/"
-      className="usa-link">
+    <a href="https://www.usa.gov/espanol/" className="usa-link">
       Visite USAGov en Español
     </a>
   </>,
@@ -132,16 +123,12 @@ export const identifierDefault = (): React.ReactElement => (
       <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
       </IdentifierLogos>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Agency description">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`An official website of the `}
           <a href="#">Test Agency Name</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
       {testLinks}
@@ -155,19 +142,15 @@ export const identifierDefault = (): React.ReactElement => (
 export const identifierSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Descripción de la agencia">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`Un sitio web oficial de `}
           <a href="#">Test Agency Name Spanish</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
       {testLinksSpanish}
@@ -181,22 +164,18 @@ export const identifierSpanish = (): React.ReactElement => (
 export const multipleParentsAndLogos = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Agency description">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`An official website of the `}
           <a href="#">Test Agency Name</a>
           {` and the `}
           <a href="#">Other Test Agency Name</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
       {testLinks}
@@ -210,22 +189,18 @@ export const multipleParentsAndLogos = (): React.ReactElement => (
 export const multipleParentsAndLogosSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Descripción de la agencia">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`Un sitio web oficial de `}
           <a href="#">Test Agency Name</a>
           {` y `}
           <a href="#">Other Test Agency Name</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks>{testLinksSpanish}</IdentifierLinks>
     <IdentifierGov aria-label="Información y servicios del Gobierno de EE. UU.">
@@ -237,16 +212,12 @@ export const multipleParentsAndLogosSpanish = (): React.ReactElement => (
 export const moreThanTwoParentsAndLogos = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Agency description">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`An official website of the `}
           <a href="#">Test Agency Name</a>
@@ -255,7 +226,7 @@ export const moreThanTwoParentsAndLogos = (): React.ReactElement => (
           {`, and the `}
           <a href="#">Third Test Agency Name</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
       {testLinks}
@@ -269,16 +240,12 @@ export const moreThanTwoParentsAndLogos = (): React.ReactElement => (
 export const noLogosEnglish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Agency description">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`An official website of the `}
           <a href="#">Test Agency Name</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
       {testLinks}
@@ -292,16 +259,12 @@ export const noLogosEnglish = (): React.ReactElement => (
 export const noLogosSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Descripción de la agencia">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`Un sitio web oficial de `}
           <a href="#">Test Agency Name Spanish</a>
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
       {testLinksSpanish}
@@ -315,20 +278,16 @@ export const noLogosSpanish = (): React.ReactElement => (
 export const taxDisclaimerEnglish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Agency description">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`An official website of the `}
           <a href="#">Test Agency Name</a>
           {`. Produced and published at taxpayer expense.`}
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
       {testLinks}
@@ -342,20 +301,16 @@ export const taxDisclaimerEnglish = (): React.ReactElement => (
 export const taxDisclaimerSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Descripción de la agencia">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`Un sitio web oficial de `}
           <a href="#">Test Agency Name Spanish</a>
           {`. Producido y publicado con dinero de los contribuyentes de impuestos.`}
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
       {testLinksSpanish}
@@ -369,15 +324,11 @@ export const taxDisclaimerSpanish = (): React.ReactElement => (
 export const taxDisclaimerAndMultipleParentsAndLogos = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-      </div>
-      <div
-        data-testid="identifierMasthead-agency-description"
-        className="usa-identifier__identity"
-        aria-label="Agency description">
-        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+      </IdentifierLogos>
+      <IdentifierIdentity domain="domain.edu.mil.gov">
         <p className="usa-identifier__identity-disclaimer">
           {`An official website of the `}
           <a href="#">Test Agency Name</a>
@@ -385,7 +336,7 @@ export const taxDisclaimerAndMultipleParentsAndLogos = (): React.ReactElement =>
           <a href="#">Other Test Agency Name</a>
           {`. Produced and published at taxpayer expense.`}
         </p>
-      </div>
+      </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
       {testLinks}

--- a/src/components/Identifier/Identifier/Identifier.stories.tsx
+++ b/src/components/Identifier/Identifier/Identifier.stories.tsx
@@ -8,6 +8,7 @@ import { IdentifierGov } from '../IdentifierGov/IdentifierGov'
 import { IdentifierLinkItem } from '../IdentifierLinkItem/IdentifierLinkItem'
 import { IdentifierLink } from '../IdentifierLink/IdentifierLink'
 import { IdentifierLogo } from '../IdentifierLogo/IdentifierLogo'
+import { IdentifierLogos } from '../IdentifierLogos/IdentifierLogos'
 
 import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
 
@@ -128,9 +129,9 @@ const testIdentifierGovContentSpanish = [
 export const identifierDefault = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__logos">
+      <IdentifierLogos>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-      </div>
+      </IdentifierLogos>
       <div
         data-testid="identifierMasthead-agency-description"
         className="usa-identifier__identity"

--- a/src/components/Identifier/Identifier/Identifier.stories.tsx
+++ b/src/components/Identifier/Identifier/Identifier.stories.tsx
@@ -11,6 +11,8 @@ import { IdentifierLink } from '../IdentifierLink/IdentifierLink'
 import { IdentifierLogo } from '../IdentifierLogo/IdentifierLogo'
 import { IdentifierLogos } from '../IdentifierLogos/IdentifierLogos'
 
+import { Link } from '../../Link/Link'
+
 import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
 
 export default {
@@ -99,9 +101,9 @@ const testIdentifierGovContent = [
       Looking for U.S. government information and services?
     </div>
     &nbsp;
-    <a href="https://www.usa.gov/" className="usa-link">
+    <Link href="https://www.usa.gov/" className="usa-link">
       Visit USA.gov
-    </a>
+    </Link>
   </>,
 ]
 
@@ -111,9 +113,9 @@ const testIdentifierGovContentSpanish = [
       ¿Necesita información y servicios del Gobierno?
     </div>
     &nbsp;
-    <a href="https://www.usa.gov/espanol/" className="usa-link">
+    <Link href="https://www.usa.gov/espanol/" className="usa-link">
       Visite USAGov en Español
-    </a>
+    </Link>
   </>,
 ]
 
@@ -124,10 +126,8 @@ export const identifierDefault = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`An official website of the `}
-          <a href="#">Test Agency Name</a>
-        </p>
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -146,10 +146,8 @@ export const identifierSpanish = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`Un sitio web oficial de `}
-          <a href="#">Test Agency Name Spanish</a>
-        </p>
+        {`Un sitio web oficial de `}
+        <Link href="#">Test Agency Name Spanish</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
@@ -169,12 +167,10 @@ export const multipleParentsAndLogos = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`An official website of the `}
-          <a href="#">Test Agency Name</a>
-          {` and the `}
-          <a href="#">Other Test Agency Name</a>
-        </p>
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
+        {` and the `}
+        <Link href="#">Other Test Agency Name</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -194,12 +190,10 @@ export const multipleParentsAndLogosSpanish = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`Un sitio web oficial de `}
-          <a href="#">Test Agency Name</a>
-          {` y `}
-          <a href="#">Other Test Agency Name</a>
-        </p>
+        {`Un sitio web oficial de `}
+        <Link href="#">Test Agency Name</Link>
+        {` y `}
+        <Link href="#">Other Test Agency Name</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks>{testLinksSpanish}</IdentifierLinks>
@@ -218,14 +212,12 @@ export const moreThanTwoParentsAndLogos = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`An official website of the `}
-          <a href="#">Test Agency Name</a>
-          {`, `}
-          <a href="#">Second Test Agency Name</a>
-          {`, and the `}
-          <a href="#">Third Test Agency Name</a>
-        </p>
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
+        {`, `}
+        <Link href="#">Second Test Agency Name</Link>
+        {`, and the `}
+        <Link href="#">Third Test Agency Name</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -241,10 +233,8 @@ export const noLogosEnglish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`An official website of the `}
-          <a href="#">Test Agency Name</a>
-        </p>
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -260,10 +250,8 @@ export const noLogosSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`Un sitio web oficial de `}
-          <a href="#">Test Agency Name Spanish</a>
-        </p>
+        {`Un sitio web oficial de `}
+        <Link href="#">Test Agency Name Spanish</Link>
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
@@ -282,11 +270,9 @@ export const taxDisclaimerEnglish = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`An official website of the `}
-          <a href="#">Test Agency Name</a>
-          {`. Produced and published at taxpayer expense.`}
-        </p>
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
+        {`. Produced and published at taxpayer expense.`}
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -305,11 +291,9 @@ export const taxDisclaimerSpanish = (): React.ReactElement => (
         <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`Un sitio web oficial de `}
-          <a href="#">Test Agency Name Spanish</a>
-          {`. Producido y publicado con dinero de los contribuyentes de impuestos.`}
-        </p>
+        {`Un sitio web oficial de `}
+        <Link href="#">Test Agency Name Spanish</Link>
+        {`. Producido y publicado con dinero de los contribuyentes de impuestos.`}
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
@@ -329,13 +313,11 @@ export const taxDisclaimerAndMultipleParentsAndLogos = (): React.ReactElement =>
         <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
       </IdentifierLogos>
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        <p className="usa-identifier__identity-disclaimer">
-          {`An official website of the `}
-          <a href="#">Test Agency Name</a>
-          {` and the `}
-          <a href="#">Other Test Agency Name</a>
-          {`. Produced and published at taxpayer expense.`}
-        </p>
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
+        {` and the `}
+        <Link href="#">Other Test Agency Name</Link>
+        {`. Produced and published at taxpayer expense.`}
       </IdentifierIdentity>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>

--- a/src/components/Identifier/Identifier/Identifier.stories.tsx
+++ b/src/components/Identifier/Identifier/Identifier.stories.tsx
@@ -92,7 +92,7 @@ const testLinksSpanish = [
 ]
 
 const testIdentifierGovContent = [
-  <div className="usa-identifier__container" key="one">
+  <>
     <div
       data-testid="identifierGov-description"
       className="usa-identifier__usagov-description">
@@ -105,11 +105,11 @@ const testIdentifierGovContent = [
       className="usa-link">
       Visit USA.gov
     </a>
-  </div>,
+  </>,
 ]
 
 const testIdentifierGovContentSpanish = [
-  <div className="usa-identifier__container" key="two">
+  <>
     <div
       data-testid="identifierGov-description"
       className="usa-identifier__usagov-description">
@@ -122,26 +122,24 @@ const testIdentifierGovContentSpanish = [
       className="usa-link">
       Visite USAGov en Español
     </a>
-  </div>,
+  </>,
 ]
 
 export const identifierDefault = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="#">Test Agency Name</a>
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Agency description">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`An official website of the `}
+          <a href="#">Test Agency Name</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -156,20 +154,18 @@ export const identifierDefault = (): React.ReactElement => (
 export const identifierSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Descripción de la agencia">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`Un sitio web oficial de `}
-            <a href="#">Test Agency Name Spanish</a>
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Descripción de la agencia">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`Un sitio web oficial de `}
+          <a href="#">Test Agency Name Spanish</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
@@ -184,23 +180,21 @@ export const identifierSpanish = (): React.ReactElement => (
 export const multipleParentsAndLogos = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="#">Test Agency Name</a>
-            {` and the `}
-            <a href="#">Other Test Agency Name</a>
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Agency description">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`An official website of the `}
+          <a href="#">Test Agency Name</a>
+          {` and the `}
+          <a href="#">Other Test Agency Name</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -215,23 +209,21 @@ export const multipleParentsAndLogos = (): React.ReactElement => (
 export const multipleParentsAndLogosSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-          <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Descripción de la agencia">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`Un sitio web oficial de `}
-            <a href="#">Test Agency Name</a>
-            {` y `}
-            <a href="#">Other Test Agency Name</a>
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
+        <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Descripción de la agencia">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`Un sitio web oficial de `}
+          <a href="#">Test Agency Name</a>
+          {` y `}
+          <a href="#">Other Test Agency Name</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks>{testLinksSpanish}</IdentifierLinks>
@@ -244,26 +236,24 @@ export const multipleParentsAndLogosSpanish = (): React.ReactElement => (
 export const moreThanTwoParentsAndLogos = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="#">Test Agency Name</a>
-            {`, `}
-            <a href="#">Second Test Agency Name</a>
-            {`, and the `}
-            <a href="#">Third Test Agency Name</a>
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Agency description">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`An official website of the `}
+          <a href="#">Test Agency Name</a>
+          {`, `}
+          <a href="#">Second Test Agency Name</a>
+          {`, and the `}
+          <a href="#">Third Test Agency Name</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -278,17 +268,15 @@ export const moreThanTwoParentsAndLogos = (): React.ReactElement => (
 export const noLogosEnglish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__container">
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="#">Test Agency Name</a>
-          </p>
-        </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Agency description">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`An official website of the `}
+          <a href="#">Test Agency Name</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -303,17 +291,15 @@ export const noLogosEnglish = (): React.ReactElement => (
 export const noLogosSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__container">
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Descripción de la agencia">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`Un sitio web oficial de `}
-            <a href="#">Test Agency Name Spanish</a>
-          </p>
-        </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Descripción de la agencia">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`Un sitio web oficial de `}
+          <a href="#">Test Agency Name Spanish</a>
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
@@ -328,21 +314,19 @@ export const noLogosSpanish = (): React.ReactElement => (
 export const taxDisclaimerEnglish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="#">Test Agency Name</a>
-            {`. Produced and published at taxpayer expense.`}
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Agency description">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`An official website of the `}
+          <a href="#">Test Agency Name</a>
+          {`. Produced and published at taxpayer expense.`}
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -357,21 +341,19 @@ export const taxDisclaimerEnglish = (): React.ReactElement => (
 export const taxDisclaimerSpanish = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Identificador de la agencia">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Descripción de la agencia">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`Un sitio web oficial de `}
-            <a href="#">Test Agency Name Spanish</a>
-            {`. Producido y publicado con dinero de los contribuyentes de impuestos.`}
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogoSpanish}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Descripción de la agencia">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`Un sitio web oficial de `}
+          <a href="#">Test Agency Name Spanish</a>
+          {`. Producido y publicado con dinero de los contribuyentes de impuestos.`}
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
@@ -386,24 +368,22 @@ export const taxDisclaimerSpanish = (): React.ReactElement => (
 export const taxDisclaimerAndMultipleParentsAndLogos = (): React.ReactElement => (
   <Identifier>
     <IdentifierMasthead aria-label="Agency identifier">
-      <div className="usa-identifier__container">
-        <div className="usa-identifier__logos">
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        </div>
-        <div
-          data-testid="identifierMasthead-agency-description"
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="#">Test Agency Name</a>
-            {` and the `}
-            <a href="#">Other Test Agency Name</a>
-            {`. Produced and published at taxpayer expense.`}
-          </p>
-        </div>
+      <div className="usa-identifier__logos">
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+      </div>
+      <div
+        data-testid="identifierMasthead-agency-description"
+        className="usa-identifier__identity"
+        aria-label="Agency description">
+        <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+        <p className="usa-identifier__identity-disclaimer">
+          {`An official website of the `}
+          <a href="#">Test Agency Name</a>
+          {` and the `}
+          <a href="#">Other Test Agency Name</a>
+          {`. Produced and published at taxpayer expense.`}
+        </p>
       </div>
     </IdentifierMasthead>
     <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>

--- a/src/components/Identifier/Identifier/Identifier.test.tsx
+++ b/src/components/Identifier/Identifier/Identifier.test.tsx
@@ -76,7 +76,7 @@ const testLinksSpanish = [
 ]
 
 const testIdentifierGovContent = [
-  <div className="usa-identifier__container" key="one">
+  <>
     <div
       data-testid="identifierGov-description"
       className="usa-identifier__usagov-description">
@@ -89,11 +89,11 @@ const testIdentifierGovContent = [
       className="usa-link">
       Visit USA.gov
     </a>
-  </div>,
+  </>,
 ]
 
 const testIdentifierGovContentSpanish = [
-  <div className="usa-identifier__container" key="two">
+  <>
     <div
       data-testid="identifierGov-description"
       className="usa-identifier__usagov-description">
@@ -106,7 +106,7 @@ const testIdentifierGovContentSpanish = [
       className="usa-link">
       Visite USAGov en Español
     </a>
-  </div>,
+  </>,
 ]
 
 describe('Identifier component', () => {

--- a/src/components/Identifier/Identifier/Identifier.test.tsx
+++ b/src/components/Identifier/Identifier/Identifier.test.tsx
@@ -77,16 +77,11 @@ const testLinksSpanish = [
 
 const testIdentifierGovContent = [
   <>
-    <div
-      data-testid="identifierGov-description"
-      className="usa-identifier__usagov-description">
+    <div className="usa-identifier__usagov-description">
       Looking for U.S. government information and services?
     </div>
     &nbsp;
-    <a
-      data-testid="identifierGov-link"
-      href="https://www.usa.gov/"
-      className="usa-link">
+    <a href="https://www.usa.gov/" className="usa-link">
       Visit USA.gov
     </a>
   </>,
@@ -94,16 +89,11 @@ const testIdentifierGovContent = [
 
 const testIdentifierGovContentSpanish = [
   <>
-    <div
-      data-testid="identifierGov-description"
-      className="usa-identifier__usagov-description">
+    <div className="usa-identifier__usagov-description">
       ¿Necesita información y servicios del Gobierno?
     </div>
     &nbsp;
-    <a
-      data-testid="identifierGov-link"
-      href="https://www.usa.gov/espanol/"
-      className="usa-link">
+    <a href="https://www.usa.gov/espanol/" className="usa-link">
       Visite USAGov en Español
     </a>
   </>,
@@ -157,7 +147,6 @@ describe('Identifier component', () => {
             </IdentifierLogo>
 
             <div
-              data-testid="identifierMasthead-agency-description"
               className="usa-identifier__identity"
               aria-label="Descripción de la agencia">
               <p className="usa-identifier__identity-domain">
@@ -227,7 +216,6 @@ describe('Identifier component', () => {
             <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
           </div>
           <div
-            data-testid="identifierMasthead-agency-description"
             className="usa-identifier__identity"
             aria-label="Agency description">
             <p className="usa-identifier__identity-domain">

--- a/src/components/Identifier/Identifier/Identifier.test.tsx
+++ b/src/components/Identifier/Identifier/Identifier.test.tsx
@@ -118,9 +118,7 @@ describe('Identifier component', () => {
             <IdentifierLogo href="#" className="custom-class-name">
               {testIdentifierLogo}
             </IdentifierLogo>
-
             <div
-              data-testid="identifierMasthead-agency-description"
               className="usa-identifier__identity"
               aria-label="Agency description">
               <p className="usa-identifier__identity-domain">

--- a/src/components/Identifier/Identifier/Identifier.test.tsx
+++ b/src/components/Identifier/Identifier/Identifier.test.tsx
@@ -3,11 +3,14 @@ import { render } from '@testing-library/react'
 
 import { Identifier } from './Identifier'
 import { IdentifierMasthead } from '../IdentifierMasthead/IdentifierMasthead'
+import { IdentifierLogos } from '../IdentifierLogos/IdentifierLogos'
 import { IdentifierLogo } from '../IdentifierLogo/IdentifierLogo'
+import { IdentifierIdentity } from '../IdentifierIdentity/IdentifierIdentity'
 import { IdentifierLinks } from '../IdentifierLinks/IdentifierLinks'
 import { IdentifierLink } from '../IdentifierLink/IdentifierLink'
 import { IdentifierLinkItem } from '../IdentifierLinkItem/IdentifierLinkItem'
 import { IdentifierGov } from '../IdentifierGov/IdentifierGov'
+import { Link } from '../../Link/Link'
 
 import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
 
@@ -81,9 +84,9 @@ const testIdentifierGovContent = [
       Looking for U.S. government information and services?
     </div>
     &nbsp;
-    <a href="https://www.usa.gov/" className="usa-link">
+    <Link href="https://www.usa.gov/" className="usa-link">
       Visit USA.gov
-    </a>
+    </Link>
   </>,
 ]
 
@@ -93,9 +96,9 @@ const testIdentifierGovContentSpanish = [
       ¿Necesita información y servicios del Gobierno?
     </div>
     &nbsp;
-    <a href="https://www.usa.gov/espanol/" className="usa-link">
+    <Link href="https://www.usa.gov/espanol/" className="usa-link">
       Visite USAGov en Español
-    </a>
+    </Link>
   </>,
 ]
 
@@ -104,22 +107,15 @@ describe('Identifier component', () => {
     const { getByRole, getAllByRole, queryByTestId } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__logos">
+          <IdentifierLogos>
             <IdentifierLogo href="#" className="custom-class-name">
               {testIdentifierLogo}
             </IdentifierLogo>
-            <div
-              className="usa-identifier__identity"
-              aria-label="Agency description">
-              <p className="usa-identifier__identity-domain">
-                domain.edu.mil.gov
-              </p>
-              <p className="usa-identifier__identity-disclaimer">
-                {`An official website of the `}
-                <a href="testlink">Test Agency Name</a>
-              </p>
-            </div>
-          </div>
+          </IdentifierLogos>
+          <IdentifierIdentity domain="domain.edu.mil.gov">
+            {`An official website of the `}
+            <Link href="testlink">Test Agency Name</Link>
+          </IdentifierIdentity>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
           {testLinks}
@@ -141,23 +137,15 @@ describe('Identifier component', () => {
     const { getAllByRole, queryByText } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Identificador de la agencia">
-          <div className="usa-identifier__logos">
+          <IdentifierLogos>
             <IdentifierLogo href="#">
               {testIdentifierLogoSpanish}
             </IdentifierLogo>
-
-            <div
-              className="usa-identifier__identity"
-              aria-label="Descripción de la agencia">
-              <p className="usa-identifier__identity-domain">
-                domain.edu.mil.gov
-              </p>
-              <p className="usa-identifier__identity-disclaimer">
-                {`Un sitio web oficial de `}
-                <a href="testlink">Test Agency Name Spanish</a>
-              </p>
-            </div>
-          </div>
+          </IdentifierLogos>
+          <IdentifierIdentity domain="domain.edu.mil.gov">
+            {`Un sitio web oficial de `}
+            <Link href="testlink">Test Agency Name Spanish</Link>
+          </IdentifierIdentity>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Enlaces importantes' }}>
           {testLinksSpanish}
@@ -177,18 +165,13 @@ describe('Identifier component', () => {
     const { getAllByRole, getByTestId, queryByText } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div
+          <IdentifierIdentity
             data-testid="identifierMasthead-agency-description"
-            className="usa-identifier__identity"
+            domain="domain.edu.mil.gov"
             aria-label="Agency description">
-            <p className="usa-identifier__identity-domain">
-              domain.edu.mil.gov
-            </p>
-            <p className="usa-identifier__identity-disclaimer">
-              {`An official website of the `}
-              <a href="testlink">Test Agency Name</a>
-            </p>
-          </div>
+            {`An official website of the `}
+            <Link href="testlink">Test Agency Name</Link>
+          </IdentifierIdentity>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
           {testLinks}
@@ -210,26 +193,19 @@ describe('Identifier component', () => {
     const { getAllByRole, queryByText } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__logos">
+          <IdentifierLogos>
             <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
             <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
             <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          </div>
-          <div
-            className="usa-identifier__identity"
-            aria-label="Agency description">
-            <p className="usa-identifier__identity-domain">
-              domain.edu.mil.gov
-            </p>
-            <p className="usa-identifier__identity-disclaimer">
-              {`An official website of the `}
-              <a href="testlink">Test Agency Name</a>
-              {`, `}
-              <a href="secondTestLink">Second Test Agency Name</a>
-              {`, and the `}
-              <a href="ThirdTestLink">Third Test Agency Name</a>
-            </p>
-          </div>
+          </IdentifierLogos>
+          <IdentifierIdentity domain="domain.edu.mil.gov">
+            {`An official website of the `}
+            <Link href="#">Test Agency Name</Link>
+            {`, `}
+            <Link href="#">Second Test Agency Name</Link>
+            {`, and the `}
+            <Link href="#">Third Test Agency Name</Link>
+          </IdentifierIdentity>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
           {testLinks}
@@ -249,22 +225,16 @@ describe('Identifier component', () => {
     const { getByTestId } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__logos">
+          <IdentifierLogos>
             <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          </div>
-          <div
+          </IdentifierLogos>
+          <IdentifierIdentity
             data-testid="identifierMasthead-agency-description"
-            className="usa-identifier__identity"
-            aria-label="Agency description">
-            <p className="usa-identifier__identity-domain">
-              domain.edu.mil.gov
-            </p>
-            <p className="usa-identifier__identity-disclaimer">
-              {`An official website of the `}
-              <a href="testlink">Test Agency Name</a>
-              {`. Produced and published at taxpayer expense.`}
-            </p>
-          </div>
+            domain="domain.edu.mil.gov">
+            {`An official website of the `}
+            <Link href="#">Test Agency Name</Link>
+            {`. Produced and published at taxpayer expense.`}
+          </IdentifierIdentity>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
           {testLinks}

--- a/src/components/Identifier/Identifier/Identifier.test.tsx
+++ b/src/components/Identifier/Identifier/Identifier.test.tsx
@@ -114,12 +114,11 @@ describe('Identifier component', () => {
     const { getByRole, getAllByRole, queryByTestId } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__container">
-            <div className="usa-identifier__logos">
-              <IdentifierLogo href="#" className="custom-class-name">
-                {testIdentifierLogo}
-              </IdentifierLogo>
-            </div>
+          <div className="usa-identifier__logos">
+            <IdentifierLogo href="#" className="custom-class-name">
+              {testIdentifierLogo}
+            </IdentifierLogo>
+
             <div
               data-testid="identifierMasthead-agency-description"
               className="usa-identifier__identity"
@@ -154,12 +153,11 @@ describe('Identifier component', () => {
     const { getAllByRole, queryByText } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Identificador de la agencia">
-          <div className="usa-identifier__container">
-            <div className="usa-identifier__logos">
-              <IdentifierLogo href="#">
-                {testIdentifierLogoSpanish}
-              </IdentifierLogo>
-            </div>
+          <div className="usa-identifier__logos">
+            <IdentifierLogo href="#">
+              {testIdentifierLogoSpanish}
+            </IdentifierLogo>
+
             <div
               data-testid="identifierMasthead-agency-description"
               className="usa-identifier__identity"
@@ -192,19 +190,17 @@ describe('Identifier component', () => {
     const { getAllByRole, getByTestId, queryByText } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__container">
-            <div
-              data-testid="identifierMasthead-agency-description"
-              className="usa-identifier__identity"
-              aria-label="Agency description">
-              <p className="usa-identifier__identity-domain">
-                domain.edu.mil.gov
-              </p>
-              <p className="usa-identifier__identity-disclaimer">
-                {`An official website of the `}
-                <a href="testlink">Test Agency Name</a>
-              </p>
-            </div>
+          <div
+            data-testid="identifierMasthead-agency-description"
+            className="usa-identifier__identity"
+            aria-label="Agency description">
+            <p className="usa-identifier__identity-domain">
+              domain.edu.mil.gov
+            </p>
+            <p className="usa-identifier__identity-disclaimer">
+              {`An official website of the `}
+              <a href="testlink">Test Agency Name</a>
+            </p>
           </div>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -227,28 +223,26 @@ describe('Identifier component', () => {
     const { getAllByRole, queryByText } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__container">
-            <div className="usa-identifier__logos">
-              <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-              <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-              <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-            </div>
-            <div
-              data-testid="identifierMasthead-agency-description"
-              className="usa-identifier__identity"
-              aria-label="Agency description">
-              <p className="usa-identifier__identity-domain">
-                domain.edu.mil.gov
-              </p>
-              <p className="usa-identifier__identity-disclaimer">
-                {`An official website of the `}
-                <a href="testlink">Test Agency Name</a>
-                {`, `}
-                <a href="secondTestLink">Second Test Agency Name</a>
-                {`, and the `}
-                <a href="ThirdTestLink">Third Test Agency Name</a>
-              </p>
-            </div>
+          <div className="usa-identifier__logos">
+            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+          </div>
+          <div
+            data-testid="identifierMasthead-agency-description"
+            className="usa-identifier__identity"
+            aria-label="Agency description">
+            <p className="usa-identifier__identity-domain">
+              domain.edu.mil.gov
+            </p>
+            <p className="usa-identifier__identity-disclaimer">
+              {`An official website of the `}
+              <a href="testlink">Test Agency Name</a>
+              {`, `}
+              <a href="secondTestLink">Second Test Agency Name</a>
+              {`, and the `}
+              <a href="ThirdTestLink">Third Test Agency Name</a>
+            </p>
           </div>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
@@ -269,23 +263,21 @@ describe('Identifier component', () => {
     const { getByTestId } = render(
       <Identifier>
         <IdentifierMasthead aria-label="Agency identifier">
-          <div className="usa-identifier__container">
-            <div className="usa-identifier__logos">
-              <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-            </div>
-            <div
-              data-testid="identifierMasthead-agency-description"
-              className="usa-identifier__identity"
-              aria-label="Agency description">
-              <p className="usa-identifier__identity-domain">
-                domain.edu.mil.gov
-              </p>
-              <p className="usa-identifier__identity-disclaimer">
-                {`An official website of the `}
-                <a href="testlink">Test Agency Name</a>
-                {`. Produced and published at taxpayer expense.`}
-              </p>
-            </div>
+          <div className="usa-identifier__logos">
+            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+          </div>
+          <div
+            data-testid="identifierMasthead-agency-description"
+            className="usa-identifier__identity"
+            aria-label="Agency description">
+            <p className="usa-identifier__identity-domain">
+              domain.edu.mil.gov
+            </p>
+            <p className="usa-identifier__identity-disclaimer">
+              {`An official website of the `}
+              <a href="testlink">Test Agency Name</a>
+              {`. Produced and published at taxpayer expense.`}
+            </p>
           </div>
         </IdentifierMasthead>
         <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>

--- a/src/components/Identifier/IdentifierGov/IdentifierGov.test.tsx
+++ b/src/components/Identifier/IdentifierGov/IdentifierGov.test.tsx
@@ -25,20 +25,18 @@ describe('IdentifierGov component', () => {
     const tree = renderer
       .create(
         <IdentifierGov>
-          <div className="usa-identifier__container">
-            <div
-              data-testid="identifierGov-description"
-              className="usa-identifier__usagov-description">
-              ¿Necesita información y servicios del Gobierno?
-            </div>
-            &nbsp;
-            <a
-              data-testid="identifierGov-link"
-              href="https://www.usa.gov/espanol/"
-              className="usa-link">
-              Visite USAGov en Español
-            </a>
+          <div
+            data-testid="identifierGov-description"
+            className="usa-identifier__usagov-description">
+            ¿Necesita información y servicios del Gobierno?
           </div>
+          &nbsp;
+          <a
+            data-testid="identifierGov-link"
+            href="https://www.usa.gov/espanol/"
+            className="usa-link">
+            Visite USAGov en Español
+          </a>
         </IdentifierGov>
       )
       .toJSON()

--- a/src/components/Identifier/IdentifierGov/IdentifierGov.test.tsx
+++ b/src/components/Identifier/IdentifierGov/IdentifierGov.test.tsx
@@ -25,16 +25,11 @@ describe('IdentifierGov component', () => {
     const tree = renderer
       .create(
         <IdentifierGov>
-          <div
-            data-testid="identifierGov-description"
-            className="usa-identifier__usagov-description">
+          <div className="usa-identifier__usagov-description">
             ¿Necesita información y servicios del Gobierno?
           </div>
           &nbsp;
-          <a
-            data-testid="identifierGov-link"
-            href="https://www.usa.gov/espanol/"
-            className="usa-link">
+          <a href="https://www.usa.gov/espanol/" className="usa-link">
             Visite USAGov en Español
           </a>
         </IdentifierGov>

--- a/src/components/Identifier/IdentifierGov/IdentifierGov.tsx
+++ b/src/components/Identifier/IdentifierGov/IdentifierGov.tsx
@@ -19,7 +19,7 @@ export const IdentifierGov = ({
 
   return (
     <section data-testid="identifierGov" className={classes} {...sectionProps}>
-      {children}
+      <div className="usa-identifier__container">{children}</div>
     </section>
   )
 }

--- a/src/components/Identifier/IdentifierGov/__snapshots__/IdentifierGov.test.tsx.snap
+++ b/src/components/Identifier/IdentifierGov/__snapshots__/IdentifierGov.test.tsx.snap
@@ -10,14 +10,12 @@ exports[`IdentifierGov component renders consistently in Spanish 1`] = `
   >
     <div
       className="usa-identifier__usagov-description"
-      data-testid="identifierGov-description"
     >
       ¿Necesita información y servicios del Gobierno?
     </div>
      
     <a
       className="usa-link"
-      data-testid="identifierGov-link"
       href="https://www.usa.gov/espanol/"
     >
       Visite USAGov en Español

--- a/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.test.tsx
+++ b/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { queryByTestId, render } from '@testing-library/react'
+
+import { IdentifierIdentity } from './IdentifierIdentity'
+
+const testData = [
+  <p className="usa-identifier__identity-disclaimer" key="one">
+    {`An official website of the `}
+    <a href="#slsf">Test Agency Name</a>
+  </p>,
+]
+describe('IdentifierIdentity component', () => {
+  it('renders without errors', () => {
+    const { queryByText } = render(
+      <IdentifierIdentity domain="domain.edu.mil.gov">
+        {testData}
+      </IdentifierIdentity>
+    )
+
+    expect(queryByText('Test Agency Name')).toBeInTheDocument()
+  })
+
+  it('can apply attributes passed in as props', () => {
+    const { queryByTestId } = render(
+      <IdentifierIdentity
+        className="custom-class"
+        aria-label="Test aria label"
+        domain="a.domain">
+        {testData}
+      </IdentifierIdentity>
+    )
+    const testIdQuery = queryByTestId('identifierIdentity')
+    expect(testIdQuery).toHaveClass('usa-identifier__identity custom-class')
+    expect(testIdQuery).toHaveAttribute('aria-label', 'Test aria label')
+  })
+})

--- a/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.test.tsx
+++ b/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.test.tsx
@@ -1,12 +1,13 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react'
-import { queryByTestId, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import { IdentifierIdentity } from './IdentifierIdentity'
 
 const testData = [
   <p className="usa-identifier__identity-disclaimer" key="one">
     {`An official website of the `}
-    <a href="#slsf">Test Agency Name</a>
+    <a href="#">Test Agency Name</a>
   </p>,
 ]
 describe('IdentifierIdentity component', () => {

--- a/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.test.tsx
+++ b/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.test.tsx
@@ -3,22 +3,20 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import { IdentifierIdentity } from './IdentifierIdentity'
+import { Link } from '../../Link/Link'
 
-const testData = [
-  <p className="usa-identifier__identity-disclaimer" key="one">
-    {`An official website of the `}
-    <a href="#">Test Agency Name</a>
-  </p>,
-]
 describe('IdentifierIdentity component', () => {
   it('renders without errors', () => {
-    const { queryByText } = render(
+    const { queryByTestId } = render(
       <IdentifierIdentity domain="domain.edu.mil.gov">
-        {testData}
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
       </IdentifierIdentity>
     )
 
-    expect(queryByText('Test Agency Name')).toBeInTheDocument()
+    const testIdQuery = queryByTestId('identifierIdentity')
+    expect(testIdQuery).toBeInTheDocument()
+    expect(testIdQuery).toHaveClass('usa-identifier__identity')
   })
 
   it('can apply attributes passed in as props', () => {
@@ -27,7 +25,8 @@ describe('IdentifierIdentity component', () => {
         className="custom-class"
         aria-label="Test aria label"
         domain="a.domain">
-        {testData}
+        {`An official website of the `}
+        <Link href="#">Test Agency Name</Link>
       </IdentifierIdentity>
     )
     const testIdQuery = queryByTestId('identifierIdentity')

--- a/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.tsx
+++ b/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import classnames from 'classnames'
+
+interface IdentifierIdentityProps {
+  children: React.ReactNode
+  domain: string
+  className?: string
+}
+
+export const IdentifierIdentity = ({
+  children,
+  domain,
+  className,
+  ...divProps
+}: IdentifierIdentityProps &
+  JSX.IntrinsicElements['div']): React.ReactElement => {
+  const classes = classnames('usa-identifier__identity', className)
+  return (
+    <div data-testid="identifierIdentity" className={classes} {...divProps}>
+      <p className="usa-identifier__identity-domain">{domain}</p>
+      {children}
+    </div>
+  )
+}
+
+export default IdentifierIdentity

--- a/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.tsx
+++ b/src/components/Identifier/IdentifierIdentity/IdentifierIdentity.tsx
@@ -18,7 +18,7 @@ export const IdentifierIdentity = ({
   return (
     <div data-testid="identifierIdentity" className={classes} {...divProps}>
       <p className="usa-identifier__identity-domain">{domain}</p>
-      {children}
+      <p className="usa-identifier__identity-disclaimer">{children}</p>
     </div>
   )
 }

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
@@ -4,10 +4,30 @@ import { render } from '@testing-library/react'
 
 import { IdentifierLogos } from './IdentifierLogos'
 
+import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
+
+const testIdentifierLogo = (
+  <img
+    src={dotGovIcon}
+    className="usa-identifier__logo-img"
+    alt="Test Agency Name logo"
+  />
+)
+
+// const testIdentifierLogoSpanish = (
+//   <img
+//     src={dotGovIcon}
+//     className="usa-identifier__logo-img"
+//     alt="Logo de Test Agency Name"
+//   />
+// )
+
 describe('IdentifierLogos component', () => {
   it('renders without errors', () => {
-    const { queryByText } = render(<IdentifierLogos />)
+    const { getByRole } = render(
+      <IdentifierLogos>{testIdentifierLogo}</IdentifierLogos>
+    )
 
-    expect(queryByText('logos text')).toBeInTheDocument()
+    expect(getByRole('img')).toBeInTheDocument()
   })
 })

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-
 import { render } from '@testing-library/react'
-
 import { IdentifierLogos } from './IdentifierLogos'
 
 import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
@@ -14,14 +12,6 @@ const testIdentifierLogo = (
   />
 )
 
-// const testIdentifierLogoSpanish = (
-//   <img
-//     src={dotGovIcon}
-//     className="usa-identifier__logo-img"
-//     alt="Logo de Test Agency Name"
-//   />
-// )
-
 describe('IdentifierLogos component', () => {
   it('renders without errors', () => {
     const { getByRole } = render(
@@ -31,15 +21,15 @@ describe('IdentifierLogos component', () => {
     expect(getByRole('img')).toBeInTheDocument()
   })
 
-  it('accepts a custom class name', () => {
+  it('can apply attributes passed in as props', () => {
     const { queryByTestId } = render(
-      <IdentifierLogos className="custom-class">
+      <IdentifierLogos aria-label="Test aria label" className="custom-class">
         {testIdentifierLogo}
       </IdentifierLogos>
     )
 
-    expect(queryByTestId('identifierLogos')).toHaveClass(
-      'usa-identifier__logos custom-class'
-    )
+    const testIdQuery = queryByTestId('identifierLogos')
+    expect(testIdQuery).toHaveClass('usa-identifier__logos custom-class')
+    expect(testIdQuery).toHaveAttribute('aria-label', 'Test aria label')
   })
 })

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { render } from '@testing-library/react'
+
+import { IdentifierLogos } from './IdentifierLogos'
+
+describe('IdentifierLogos component', () => {
+  it('renders without errors', () => {
+    const { queryByText } = render(<IdentifierLogos />)
+
+    expect(queryByText('logos text')).toBeInTheDocument()
+  })
+})

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
@@ -30,4 +30,16 @@ describe('IdentifierLogos component', () => {
 
     expect(getByRole('img')).toBeInTheDocument()
   })
+
+  it('accepts a custom class name', () => {
+    const { queryByTestId } = render(
+      <IdentifierLogos className="custom-class">
+        {testIdentifierLogo}
+      </IdentifierLogos>
+    )
+
+    expect(queryByTestId('identifierLogos')).toHaveClass(
+      'usa-identifier__logos custom-class'
+    )
+  })
 })

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { render } from '@testing-library/react'
 import { IdentifierLogos } from './IdentifierLogos'
 

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.tsx
@@ -1,7 +1,17 @@
 import React from 'react'
+import classnames from 'classnames'
 
-export const IdentifierLogos = (): React.ReactElement => {
-  return <div>logos text</div>
+interface IdentifierLogosProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export const IdentifierLogos = ({
+  children,
+  className,
+}: IdentifierLogosProps & JSX.IntrinsicElements['div']): React.ReactElement => {
+  const classes = classnames('usa-identifier__logos', className)
+  return <div className={classes}>{children}</div>
 }
 
 export default IdentifierLogos

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.tsx
@@ -9,9 +9,14 @@ interface IdentifierLogosProps {
 export const IdentifierLogos = ({
   children,
   className,
+  ...divProps
 }: IdentifierLogosProps & JSX.IntrinsicElements['div']): React.ReactElement => {
   const classes = classnames('usa-identifier__logos', className)
-  return <div className={classes}>{children}</div>
+  return (
+    <div data-testid="identifierLogos" className={classes} {...divProps}>
+      {children}
+    </div>
+  )
 }
 
 export default IdentifierLogos

--- a/src/components/Identifier/IdentifierLogos/IdentifierLogos.tsx
+++ b/src/components/Identifier/IdentifierLogos/IdentifierLogos.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const IdentifierLogos = (): React.ReactElement => {
+  return <div>logos text</div>
+}
+
+export default IdentifierLogos

--- a/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
+++ b/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
@@ -30,24 +30,20 @@ describe('IdentifierMasthead component', () => {
       <IdentifierMasthead
         className="usa-identifier__custom-class-name"
         aria-label="Agency identifier">
-        <div className="usa-identifier__container">
-          <div className="usa-identifier__logos">
-            <IdentifierLogo href="#" className="custom-class-name">
-              {testIdentifierLogo}
-            </IdentifierLogo>
-          </div>
-          <div
-            data-testid="identifierMasthead-agency-description"
-            className="usa-identifier__identity"
-            aria-label="Agency description">
-            <p className="usa-identifier__identity-domain">
-              domain.edu.mil.gov
-            </p>
-            <p className="usa-identifier__identity-disclaimer">
-              {`An official website of the `}
-              <a href="testlink">Test Agency Name</a>
-            </p>
-          </div>
+        <div className="usa-identifier__logos">
+          <IdentifierLogo href="#" className="custom-class-name">
+            {testIdentifierLogo}
+          </IdentifierLogo>
+        </div>
+        <div
+          data-testid="identifierMasthead-agency-description"
+          className="usa-identifier__identity"
+          aria-label="Agency description">
+          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+          <p className="usa-identifier__identity-disclaimer">
+            {`An official website of the `}
+            <a href="testlink">Test Agency Name</a>
+          </p>
         </div>
       </IdentifierMasthead>
     )
@@ -75,28 +71,24 @@ describe('IdentifierMasthead component', () => {
   it('renders with more than two logos passed in', () => {
     const { getAllByRole, queryByText } = render(
       <IdentifierMasthead aria-label="Agency identifier">
-        <div className="usa-identifier__container">
-          <div className="usa-identifier__logos">
-            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-            <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-          </div>
-          <div
-            data-testid="identifierMasthead-agency-description"
-            className="usa-identifier__identity"
-            aria-label="Agency description">
-            <p className="usa-identifier__identity-domain">
-              domain.edu.mil.gov
-            </p>
-            <p className="usa-identifier__identity-disclaimer">
-              {`An official website of the `}
-              <a href="testlink">Test Agency Name</a>
-              {`, `}
-              <a href="secondTestLink">Second Test Agency Name</a>
-              {`, and the `}
-              <a href="thirdTestLink">Third Test Agency Name</a>
-            </p>
-          </div>
+        <div className="usa-identifier__logos">
+          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+        </div>
+        <div
+          data-testid="identifierMasthead-agency-description"
+          className="usa-identifier__identity"
+          aria-label="Agency description">
+          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
+          <p className="usa-identifier__identity-disclaimer">
+            {`An official website of the `}
+            <a href="testlink">Test Agency Name</a>
+            {`, `}
+            <a href="secondTestLink">Second Test Agency Name</a>
+            {`, and the `}
+            <a href="thirdTestLink">Third Test Agency Name</a>
+          </p>
         </div>
       </IdentifierMasthead>
     )

--- a/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
+++ b/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
@@ -5,6 +5,9 @@ import dotGovIcon from 'uswds/src/img/icon-dot-gov.svg'
 
 import { IdentifierMasthead } from './IdentifierMasthead'
 import { IdentifierLogo } from '../IdentifierLogo/IdentifierLogo'
+import { IdentifierLogos } from '../IdentifierLogos/IdentifierLogos'
+import { IdentifierIdentity } from '../IdentifierIdentity/IdentifierIdentity'
+import { Link } from '../../Link/Link'
 
 const testIdentifierLogo = [
   <img
@@ -30,20 +33,15 @@ describe('IdentifierMasthead component', () => {
       <IdentifierMasthead
         className="usa-identifier__custom-class-name"
         aria-label="Agency identifier">
-        <div className="usa-identifier__logos">
+        <IdentifierLogos>
           <IdentifierLogo href="#" className="custom-class-name">
             {testIdentifierLogo}
           </IdentifierLogo>
-        </div>
-        <div
-          className="usa-identifier__identity"
-          aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="testlink">Test Agency Name</a>
-          </p>
-        </div>
+        </IdentifierLogos>
+        <IdentifierIdentity domain="domain.edu.mil.gov">
+          {`An official website of the `}
+          <Link href="#">Test Agency Name</Link>
+        </IdentifierIdentity>
       </IdentifierMasthead>
     )
 
@@ -70,22 +68,19 @@ describe('IdentifierMasthead component', () => {
   it('renders with more than two logos passed in', () => {
     const { getAllByRole, queryByText } = render(
       <IdentifierMasthead aria-label="Agency identifier">
-        <div className="usa-identifier__logos">
+        <IdentifierLogos>
           <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
           <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
           <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        </div>
-        <div aria-label="Agency description">
-          <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
-          <p className="usa-identifier__identity-disclaimer">
-            {`An official website of the `}
-            <a href="testlink">Test Agency Name</a>
-            {`, `}
-            <a href="secondTestLink">Second Test Agency Name</a>
-            {`, and the `}
-            <a href="thirdTestLink">Third Test Agency Name</a>
-          </p>
-        </div>
+        </IdentifierLogos>
+        <IdentifierIdentity domain="domain.edu.mil.gov">
+          {`An official website of the `}
+          <Link href="#">Test Agency Name</Link>
+          {`, `}
+          <Link href="#">Second Test Agency Name</Link>
+          {`, and the `}
+          <Link href="#">Third Test Agency Name</Link>
+        </IdentifierIdentity>
       </IdentifierMasthead>
     )
     expect(getAllByRole('img')).toHaveLength(3)

--- a/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
+++ b/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
@@ -36,7 +36,7 @@ describe('IdentifierMasthead component', () => {
           </IdentifierLogo>
         </div>
         <div
-          data-testid="identifierMasthead-agency-description"
+          data-testid="identifier__identity"
           className="usa-identifier__identity"
           aria-label="Agency description">
           <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
@@ -77,7 +77,6 @@ describe('IdentifierMasthead component', () => {
           <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
         </div>
         <div
-          data-testid="identifierMasthead-agency-description"
           className="usa-identifier__identity"
           aria-label="Agency description">
           <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>

--- a/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
+++ b/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.test.tsx
@@ -36,7 +36,6 @@ describe('IdentifierMasthead component', () => {
           </IdentifierLogo>
         </div>
         <div
-          data-testid="identifier__identity"
           className="usa-identifier__identity"
           aria-label="Agency description">
           <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
@@ -76,9 +75,7 @@ describe('IdentifierMasthead component', () => {
           <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
           <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
         </div>
-        <div
-          className="usa-identifier__identity"
-          aria-label="Agency description">
+        <div aria-label="Agency description">
           <p className="usa-identifier__identity-domain">domain.edu.mil.gov</p>
           <p className="usa-identifier__identity-disclaimer">
             {`An official website of the `}

--- a/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.tsx
+++ b/src/components/Identifier/IdentifierMasthead/IdentifierMasthead.tsx
@@ -22,7 +22,7 @@ export const IdentifierMasthead = ({
       data-testid="identifierMasthead"
       className={classes}
       {...sectionProps}>
-      {children}
+      <div className="usa-identifier__container">{children}</div>
     </section>
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export { Title } from './components/header/Title/Title'
 /** Identifier Components */
 export { Identifier } from './components/Identifier/Identifier/Identifier'
 export { IdentifierGov } from './components/Identifier/IdentifierGov/IdentifierGov'
+export { IdentifierIdentity } from './components/Identifier/IdentifierIdentity/IdentifierIdentity'
 export { IdentifierLink } from './components/Identifier/IdentifierLink/IdentifierLink'
 export { IdentifierLinkItem } from './components/Identifier/IdentifierLinkItem/IdentifierLinkItem'
 export { IdentifierLinks } from './components/Identifier/IdentifierLinks/IdentifierLinks'

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export { IdentifierLink } from './components/Identifier/IdentifierLink/Identifie
 export { IdentifierLinkItem } from './components/Identifier/IdentifierLinkItem/IdentifierLinkItem'
 export { IdentifierLinks } from './components/Identifier/IdentifierLinks/IdentifierLinks'
 export { IdentifierLogo } from './components/Identifier/IdentifierLogo/IdentifierLogo'
+export { IdentifierLogos } from './components/Identifier/IdentifierLogos/IdentifierLogos'
 export { IdentifierMasthead } from './components/Identifier/IdentifierMasthead/IdentifierMasthead'
 
 /** Footer components */


### PR DESCRIPTION
# Summary

This PR implements two subcomponents `IdentifierIdentity` and `IdentityLogos` in order to prevent our users from having to manually apply [USWDS Identity component](https://designsystem.digital.gov/components/identifier/) classes.

## Related Issues or PRs

closes #1100 

## How To Test

Check out this branch and run `yarn test` to execute tests and `yarn storybook` to see the new component in action.

Alternatively, you can scroll to the bottom of this page and click "Show environments" on the right above the comment input box to access this component in Storybook. 

### Screenshots (optional)

These changes are completely abstract, we are merely adding more structure to the code. 