### PR TITLE
build(node): Support Node 16

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,12 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node: ['12', '14', '16']
+
+    name: Node ${{ matrix.node }} tests
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -17,10 +23,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
-      # The yarn cache is not node_modules
       - name: Install dependencies
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: 'yarn'
+
       - name: Happo
         run: yarn happo-ci
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Run node server side tests
         run: yarn test:serverside
 
-      - name: Lint code
-        run: yarn lint
-
   run-checks:
     runs-on: ubuntu-latest
 
@@ -46,6 +43,13 @@ jobs:
           node-version: 12.x
           cache: 'yarn'
 
+      # The yarn cache is not node_modules
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Lint code
+        run: yarn lint
+
       - name: Happo
         run: yarn happo-ci
         env:
@@ -53,6 +57,6 @@ jobs:
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
 
       - name: Run Danger JS
-        run: danger/danger-js@9.1.8
+        run: yarn danger ci --failOnErrors
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
-        with: 
+        with:
           node-version: 12.x
           cache: 'yarn'
 
@@ -33,13 +33,20 @@ jobs:
       - name: Lint code
         run: yarn lint
 
+  run-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
       - name: Happo
         run: yarn happo-ci
-        env: 
+        env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
 
-      - name: Run Danger JS 
-        run: yarn danger ci --failOnErrors
-        env: 
+      - name: Run Danger JS
+        run: danger/danger-js@9.1.8
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lib"
   ],
   "engines": {
-    "node": "10.x - 14.x"
+    "node": "10.x - 16.x"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
# Summary

Add support for Node 16 (pushed to internal branch from forked PR)

## Related Issues or PRs

Internally branched PR for @epicfaace's change in https://github.com/trussworks/react-uswds/pull/1743/ to allow our CI to run.

> Fixes #1582, so that users with node 16 can install this package.
