### PR TITLE
fix: Package crash on server-side import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
 
       - run: yarn test:coverage -w 1
 
+      - run: yarn test:serverside
+
       - run:
           name: 'Happo'
           command: 'yarn happo-ci'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:serverside": "yarn build && node src/serverSideTest.js",
     "storybook": "start-storybook -p 9009",
     "storybook:deploy": "storybook-to-ghpages",
     "build": "webpack --progress",

--- a/src/components/forms/FileInput/FilePreview.tsx
+++ b/src/components/forms/FileInput/FilePreview.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react'
 import classnames from 'classnames'
 
-import { SPACER_GIF } from './constants'
+/** Moving the SPACER_GIF definition here instead of the constants.ts file,
+ * as webpack was exporting that entire file, including use of the File
+ * WebAPI; this was causing server-side site generators to break (#1250). */
+
+const SPACER_GIF =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 
 export const FilePreview = ({
   imageId,

--- a/src/serverSideTest.js
+++ b/src/serverSideTest.js
@@ -1,0 +1,14 @@
+/** Bare-bones check to see if server-side use of this code is inadvertantly
+ * prevented by any use of Web APIs that aren't available in node.
+ *
+ * This script should only run as part of the yarn test:serverside command,
+ * and takes place after a webpack build.
+ */
+
+const library = require('../lib')
+
+console.log('server-side test running')
+
+/** This will throw a ReferenceError if there's any use of a Web API
+ * that node doesn't know about, which will cause CircleCI to fail a build. */
+module.exports = library


### PR DESCRIPTION
The `forms/FileInput/FilePreview.tsx` sub-component was importing a string from a constants file; this caused Webpack to include all exported variables in that file in the final build. This meant that uses of the `File` web-only API were included in said build, which caused server-side site generation (such as Next or Gatsby) to throw a ReferenceError when importing this package, as those are running in a node-only context where that API doesn't exist.

The simple fix was to move the value of that constant into the FilePreview subcomponent, which prevents the entire constants file from being included in a webpack build.

This PR also adds:

1. A very simple e2e test (`/src/serverSideTest.js`) to check for package importability -- it just `require`s the version of the local version of the package that's been built by webpack and immediately exports it. This is sufficient to uncover any future `ReferenceError`s-on-import like this.
2. A package.json command (`yarn test:serverside`) that just runs a webpack build followed immediately by the aforementioned e2e test.
3. An update to CircleCI, running that command immediately following the traditional test suite.

# Summary

Closes #1250 

## How To Test

* Make sure that this PR's CircleCI build check passes, and that it includes the `yarn test:serverside` task as part of it.
* Run `yarn test:serverside`, and verify that the command exits with code 0. Edit line 4 of `src/components/forms/FileInput/FilePreview.tsx` back (to `import { SPACER_GIF } from './constants'`), then run `yarn test:serverside` again and verify that the command now exits with code 1.