### PR TITLE
feat!: Expose ComboBox component ref with a clearSelection method

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
-import { ComboBox } from './ComboBox'
+import { ComboBox, ComboBoxRef } from './ComboBox'
 import { Form } from '../Form/Form'
 import { Label } from '../Label/Label'
 import { TextInput } from '../TextInput/TextInput'
+import { Button } from '../../Button/Button'
 import { fruits } from './fruits'
 
 export default {
@@ -115,6 +116,33 @@ export const withOtherFields = (): React.ReactElement => {
       <ComboBox id="fruit" name="fruit" options={fruitList} onChange={noop} />
       <Label htmlFor="fruitDescription">Description</Label>
       <TextInput id="fruitDescription" name="fruitDescription" type="text" />
+    </Form>
+  )
+}
+
+export const externalClearSelection = (): React.ReactElement => {
+  const ref = useRef<ComboBoxRef>()
+
+  const fruitList = Object.entries(fruits).map(([value, key]) => ({
+    value: value,
+    label: key,
+  }))
+
+  const handleClearSelection = (): void => ref.current.clearSelection()
+
+  return (
+    <Form onSubmit={noop}>
+      <Label htmlFor="fruit">Select a Fruit</Label>
+      <ComboBox
+        id="fruit"
+        name="fruit"
+        options={fruitList}
+        onChange={noop}
+        ref={ref}
+      />
+      <Button type="reset" onClick={handleClearSelection}>
+        Clear Selected Value
+      </Button>
     </Form>
   )
 }

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { ComboBox } from './ComboBox'
+import { ComboBox, ComboBoxRef } from './ComboBox'
 import { TextInput } from '../TextInput/TextInput'
 import { fruits } from './fruits'
 
@@ -1425,6 +1425,44 @@ describe('ComboBox component', () => {
       userEvent.type(getByTestId('combo-box-input'), 'zzz')
       const firstItem = getByTestId('combo-box-option-list').children[0]
       expect(firstItem).toHaveTextContent('NOTHING')
+    })
+  })
+
+  describe('exposed ref', () => {
+    it('can be used to clear the selected value', () => {
+      const comboRef = React.createRef<ComboBoxRef>()
+      const onChange = jest.fn()
+      const handleClearSelection = (): void =>
+        comboRef.current?.clearSelection()
+
+      const { getByTestId } = render(
+        <>
+          <ComboBox
+            id="favorite-fruit"
+            name="favorite-fruit"
+            options={fruitOptions}
+            onChange={onChange}
+            ref={comboRef}
+          />
+          <button data-testid="clear-button" onClick={handleClearSelection}>
+            Clear
+          </button>
+        </>
+      )
+
+      const input = getByTestId('combo-box-input')
+      fireEvent.click(getByTestId('combo-box-toggle'))
+      fireEvent.click(getByTestId('combo-box-option-apple'))
+
+      expect(onChange).toHaveBeenLastCalledWith('apple')
+      expect(input).toHaveDisplayValue('Apple')
+      expect(input).toHaveValue('Apple')
+
+      fireEvent.click(getByTestId('clear-button'))
+
+      expect(onChange).toHaveBeenLastCalledWith(undefined)
+      expect(input).toHaveDisplayValue('')
+      expect(input).toHaveValue('')
     })
   })
 })

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -1,4 +1,11 @@
-import React, { KeyboardEvent, FocusEvent, useEffect, useRef } from 'react'
+import React, {
+  KeyboardEvent,
+  FocusEvent,
+  useEffect,
+  useRef,
+  forwardRef,
+  useImperativeHandle,
+} from 'react'
 import classnames from 'classnames'
 
 import { ActionTypes, Action, State, useComboBox } from './useComboBox'
@@ -78,372 +85,391 @@ const Input = ({
   )
 }
 
