### PR TITLE
Combobox fires custom onChange events when option is selected

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -40,6 +40,8 @@ export const defaultComboBoxWithPropOptions = (): React.ReactElement => {
         name="input-ComboBox"
         options={fruitList}
         onChange={noop}
+        inputProps={{ onChange: (e) => console.log('input') }}
+        selectProps={{ onChange: (e) => console.log('select') }}
       />
     </Form>
   )

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -318,6 +318,25 @@ describe('ComboBox component', () => {
         'test-label-id'
       )
     })
+
+    it('calls a custom input onChange handler when an option is selected', () => {
+      const mockOnInputChange = jest.fn()
+
+      const { getByTestId } = render(
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={fruitOptions}
+          onChange={jest.fn()}
+          inputProps={{ onChange: mockOnInputChange }}
+        />
+      )
+
+      const input = getByTestId('combo-box-input')
+      userEvent.type(input, 'y')
+      userEvent.click(getByTestId('combo-box-option-yuzu'))
+      expect(mockOnInputChange).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('scrolling to a focused option', () => {

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -206,6 +206,30 @@ export const ComboBox = forwardRef(
       []
     )
 
+    const changeElementValue = (
+      el: HTMLInputElement | HTMLSelectElement,
+      value = ''
+    ) => {
+      const elementToChange = el
+      elementToChange.value = value
+
+      const event = new CustomEvent('change', {
+        bubbles: true,
+        cancelable: true,
+        detail: { value },
+      })
+      elementToChange.dispatchEvent(event)
+    }
+
+    const fireOnChangeAndDispatchSelect = (option: ComboBoxOption) => {
+      inputRef.current && changeElementValue(inputRef.current, option.label)
+      selectRef.current && changeElementValue(selectRef.current, option.value)
+      dispatch({
+        type: ActionTypes.SELECT_OPTION,
+        option: option,
+      })
+    }
+
     const handleInputKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
         dispatch({ type: ActionTypes.CLOSE_LIST })
@@ -252,10 +276,7 @@ export const ComboBox = forwardRef(
               option.label.toLowerCase() === state.inputValue.toLowerCase()
           )
           if (exactMatch) {
-            dispatch({
-              type: ActionTypes.SELECT_OPTION,
-              option: exactMatch,
-            })
+            fireOnChangeAndDispatchSelect(exactMatch)
           } else {
             if (state.selectedOption) {
               dispatch({
@@ -336,10 +357,7 @@ export const ComboBox = forwardRef(
       } else if (event.key === 'Tab' || event.key === 'Enter') {
         event.preventDefault()
         if (state.focusedOption) {
-          dispatch({
-            type: ActionTypes.SELECT_OPTION,
-            option: state.focusedOption,
-          })
+          fireOnChangeAndDispatchSelect(state.focusedOption)
         }
       } else if (event.key === 'ArrowDown' || event.key === 'Down') {
         event.preventDefault()
@@ -348,21 +366,6 @@ export const ComboBox = forwardRef(
         event.preventDefault()
         focusSibling(dispatch, state, Direction.Previous)
       }
-    }
-
-    const changeElementValue = (
-      el: HTMLInputElement | HTMLSelectElement,
-      value = ''
-    ) => {
-      const elementToChange = el
-      elementToChange.value = value
-
-      const event = new CustomEvent('change', {
-        bubbles: true,
-        cancelable: true,
-        detail: { value },
-      })
-      elementToChange.dispatchEvent(event)
     }
 
     const isPristine =
@@ -501,11 +504,7 @@ export const ComboBox = forwardRef(
                   dispatch({ type: ActionTypes.FOCUS_OPTION, option: option })
                 }
                 onClick={(): void => {
-                  inputRef.current &&
-                    changeElementValue(inputRef.current, option.value)
-                  selectRef.current &&
-                    changeElementValue(selectRef.current, option.value)
-                  dispatch({ type: ActionTypes.SELECT_OPTION, option: option })
+                  fireOnChangeAndDispatchSelect(option)
                 }}
               >
                 {option.label}


### PR DESCRIPTION
# Summary

If a custom onChange prop is passed to the input or the select in ComboBox, that function will be called whenever a ComboBox option is selected. 

## Related Issues or PRs

Closes #1730 

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
