### PR TITLE
Update isCustomProps to accept "otherProps"

### DIFF
--- a/src/components/grid/Grid/Grid.tsx
+++ b/src/components/grid/Grid/Grid.tsx
@@ -25,41 +25,26 @@ export type CustomGridProps<T> = GridComponentProps<
 > &
   WithCustomGridProps<React.PropsWithChildren<T>>
 
+type omittedProps =
+  | 'mobile'
+  | 'tablet'
+  | 'desktop'
+  | 'widescreen'
+  | 'mobileLg'
+  | 'tabletLg'
+  | 'desktopLg'
+  | 'children'
+  | 'className'
+  | 'row'
+  | 'col'
+  | 'gap'
+  | 'offset'
+
 export function isCustomProps<T>(
   props:
-    | Omit<
-        DefaultGridProps,
-        | 'mobile'
-        | 'tablet'
-        | 'desktop'
-        | 'widescreen'
-        | 'mobileLg'
-        | 'tabletLg'
-        | 'desktopLg'
-        | 'children'
-        | 'className'
-        | 'row'
-        | 'col'
-        | 'gap'
-        | 'offset'
-      >
-    | Omit<
-        CustomGridProps<T>,
-        | 'mobile'
-        | 'tablet'
-        | 'desktop'
-        | 'widescreen'
-        | 'mobileLg'
-        | 'tabletLg'
-        | 'desktopLg'
-        | 'children'
-        | 'className'
-        | 'row'
-        | 'col'
-        | 'gap'
-        | 'offset'
-      >
-): props is CustomGridProps<T> {
+    | Omit<DefaultGridProps, omittedProps>
+    | Omit<CustomGridProps<T>, omittedProps>
+): props is Omit<CustomGridProps<T>, omittedProps> {
   return 'asCustom' in props
 }
 

--- a/src/components/grid/Grid/Grid.tsx
+++ b/src/components/grid/Grid/Grid.tsx
@@ -26,7 +26,39 @@ export type CustomGridProps<T> = GridComponentProps<
   WithCustomGridProps<React.PropsWithChildren<T>>
 
 export function isCustomProps<T>(
-  props: DefaultGridProps | CustomGridProps<T>
+  props:
+    | Omit<
+        DefaultGridProps,
+        | 'mobile'
+        | 'tablet'
+        | 'desktop'
+        | 'widescreen'
+        | 'mobileLg'
+        | 'tabletLg'
+        | 'desktopLg'
+        | 'children'
+        | 'className'
+        | 'row'
+        | 'col'
+        | 'gap'
+        | 'offset'
+      >
+    | Omit<
+        CustomGridProps<T>,
+        | 'mobile'
+        | 'tablet'
+        | 'desktop'
+        | 'widescreen'
+        | 'mobileLg'
+        | 'tabletLg'
+        | 'desktopLg'
+        | 'children'
+        | 'className'
+        | 'row'
+        | 'col'
+        | 'gap'
+        | 'offset'
+      >
 ): props is CustomGridProps<T> {
   return 'asCustom' in props
 }
@@ -118,8 +150,8 @@ export function Grid<FCProps = DefaultGridProps>(
 
   classes = classnames(classes, className)
 
-  if (isCustomProps(props)) {
-    const { asCustom, ...remainingProps } = props
+  if (isCustomProps(otherProps)) {
+    const { asCustom, ...remainingProps } = otherProps
 
     const gridProps: FCProps = (remainingProps as unknown) as FCProps
     return React.createElement(


### PR DESCRIPTION
# Summary

I'm pretty sure we tried almost exactly this a few days ago, but I just gave it another shot and it looks like it works!! 

This resolves an issue in https://github.com/trussworks/react-uswds/pull/1166 where the omitted props were being spread to the custom rendered element.