### PR TITLE
Add dependabot reviewers for example app deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,11 @@ updates:
     pull-request-branch-name:
       separator: '-'
     open-pull-requests-limit: 10
+    reviewers:
+      - "suzubara"
+      - "haworku"
+      - "ahobson"
+      - "brandonlenz"
     labels:
       - 'type: dependencies'
       - 'type: automerge'


### PR DESCRIPTION
# Summary

Previous PR missed the example app dependabot configuration (I didn't scroll down to see it).

I wanted to use a yaml anchor to be more DRY, but for whatever reason, [dependabot does not support anchors and aliases in yaml config](https://github.com/dependabot/dependabot-core/issues/2127)

## Related Issues or PRs

Previous PR: https://github.com/trussworks/react-uswds/pull/1587 