### PR TITLE
feat: accept prop for heading level (#1751)

### DIFF
--- a/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
@@ -65,7 +65,7 @@ export const smallCounters = (): React.ReactElement => (
   </StepIndicator>
 )
 
-export const heading = (): React.ReactElement => (
+export const customHeadingLevel = (): React.ReactElement => (
   <StepIndicator headingLevel="h2">
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />

--- a/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
@@ -64,3 +64,13 @@ export const smallCounters = (): React.ReactElement => (
     <StepIndicatorStep label="Review and submit" />
   </StepIndicator>
 )
+
+export const heading = (): React.ReactElement => (
+  <StepIndicator headingLevel="h2">
+    <StepIndicatorStep label="Personal information" status="complete" />
+    <StepIndicatorStep label="Household status" status="complete" />
+    <StepIndicatorStep label="Supporting documents" status="current" />
+    <StepIndicatorStep label="Signature" />
+    <StepIndicatorStep label="Review and submit" />
+  </StepIndicator>
+)

--- a/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
@@ -110,4 +110,34 @@ describe('StepIndicator component', () => {
     expect(queryByText(step3)).toBeInTheDocument()
     expect(getByRole('list')).toHaveClass('usa-step-indicator__segments')
   })
+
+  it('renders properly with a passed in heading level', () => {
+    const { getByRole, queryByTestId } = render(
+      <StepIndicator headingLevel="h2">
+        <StepIndicatorStep label={step1} status="complete" />
+        <StepIndicatorStep label={step2} status="current" />
+        <StepIndicatorStep label={step3} status="incomplete" />
+      </StepIndicator>
+    )
+
+    const stepIndicator = queryByTestId('step-indicator')
+
+    expect(stepIndicator).toBeInTheDocument()
+    expect(getByRole('heading', { level: 2 })).toBeInTheDocument()
+  })
+
+  it('renders properly with a default heading level', () => {
+    const { getByRole, queryByTestId } = render(
+      <StepIndicator>
+        <StepIndicatorStep label={step1} status="complete" />
+        <StepIndicatorStep label={step2} status="current" />
+        <StepIndicatorStep label={step3} status="incomplete" />
+      </StepIndicator>
+    )
+
+    const stepIndicator = queryByTestId('step-indicator')
+
+    expect(stepIndicator).toBeInTheDocument()
+    expect(getByRole('heading', { level: 4 })).toBeInTheDocument()
+  })
 })

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -53,8 +53,7 @@ export const StepIndicator = (
       className={classes}
       data-testid="step-indicator"
       aria-label="progress"
-      {...divProps}
-    >
+      {...divProps}>
       <ol className="usa-step-indicator__segments" {...listProps}>
         {children}
       </ol>

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -10,6 +10,7 @@ interface StepIndicatorProps {
   className?: string
   divProps?: JSX.IntrinsicElements['div']
   listProps?: JSX.IntrinsicElements['ol']
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }
 export const StepIndicator = (
   props: StepIndicatorProps
@@ -22,7 +23,10 @@ export const StepIndicator = (
     className,
     divProps,
     listProps,
+    headingLevel = 'h4',
   } = props
+
+  const Heading = headingLevel
 
   const classes = classnames(
     'usa-step-indicator',
@@ -49,12 +53,13 @@ export const StepIndicator = (
       className={classes}
       data-testid="step-indicator"
       aria-label="progress"
-      {...divProps}>
+      {...divProps}
+    >
       <ol className="usa-step-indicator__segments" {...listProps}>
         {children}
       </ol>
       <div className="usa-step-indicator__header">
-        <h4 className="usa-step-indicator__heading">
+        <Heading className="usa-step-indicator__heading">
           <span className="usa-step-indicator__heading-counter">
             <span className="usa-sr-only">Step</span>
             <span className="usa-step-indicator__current-step">
@@ -67,7 +72,7 @@ export const StepIndicator = (
           <span className="usa-step-indicator__heading-text">
             {currentStepLabel}
           </span>
-        </h4>
+        </Heading>
       </div>
     </div>
   )


### PR DESCRIPTION
# Summary

The heading level in the StepIndicator currently defaults to `h4`, and the inability to change this causes an accessibility issue when used in a document that doesn't include `h1`, `h2`, and `h3`.  We should be able to specify the desired heading level.

This PR introduces a `headingLevel` prop to the StepIndicator, so that any given instance can have any valid heading level. 

In order to make this a non-breaking change, if no heading level is specified, the component maintains the current behavior of defaulting to `h4`.

## Related Issues or PRs

Closes #1751 

## How To Test

In Storybook, select the Heading variant of the StepIndicator, and inspect the markup to see that it accords with the screenshot below.

Review new unit tests.

### Screenshots (optional)

![image](https://user-images.githubusercontent.com/8964335/148488586-d23739ad-1dea-4fbe-be67-4be91e22fde1.png)

