### PR TITLE
chore: Revert "chore(release): 2.1.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [2.1.0](https://github.com/trussworks/react-uswds/compare/2.0.0...2.1.0) (2021-09-24)
-
-
-### Features
-
-* SiteAlert child enhancement([#1215](https://github.com/trussworks/react-uswds/issues/1215)) ([3cd70f9 ](https://github.com/trussworks/react-uswds/commit/3cd70f95d04eab23e3ad6b1f31634d3b507b3692))
-* Add aria attributes to RangeInput ([#1560](https://github.com/trussworks/react-uswds/issues/1560)) ([0034835](https://github.com/trussworks/react-uswds/commit/00348350ced514bf33c9a1795270838e2df33a24))
-
 ## [2.0.0](https://github.com/trussworks/react-uswds/compare/1.17.0...2.0.0) (2021-06-15)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trussworks/react-uswds",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "React USWDS 2.0 component library",
   "keywords": [
     "react",


### PR DESCRIPTION
Failed release - `yarn build` is is throwing an error.  We will fix and then retry release at this tag.
Reverts trussworks/react-uswds#1588