### PR TITLE
[WIP] feat: New Component Modal

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }, ],
-    '@babel/preset-react'
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-react',
+  ],
+  plugins: [
+    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
   ],
 }

--- a/src/components/ModalNew/Modal.stories.tsx
+++ b/src/components/ModalNew/Modal.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { ModalNew } from './Modal'
+
+export default {
+  title: 'Components/Modal',
+  component: ModalNew,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+### USWDS 2.0 SiteAlert component
+
+Source: http://designsystem.digital.gov/components/modal
+`,
+      },
+    },
+  },
+}
+
+export const defaultModal = (): React.ReactElement => (
+  <ModalNew>some children</ModalNew>
+)
+
+export const largeModal = (): React.ReactElement => (
+  <ModalNew isLarge>large modal</ModalNew>
+)
+
+export const modalWithForcedAction = (): React.ReactElement => (
+  <ModalNew>forced action</ModalNew>
+)

--- a/src/components/ModalNew/Modal.test.tsx
+++ b/src/components/ModalNew/Modal.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { ModalNew } from './Modal'
+
+describe('Modal component', () => {
+  it('renders without errors', () => {
+    const { getByTestId } = render(<ModalNew>some children</ModalNew>)
+
+    expect(getByTestId('modal')).toBeInTheDocument()
+  })
+
+  it('renders large model when passed isLarge', () => {
+    const { getByTestId } = render(<ModalNew isLarge>some children</ModalNew>)
+
+    expect(getByTestId('modal')).toHaveClass('usa-modal--lg')
+  })
+
+  it('accepts attributes passed in through props', () => {
+    const { getByTestId } = render(
+      <ModalNew aria-label="aria-label-model">some children</ModalNew>
+    )
+
+    expect(getByTestId('modal')).toHaveAttribute(
+      'aria-label',
+      'aria-label-model'
+    )
+  })
+
+  it('accepts a custom className', () => {
+    const { getByTestId } = render(
+      <ModalNew className="custom-class">some children</ModalNew>
+    )
+
+    expect(getByTestId('modal')).toHaveClass('usa-modal custom-class')
+  })
+})

--- a/src/components/ModalNew/Modal.tsx
+++ b/src/components/ModalNew/Modal.tsx
@@ -11,7 +11,7 @@ export const ModalNew = ({
   className,
   children,
   isLarge = false,
-  ...props
+  ...divProps
 }: ModalProps & JSX.IntrinsicElements['div']): React.ReactElement => {
   const classes = classnames(
     'usa-modal',
@@ -21,7 +21,7 @@ export const ModalNew = ({
     className
   )
   return (
-    <div data-testid="modal" className={classes} {...props}>
+    <div data-testid="modal" className={classes} {...divProps}>
       {children}
     </div>
   )

--- a/src/components/ModalNew/Modal.tsx
+++ b/src/components/ModalNew/Modal.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import classnames from 'classnames'
+
+interface ModalProps {
+  children: React.ReactNode
+  className?: string
+  isLarge?: boolean
+}
+
+export const ModalNew = ({
+  className,
+  children,
+  isLarge = false,
+  ...props
+}: ModalProps & JSX.IntrinsicElements['div']): React.ReactElement => {
+  const classes = classnames(
+    'usa-modal',
+    {
+      'usa-modal--lg': isLarge,
+    },
+    className
+  )
+  return (
+    <div data-testid="modal" className={classes} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export default ModalNew


### PR DESCRIPTION
# Summary

This PR adds USWDS new `Modal` component. 


Based on the fact that there's already a `Modal` component in ReactUSWDS with multiple `deprecationWarning`s saying
```'Modal is deprecated. Modal will be removed from react-uswds alongside all other Modal related components and functions in the next major release.'```
it seems like uswds originally had a `Modal` that they have since done away with completely - we will need to hold off on merging this `Modal` until we are ready for a major release, but we can probably update the warning messages with news of the rewrite in the mean time. 

## Related Issues or PRs

WIP for #1233 

## How To Test

Check out this branch and run `yarn test` to execute tests and `yarn storybook` to see the new component in action.

Alternatively, you can scroll to the bottom of this page and click "Show environments" on the right above the comment input box.

### Screenshots (optional)