-export const ComboBox = ({
-  id,
-  name,
-  className,
-  options,
-  defaultValue,
-  disabled,
-  onChange,
-  assistiveHint,
-  noResults,
-  selectProps,
-  inputProps,
-  ulProps,
-  customFilter,
-  disableFiltering = false,
-}: ComboBoxProps): React.ReactElement => {
-  const isDisabled = !!disabled
+export type ComboBoxRef = {
+  clearSelection: () => void
+}
 
-  let defaultOption
-  if (defaultValue) {
-    defaultOption = options.find((opt: ComboBoxOption): boolean => {
-      return opt.value === defaultValue
-    })
-  }
+export const ComboBox = forwardRef(
+  (
+    {
+      id,
+      name,
+      className,
+      options,
+      defaultValue,
+      disabled,
+      onChange,
+      assistiveHint,
+      noResults,
+      selectProps,
+      inputProps,
+      ulProps,
+      customFilter,
+      disableFiltering = false,
+    }: ComboBoxProps,
+    ref: React.Ref<ComboBoxRef>
+  ): React.ReactElement => {
+    const isDisabled = !!disabled
 
-  const filter: CustomizableFilter = customFilter
-    ? customFilter
-    : { filter: DEFAULT_FILTER }
-
-  const initialState: State = {
-    isOpen: false,
-    selectedOption: defaultOption ? defaultOption : undefined,
-    focusedOption: undefined,
-    focusMode: FocusMode.None,
-    filteredOptions: options,
-    inputValue: defaultOption ? defaultOption.label : '',
-  }
-
-  const [state, dispatch] = useComboBox(
-    initialState,
-    options,
-    disableFiltering,
-    filter
-  )
-
-  const containerRef = useRef<HTMLDivElement>(null)
-  const focusedItemRef = useRef<HTMLLIElement>(null)
-
-  useEffect(() => {
-    onChange && onChange(state.selectedOption?.value || undefined)
-  }, [state.selectedOption])
-
-  useEffect(() => {
-    if (
-      state.focusMode === FocusMode.Item &&
-      state.focusedOption &&
-      focusedItemRef.current
-    ) {
-      focusedItemRef.current.focus()
-    }
-  }, [state.focusMode, state.focusedOption])
-
-  // When opened, the list should scroll to the closest match
-  useEffect(() => {
-    if (
-      state.isOpen &&
-      state.focusedOption &&
-      focusedItemRef.current &&
-      state.focusMode === FocusMode.Input
-    ) {
-      focusedItemRef.current.scrollIntoView(false)
-    }
-  }, [state.isOpen, state.focusedOption])
-
-  // If the focused element (activeElement) is outside of the combo box,
-  // make sure the focusMode is BLUR
-  useEffect(() => {
-    if (state.focusMode !== FocusMode.None) {
-      if (!containerRef.current?.contains(window.document.activeElement)) {
-        dispatch({
-          type: ActionTypes.BLUR,
-        })
-      }
-    }
-  }, [state.focusMode])
-
-  const handleInputKeyDown = (event: KeyboardEvent): void => {
-    if (event.key === 'Escape') {
-      dispatch({ type: ActionTypes.CLOSE_LIST })
-    } else if (event.key === 'ArrowDown' || event.key == 'Down') {
-      event.preventDefault()
-      dispatch({
-        type: ActionTypes.FOCUS_OPTION,
-        option:
-          state.selectedOption ||
-          state.focusedOption ||
-          state.filteredOptions[0],
+    let defaultOption
+    if (defaultValue) {
+      defaultOption = options.find((opt: ComboBoxOption): boolean => {
+        return opt.value === defaultValue
       })
-    } else if (event.key === 'Tab') {
-      // Clear button is not visible in this case so manually handle focus
-      if (state.isOpen && !state.selectedOption) {
-        // If there are filtered options, prevent default
-        // If there are "No Results Found", tab over to prevent a keyboard trap
-        const optionToFocus = disableFiltering
-          ? state.focusedOption
-          : state.selectedOption || state.focusedOption
-        if (optionToFocus) {
-          event.preventDefault()
-          dispatch({
-            type: ActionTypes.FOCUS_OPTION,
-            option: optionToFocus,
-          })
-        } else {
+    }
+
+    const filter: CustomizableFilter = customFilter
+      ? customFilter
+      : { filter: DEFAULT_FILTER }
+
+    const initialState: State = {
+      isOpen: false,
+      selectedOption: defaultOption ? defaultOption : undefined,
+      focusedOption: undefined,
+      focusMode: FocusMode.None,
+      filteredOptions: options,
+      inputValue: defaultOption ? defaultOption.label : '',
+    }
+
+    const [state, dispatch] = useComboBox(
+      initialState,
+      options,
+      disableFiltering,
+      filter
+    )
+
+    const containerRef = useRef<HTMLDivElement>(null)
+    const focusedItemRef = useRef<HTMLLIElement>(null)
+
+    useEffect(() => {
+      onChange && onChange(state.selectedOption?.value || undefined)
+    }, [state.selectedOption])
+
+    useEffect(() => {
+      if (
+        state.focusMode === FocusMode.Item &&
+        state.focusedOption &&
+        focusedItemRef.current
+      ) {
+        focusedItemRef.current.focus()
+      }
+    }, [state.focusMode, state.focusedOption])
+
+    // When opened, the list should scroll to the closest match
+    useEffect(() => {
+      if (
+        state.isOpen &&
+        state.focusedOption &&
+        focusedItemRef.current &&
+        state.focusMode === FocusMode.Input
+      ) {
+        focusedItemRef.current.scrollIntoView(false)
+      }
+    }, [state.isOpen, state.focusedOption])
+
+    // If the focused element (activeElement) is outside of the combo box,
+    // make sure the focusMode is BLUR
+    useEffect(() => {
+      if (state.focusMode !== FocusMode.None) {
+        if (!containerRef.current?.contains(window.document.activeElement)) {
           dispatch({
             type: ActionTypes.BLUR,
           })
         }
       }
+    }, [state.focusMode])
 
-      if (!state.isOpen && state.selectedOption) {
-        dispatch({
-          type: ActionTypes.BLUR,
-        })
-      }
-    } else if (event.key === 'Enter') {
-      if (state.isOpen) {
+    useImperativeHandle(
+      ref,
+      () => ({
+        clearSelection: (): void => dispatch({ type: ActionTypes.CLEAR }),
+      }),
+      []
+    )
+
+    const handleInputKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        dispatch({ type: ActionTypes.CLOSE_LIST })
+      } else if (event.key === 'ArrowDown' || event.key == 'Down') {
         event.preventDefault()
-        const exactMatch = state.filteredOptions.find(
-          (option) =>
-            option.label.toLowerCase() === state.inputValue.toLowerCase()
-        )
-        if (exactMatch) {
-          dispatch({
-            type: ActionTypes.SELECT_OPTION,
-            option: exactMatch,
-          })
-        } else {
-          if (state.selectedOption) {
+        dispatch({
+          type: ActionTypes.FOCUS_OPTION,
+          option:
+            state.selectedOption ||
+            state.focusedOption ||
+            state.filteredOptions[0],
+        })
+      } else if (event.key === 'Tab') {
+        // Clear button is not visible in this case so manually handle focus
+        if (state.isOpen && !state.selectedOption) {
+          // If there are filtered options, prevent default
+          // If there are "No Results Found", tab over to prevent a keyboard trap
+          const optionToFocus = disableFiltering
+            ? state.focusedOption
+            : state.selectedOption || state.focusedOption
+          if (optionToFocus) {
+            event.preventDefault()
             dispatch({
-              type: ActionTypes.CLOSE_LIST,
+              type: ActionTypes.FOCUS_OPTION,
+              option: optionToFocus,
             })
           } else {
-            dispatch({ type: ActionTypes.CLEAR })
-          }
-        }
-      }
-    }
-  }
-
-  const handleInputBlur = (event: FocusEvent<HTMLInputElement>): void => {
-    const { relatedTarget: newTarget } = event
-    const newTargetIsOutside =
-      !newTarget ||
-      (newTarget instanceof Node && !containerRef.current?.contains(newTarget))
-
-    if (newTargetIsOutside && state.focusMode !== FocusMode.None) {
-      dispatch({ type: ActionTypes.BLUR })
-    }
-  }
-
-  const handleClearKeyDown = (event: KeyboardEvent): void => {
-    if (event.key === 'Tab' && state.isOpen && state.selectedOption) {
-      event.preventDefault()
-      dispatch({
-        type: ActionTypes.FOCUS_OPTION,
-        option: state.selectedOption,
-      })
-    }
-  }
-
-  const focusSibling = (
-    dispatch: React.Dispatch<Action>,
-    state: State,
-    change: Direction
-  ): void => {
-    const currentIndex = state.focusedOption
-      ? state.filteredOptions.indexOf(state.focusedOption)
-      : -1
-    const firstOption = state.filteredOptions[0]
-    const lastOption = state.filteredOptions[state.filteredOptions.length - 1]
-
-    if (currentIndex === -1) {
-      dispatch({ type: ActionTypes.FOCUS_OPTION, option: firstOption })
-    } else {
-      const newIndex = currentIndex + change
-      if (newIndex < 0 && state.selectedOption) {
-        dispatch({ type: ActionTypes.FOCUS_OPTION, option: firstOption })
-      } else if (newIndex < 0) {
-        dispatch({ type: ActionTypes.CLOSE_LIST })
-      } else if (newIndex >= state.filteredOptions.length) {
-        dispatch({ type: ActionTypes.FOCUS_OPTION, option: lastOption })
-      } else {
-        // eslint-disable-next-line security/detect-object-injection
-        const newOption = state.filteredOptions[newIndex]
-        dispatch({ type: ActionTypes.FOCUS_OPTION, option: newOption })
-      }
-    }
-  }
-  const handleListItemBlur = (event: FocusEvent<HTMLLIElement>): void => {
-    const { relatedTarget: newTarget } = event
-
-    if (
-      !newTarget ||
-      (newTarget instanceof Node && !containerRef.current?.contains(newTarget))
-    ) {
-      dispatch({ type: ActionTypes.BLUR })
-    }
-  }
-
-  const handleListItemKeyDown = (event: KeyboardEvent): void => {
-    if (event.key === 'Escape') {
-      dispatch({ type: ActionTypes.CLOSE_LIST })
-    } else if (event.key === 'Tab' || event.key === 'Enter') {
-      event.preventDefault()
-      if (state.focusedOption) {
-        dispatch({
-          type: ActionTypes.SELECT_OPTION,
-          option: state.focusedOption,
-        })
-      }
-    } else if (event.key === 'ArrowDown' || event.key === 'Down') {
-      event.preventDefault()
-      focusSibling(dispatch, state, Direction.Next)
-    } else if (event.key === 'ArrowUp' || event.key === 'Up') {
-      event.preventDefault()
-      focusSibling(dispatch, state, Direction.Previous)
-    }
-  }
-
-  const isPristine =
-    state.selectedOption && state.selectedOption.label === state.inputValue
-
-  const containerClasses = classnames('usa-combo-box', className, {
-    'usa-combo-box--pristine': isPristine,
-  })
-  const listID = `combobox-${name}-list`
-  const assistiveHintID = `combobox-${name}-assistive-hint`
-
-  return (
-    <div
-      data-testid="combo-box"
-      className={containerClasses}
-      id={id}
-      ref={containerRef}>
-      <select
-        className="usa-select usa-sr-only usa-combo-box__select"
-        name={name}
-        aria-hidden
-        tabIndex={-1}
-        defaultValue={state.selectedOption?.value}
-        data-testid="combo-box-select"
-        disabled={isDisabled}
-        {...selectProps}>
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-      <Input
-        onChange={(e): void =>
-          dispatch({ type: ActionTypes.UPDATE_FILTER, value: e.target.value })
-        }
-        onClick={(): void => dispatch({ type: ActionTypes.OPEN_LIST })}
-        onBlur={handleInputBlur}
-        onKeyDown={handleInputKeyDown}
-        value={state.inputValue}
-        focused={state.focusMode === FocusMode.Input}
-        role="combobox"
-        aria-owns={listID}
-        aria-describedby={assistiveHintID}
-        aria-expanded={state.isOpen}
-        disabled={isDisabled}
-        {...inputProps}
-      />
-      <span className="usa-combo-box__clear-input__wrapper" tabIndex={-1}>
-        <button
-          type="button"
-          className="usa-combo-box__clear-input"
-          aria-label="Clear the select contents"
-          onClick={(): void => dispatch({ type: ActionTypes.CLEAR })}
-          data-testid="combo-box-clear-button"
-          onKeyDown={handleClearKeyDown}
-          hidden={!isPristine}>
-          &nbsp;
-        </button>
-      </span>
-      <span className="usa-combo-box__input-button-separator">&nbsp;</span>
-      <span className="usa-combo-box__toggle-list__wrapper" tabIndex={-1}>
-        <button
-          data-testid="combo-box-toggle"
-          type="button"
-          className="usa-combo-box__toggle-list"
-          tabIndex={-1}
-          aria-label="Toggle the dropdown list"
-          onClick={(): void =>
             dispatch({
-              type: state.isOpen
-                ? ActionTypes.CLOSE_LIST
-                : ActionTypes.OPEN_LIST,
+              type: ActionTypes.BLUR,
             })
           }
-          disabled={isDisabled}>
-          &nbsp;
-        </button>
-      </span>
-      <ul
-        data-testid="combo-box-option-list"
-        tabIndex={-1}
-        id={listID}
-        className="usa-combo-box__list"
-        role="listbox"
-        hidden={!state.isOpen}
-        {...ulProps}>
-        {state.filteredOptions.map((option, index) => {
-          const focused = option === state.focusedOption
-          const selected = option === state.selectedOption
-          const itemClasses = classnames('usa-combo-box__list-option', {
-            'usa-combo-box__list-option--focused': focused,
-            'usa-combo-box__list-option--selected': selected,
+        }
+
+        if (!state.isOpen && state.selectedOption) {
+          dispatch({
+            type: ActionTypes.BLUR,
           })
-
-          return (
-            <li
-              ref={focused ? focusedItemRef : null}
-              value={option.value}
-              key={option.value}
-              className={itemClasses}
-              tabIndex={focused ? 0 : -1}
-              role="option"
-              aria-selected={selected}
-              aria-setsize={64}
-              aria-posinset={index + 1}
-              id={listID + `--option-${index}`}
-              onKeyDown={handleListItemKeyDown}
-              onBlur={handleListItemBlur}
-              data-testid={`combo-box-option-${option.value}`}
-              onMouseEnter={(): void =>
-                dispatch({ type: ActionTypes.FOCUS_OPTION, option: option })
-              }
-              onClick={(): void => {
-                dispatch({ type: ActionTypes.SELECT_OPTION, option: option })
-              }}>
-              {option.label}
-            </li>
+        }
+      } else if (event.key === 'Enter') {
+        if (state.isOpen) {
+          event.preventDefault()
+          const exactMatch = state.filteredOptions.find(
+            (option) =>
+              option.label.toLowerCase() === state.inputValue.toLowerCase()
           )
-        })}
-        {state.filteredOptions.length === 0 ? (
-          <li className="usa-combo-box__list-option--no-results">
-            {noResults || 'No results found'}
-          </li>
-        ) : null}
-      </ul>
+          if (exactMatch) {
+            dispatch({
+              type: ActionTypes.SELECT_OPTION,
+              option: exactMatch,
+            })
+          } else {
+            if (state.selectedOption) {
+              dispatch({
+                type: ActionTypes.CLOSE_LIST,
+              })
+            } else {
+              dispatch({ type: ActionTypes.CLEAR })
+            }
+          }
+        }
+      }
+    }
 
-      <div className="usa-combo-box__status usa-sr-only" role="status"></div>
-      <span
-        id={assistiveHintID}
-        className="usa-sr-only"
-        data-testid="combo-box-assistive-hint">
-        {assistiveHint ||
-          `When autocomplete results are available use up and down arrows to review
+    const handleInputBlur = (event: FocusEvent<HTMLInputElement>): void => {
+      const { relatedTarget: newTarget } = event
+      const newTargetIsOutside =
+        !newTarget ||
+        (newTarget instanceof Node &&
+          !containerRef.current?.contains(newTarget))
+
+      if (newTargetIsOutside && state.focusMode !== FocusMode.None) {
+        dispatch({ type: ActionTypes.BLUR })
+      }
+    }
+
+    const handleClearKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Tab' && state.isOpen && state.selectedOption) {
+        event.preventDefault()
+        dispatch({
+          type: ActionTypes.FOCUS_OPTION,
+          option: state.selectedOption,
+        })
+      }
+    }
+
+    const focusSibling = (
+      dispatch: React.Dispatch<Action>,
+      state: State,
+      change: Direction
+    ): void => {
+      const currentIndex = state.focusedOption
+        ? state.filteredOptions.indexOf(state.focusedOption)
+        : -1
+      const firstOption = state.filteredOptions[0]
+      const lastOption = state.filteredOptions[state.filteredOptions.length - 1]
+
+      if (currentIndex === -1) {
+        dispatch({ type: ActionTypes.FOCUS_OPTION, option: firstOption })
+      } else {
+        const newIndex = currentIndex + change
+        if (newIndex < 0 && state.selectedOption) {
+          dispatch({ type: ActionTypes.FOCUS_OPTION, option: firstOption })
+        } else if (newIndex < 0) {
+          dispatch({ type: ActionTypes.CLOSE_LIST })
+        } else if (newIndex >= state.filteredOptions.length) {
+          dispatch({ type: ActionTypes.FOCUS_OPTION, option: lastOption })
+        } else {
+          // eslint-disable-next-line security/detect-object-injection
+          const newOption = state.filteredOptions[newIndex]
+          dispatch({ type: ActionTypes.FOCUS_OPTION, option: newOption })
+        }
+      }
+    }
+    const handleListItemBlur = (event: FocusEvent<HTMLLIElement>): void => {
+      const { relatedTarget: newTarget } = event
+
+      if (
+        !newTarget ||
+        (newTarget instanceof Node &&
+          !containerRef.current?.contains(newTarget))
+      ) {
+        dispatch({ type: ActionTypes.BLUR })
+      }
+    }
+
+    const handleListItemKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        dispatch({ type: ActionTypes.CLOSE_LIST })
+      } else if (event.key === 'Tab' || event.key === 'Enter') {
+        event.preventDefault()
+        if (state.focusedOption) {
+          dispatch({
+            type: ActionTypes.SELECT_OPTION,
+            option: state.focusedOption,
+          })
+        }
+      } else if (event.key === 'ArrowDown' || event.key === 'Down') {
+        event.preventDefault()
+        focusSibling(dispatch, state, Direction.Next)
+      } else if (event.key === 'ArrowUp' || event.key === 'Up') {
+        event.preventDefault()
+        focusSibling(dispatch, state, Direction.Previous)
+      }
+    }
+
+    const isPristine =
+      state.selectedOption && state.selectedOption.label === state.inputValue
+
+    const containerClasses = classnames('usa-combo-box', className, {
+      'usa-combo-box--pristine': isPristine,
+    })
+    const listID = `combobox-${name}-list`
+    const assistiveHintID = `combobox-${name}-assistive-hint`
+
+    return (
+      <div
+        data-testid="combo-box"
+        className={containerClasses}
+        id={id}
+        ref={containerRef}>
+        <select
+          className="usa-select usa-sr-only usa-combo-box__select"
+          name={name}
+          aria-hidden
+          tabIndex={-1}
+          defaultValue={state.selectedOption?.value}
+          data-testid="combo-box-select"
+          disabled={isDisabled}
+          {...selectProps}>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <Input
+          onChange={(e): void =>
+            dispatch({ type: ActionTypes.UPDATE_FILTER, value: e.target.value })
+          }
+          onClick={(): void => dispatch({ type: ActionTypes.OPEN_LIST })}
+          onBlur={handleInputBlur}
+          onKeyDown={handleInputKeyDown}
+          value={state.inputValue}
+          focused={state.focusMode === FocusMode.Input}
+          role="combobox"
+          aria-owns={listID}
+          aria-describedby={assistiveHintID}
+          aria-expanded={state.isOpen}
+          disabled={isDisabled}
+          {...inputProps}
+        />
+        <span className="usa-combo-box__clear-input__wrapper" tabIndex={-1}>
+          <button
+            type="button"
+            className="usa-combo-box__clear-input"
+            aria-label="Clear the select contents"
+            onClick={(): void => dispatch({ type: ActionTypes.CLEAR })}
+            data-testid="combo-box-clear-button"
+            onKeyDown={handleClearKeyDown}
+            hidden={!isPristine}>
+            &nbsp;
+          </button>
+        </span>
+        <span className="usa-combo-box__input-button-separator">&nbsp;</span>
+        <span className="usa-combo-box__toggle-list__wrapper" tabIndex={-1}>
+          <button
+            data-testid="combo-box-toggle"
+            type="button"
+            className="usa-combo-box__toggle-list"
+            tabIndex={-1}
+            aria-label="Toggle the dropdown list"
+            onClick={(): void =>
+              dispatch({
+                type: state.isOpen
+                  ? ActionTypes.CLOSE_LIST
+                  : ActionTypes.OPEN_LIST,
+              })
+            }
+            disabled={isDisabled}>
+            &nbsp;
+          </button>
+        </span>
+        <ul
+          data-testid="combo-box-option-list"
+          tabIndex={-1}
+          id={listID}
+          className="usa-combo-box__list"
+          role="listbox"
+          hidden={!state.isOpen}
+          {...ulProps}>
+          {state.filteredOptions.map((option, index) => {
+            const focused = option === state.focusedOption
+            const selected = option === state.selectedOption
+            const itemClasses = classnames('usa-combo-box__list-option', {
+              'usa-combo-box__list-option--focused': focused,
+              'usa-combo-box__list-option--selected': selected,
+            })
+
+            return (
+              <li
+                ref={focused ? focusedItemRef : null}
+                value={option.value}
+                key={option.value}
+                className={itemClasses}
+                tabIndex={focused ? 0 : -1}
+                role="option"
+                aria-selected={selected}
+                aria-setsize={64}
+                aria-posinset={index + 1}
+                id={listID + `--option-${index}`}
+                onKeyDown={handleListItemKeyDown}
+                onBlur={handleListItemBlur}
+                data-testid={`combo-box-option-${option.value}`}
+                onMouseEnter={(): void =>
+                  dispatch({ type: ActionTypes.FOCUS_OPTION, option: option })
+                }
+                onClick={(): void => {
+                  dispatch({ type: ActionTypes.SELECT_OPTION, option: option })
+                }}>
+                {option.label}
+              </li>
+            )
+          })}
+          {state.filteredOptions.length === 0 ? (
+            <li className="usa-combo-box__list-option--no-results">
+              {noResults || 'No results found'}
+            </li>
+          ) : null}
+        </ul>
+
+        <div className="usa-combo-box__status usa-sr-only" role="status"></div>
+        <span
+          id={assistiveHintID}
+          className="usa-sr-only"
+          data-testid="combo-box-assistive-hint">
+          {assistiveHint ||
+            `When autocomplete results are available use up and down arrows to review
            and enter to select. Touch device users, explore by touch or with swipe
            gestures.`}
-      </span>
-    </div>
-  )
-}
+        </span>
+      </div>
+    )
+  }
+)
 
 export default ComboBox

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -182,7 +182,8 @@ export const ComboBox = forwardRef(
     useImperativeHandle(
       ref,
       () => ({
-        clearSelection: (): void => dispatch({ type: ActionTypes.CLEAR }),
+        clearSelection: (): void =>
+          dispatch({ type: ActionTypes.CLEAR_SELECTION }),
       }),
       []
     )

--- a/src/components/forms/ComboBox/useComboBox.ts
+++ b/src/components/forms/ComboBox/useComboBox.ts
@@ -11,6 +11,7 @@ export enum ActionTypes {
   FOCUS_OPTION,
   UPDATE_FILTER,
   BLUR,
+  CLEAR_SELECTION,
 }
 
 export type Action =
@@ -37,6 +38,9 @@ export type Action =
     }
   | {
       type: ActionTypes.BLUR
+    }
+  | {
+      type: ActionTypes.CLEAR_SELECTION
     }
 
 export interface State {
@@ -181,6 +185,16 @@ export const useComboBox = (
         }
 
         return newState
+      }
+      case ActionTypes.CLEAR_SELECTION: {
+        return {
+          ...state,
+          inputValue: '',
+          isOpen: false,
+          selectedOption: undefined,
+          filteredOptions: optionsList,
+          focusedOption: optionsList[0],
+        }
       }
       default:
         throw new Error()

--- a/src/components/forms/ComboBox/useComboBox.ts
+++ b/src/components/forms/ComboBox/useComboBox.ts
@@ -191,9 +191,10 @@ export const useComboBox = (
           ...state,
           inputValue: '',
           isOpen: false,
+          focusMode: FocusMode.None,
           selectedOption: undefined,
           filteredOptions: optionsList,
-          focusedOption: optionsList[0],
+          focusedOption: undefined,
         }
       }
       default:


### PR DESCRIPTION
# Summary

This changes the `ComboBox` component to use `forwardRef` and the `useImperativeHandle` hook. It allows users to pass in a ref to a component instance and then call a `clearSelection` method on it, which will clear any existing value.

This change is _deeply_ indebted to the pattern established in PR #1165.

As this changes an existing component to use `forwardRef`, this should be considered a BREAKING CHANGE.

## Related Issues or PRs

Closes #1137 .

## How To Test

In the application, try passing a `ref` to the ComboBox component, selecting a value for the component, and using `ref.current.clearSelection()` to reset the value.