### PR TITLE
feat: Support node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lib"
   ],
   "engines": {
-    "node": "10.x - 14.x"
+    "node": "10.x - 16.x"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Fixes https://github.com/trussworks/react-uswds/issues/1582, so that users with node 16 can install this package.