### PR TITLE
build(storybook): release on any numeric tag push

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -3,7 +3,7 @@ name: Deploy Storybook
 on:
   push:
     tags:
-      - 1.*
+      - '[1-9].*'
 
 jobs:
   deploy-storybook:


### PR DESCRIPTION
# Summary

- Release on any numeric tag push. 
- [fix] Deployed storybook is not up to date

## Related Issues or PRs

closes #1357 

## How To Test

We will probably need to release 2.0.1 and push a tag

