### PR TITLE
build(circleci): Collect test coverage and require a minimum coverage threshold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@ version: 2.1
 jobs:
   build:
     docker:
-    - auth:
-        password: $DOCKER_PASSWORD
-        username: $DOCKER_USERNAME
-      image: circleci/node:14.15.3
+      - auth:
+          password: $DOCKER_PASSWORD
+          username: $DOCKER_USERNAME
+        image: circleci/node:14.15.3
     working_directory: ~/react-uswds
     steps:
       - checkout
@@ -21,7 +21,7 @@ jobs:
             - ~/.cache/yarn
           key: v1-yarn-{{ checksum "yarn.lock" }}
 
-      - run: yarn test -w 1
+      - run: yarn test:coverage -w 1
 
       - run:
           name: 'Happo'
@@ -54,5 +54,4 @@ workflows:
     jobs:
       - build:
           context:
-          - org-global
-      
+            - org-global

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,12 @@ module.exports = {
     '\\.(css|scss)$': '<rootDir>/__mocks__/styleMock.js',
   },
   setupFilesAfterEnv: ['./src/setupTests.ts'],
+  coverageThreshold: {
+    global: {
+      statements: 96,
+      branches: 87,
+      functions: 94,
+      lines: 96,
+    },
+  },
 }


### PR DESCRIPTION
# Summary

Adds the `coverageThreshold` config value to the Jest config for this project, with the minimum global values for statement, branch, function, and line coverage set to (slightly below) their current values. These can be raised over time if we want.

Changes the `yarn test` task in the CircleCI build script to also collect test coverage; similar to a test failure, this will fail the build if the test coverage drops beneath any of the aforementioned threshold values.

## Related Issues or PRs

Closes #75 

## How To Test

* Did *this* pull request's CircleCI "build" check fail? If so, that would be a problem
* Run `yarn test:coverage` and verify that the process exits with code 0. In the `jest.config.js` file, change any of the `coverageThreshold` values to `100`, run `yarn test:coverage` again and verify that the process exits with code 1. (Screenshots of sample process output are below.)

### Screenshots

Code coverage threshold met (exiting with code 0):

![Screen Shot 2021-05-05 at 4 56 38 PM](https://user-images.githubusercontent.com/83614364/117208345-063fbb00-adc3-11eb-906f-530a92fef349.png)

Code coverage threshold not met (exiting with code 1):

![Screen Shot 2021-05-05 at 4 56 19 PM](https://user-images.githubusercontent.com/83614364/117208228-e1e3de80-adc2-11eb-948b-4893442b1c69.png)

