### PR TITLE
feat: Add focus method to ComboBox ref

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -120,7 +120,7 @@ export const withOtherFields = (): React.ReactElement => {
   )
 }
 
-export const externalClearSelection = (): React.ReactElement => {
+export const exposedRefMethods = (): React.ReactElement => {
   const ref = useRef<ComboBoxRef>()
 
   const fruitList = Object.entries(fruits).map(([value, key]) => ({
@@ -129,6 +129,7 @@ export const externalClearSelection = (): React.ReactElement => {
   }))
 
   const handleClearSelection = (): void => ref.current.clearSelection()
+  const handleFocus = (): void => ref.current.focus()
 
   return (
     <Form onSubmit={noop}>
@@ -142,6 +143,10 @@ export const externalClearSelection = (): React.ReactElement => {
       />
       <Button type="reset" onClick={handleClearSelection}>
         Clear Selected Value
+      </Button>
+
+      <Button type="button" onClick={handleFocus}>
+        Focus on input
       </Button>
     </Form>
   )

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -1717,6 +1717,33 @@ describe('ComboBox component', () => {
   })
 
   describe('exposed ref', () => {
+    it('can be used to focus on the text input', () => {
+      const comboRef = React.createRef<ComboBoxRef>()
+      const onChange = jest.fn()
+      const handleFocus = (): void => comboRef.current?.focus()
+
+      const { getByTestId } = render(
+        <>
+          <ComboBox
+            id="favorite-fruit"
+            name="favorite-fruit"
+            options={fruitOptions}
+            onChange={onChange}
+            ref={comboRef}
+          />
+          <button data-testid="focus-button" onClick={handleFocus}>
+            Focus
+          </button>
+        </>
+      )
+
+      const input = getByTestId('combo-box-input')
+      expect(input).not.toHaveFocus()
+
+      fireEvent.click(getByTestId('focus-button'))
+      expect(input).toHaveFocus()
+    })
+
     it('can be used to clear the selected value', () => {
       const comboRef = React.createRef<ComboBoxRef>()
       const onChange = jest.fn()

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -86,6 +86,7 @@ const Input = ({
 }
 
 export type ComboBoxRef = {
+  focus: () => void
   clearSelection: () => void
 }
 
@@ -197,6 +198,7 @@ export const ComboBox = forwardRef(
     useImperativeHandle(
       ref,
       () => ({
+        focus: (): void => dispatch({ type: ActionTypes.FOCUS_INPUT }),
         clearSelection: (): void =>
           dispatch({ type: ActionTypes.CLEAR_SELECTION }),
       }),

--- a/src/components/forms/ComboBox/useComboBox.ts
+++ b/src/components/forms/ComboBox/useComboBox.ts
@@ -12,6 +12,7 @@ export enum ActionTypes {
   UPDATE_FILTER,
   BLUR,
   CLEAR_SELECTION,
+  FOCUS_INPUT,
 }
 
 export type Action =
@@ -41,6 +42,9 @@ export type Action =
     }
   | {
       type: ActionTypes.CLEAR_SELECTION
+    }
+  | {
+      type: ActionTypes.FOCUS_INPUT
     }
 
 export interface State {
@@ -224,6 +228,12 @@ export const useComboBox = (
           filteredOptions: optionsList,
           focusedOption: undefined,
           statusText: '',
+        }
+      }
+      case ActionTypes.FOCUS_INPUT: {
+        return {
+          ...state,
+          focusMode: FocusMode.Input,
         }
       }
       default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,3 +123,4 @@ export { ProcessListHeading } from './components/ProcessList/ProcessListHeading/
 export { SiteAlert } from './components/SiteAlert/SiteAlert'
 
 export type { FileInputRef } from './components/forms/FileInput/FileInput'
+export type { ComboBoxRef } from './components/forms/ComboBox/ComboBox'


### PR DESCRIPTION
# Summary

Adds a `focus` method to the ComboBox ref that focuses on the underlying text input element.

## Related Issues or PRs

Closes #1875 

## How To Test

- In Storybook: view the **Combo box / Exposed Ref Methods** story and click on the "Focus on input" button to verify the text input has focus
- In an application: render the `<ComboBox>` component with a forwarded ref and call `ref.current.focus()` to focus on the text input.
- See https://github.com/USSF-ORBIT/ussf-portal-client/pull/478/files#diff-057c5f93639ae6992d18848a5acdcd2301f2de84a529488bc89cc228b58492f5 for example usage