### PR TITLE
Troubleshooting the new `Icon` svg component

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,6 +16,7 @@ import {
   NavMenuButton,
   PrimaryNav,
   GridContainer,
+  Icon,
 } from '@trussworks/react-uswds'
 
 import HomePage from './pages/Home'
@@ -54,6 +55,7 @@ const App = () => {
           <div className="usa-navbar">
             <Title>
               <Link to={HOME_PAGE}>Example Application</Link>
+              <Icon name="add" size={9} />
             </Title>
             <NavMenuButton
               label="Menu"


### PR DESCRIPTION
# Summary

Drew and I spent some time pairing on this earlier today. We discovered a few things; unexpectedly `Icon` does render in all browsers in the added Happo screenshots (except in IE), we added `Icon` to the example app expecting it to work based on Happo's success but it did not, and there are rules around SVGs that differ from `image` tags which is how the rest of the components successfully render any USWDS icons as of right now.

- when running `yarn storybook` locally on the branch `ak-new-component-icon-992` the `Icon` component renders and you can view all of the 239 different options in several different sizes using Storybook controls
- when attempting to view the `Icon` component in the deployed Storybook environment available in the [feat: New Component Icon](https://github.com/trussworks/react-uswds/pull/1241) PR, the Icon does not show up and the console logs errors regarding [SVG hosting](https://github.com/jonathantneal/svg4everybody/issues/16) (errors showed up on Drew's machine, but not mine when I tried to recreate the problem for this PR)
- SVGs are stored in S3, this could be a difference with how we build locally with webpack vs how CircleCI hosts Storybook, or an issue with GitHub
- `Icon` shows up in Happo screenshots
- `Icon` does not render when imported into the example app and loaded in Chrome or Safari



## Related Issues or PRs

Relates to ongoing issues with #1241 

## How To Test

Checkout this branch and run the commands `yarn example:install` and `yarn example:start` to install dependencies for and run the example app. Inspect the small text at the top of the screen that says "Example Application" - directly following that `<em>` tag there should be an `<svg>` tag. If you hover over that tag, you should see the (empty) box where the `Icon` should be rendering. 

If when you follow these instructions you happen to see a functioning `Icon` component, please take a screenshot and ping me in Slack to let me know what browser you're using.

### Screenshots (optional)

**Chrome**
<img width="1440" alt="Screen Shot 2021-06-09 at 5 19 55 PM" src="https://user-images.githubusercontent.com/16230705/121446909-6fc66280-c949-11eb-99f9-ad8e1c22dead.png">

**Safari**
<img width="1190" alt="Screen Shot 2021-06-09 at 5 23 12 PM" src="https://user-images.githubusercontent.com/16230705/121446912-7228bc80-c949-11eb-973f-296bb1a1fba4.png">