### PR TITLE
build(happo): disable edge browser because of false postives

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -14,9 +14,10 @@ module.exports = {
     firefox: new RemoteBrowserTarget('firefox', {
       viewport: '1024x768',
     }),
-    edge: new RemoteBrowserTarget('edge', {
-      viewport: '1024x768',
-    }),
+    // happo has too many false postive diffs with edge to use it
+    // edge: new RemoteBrowserTarget('edge', {
+    //   viewport: '1024x768',
+    // }),
     'internet explorer': new RemoteBrowserTarget('internet explorer', {
       viewport: '1024x768',
     }),


### PR DESCRIPTION
# Summary

Disable edge browser in happo because it has too many false positives

