### PR TITLE
docs: Add maintainer docs as per TDR 95

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for all files
-* @suzubara @gidjin @tinyels @sarboc @haworku @ahobson @brandonlenz @sirenaborracha
+* @suzubara @gidjin @haworku @ahobson @brandonlenz @sirenaborracha
 
 # Owners for PRs that change ONLY package.json and/or yarn.lock
 # Note: Reviewers for dependabot PRs that change these files are configured in .github/dependabot.yml  under `reviewers` 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ An example application, built with React-USWDS, can be found in the `/example` f
 
 **Table of Contents**
 
-- [Install](#install)
-  - [Pre-Release](#pre-release)
-- [Usage](#usage)
-- [Background](#background)
-  - [Non-Goals](#non-goals)
-- [Maintainers](#maintainers)
-- [Contributing](#contributing)
-- [License](#license)
+- [@trussworks/react-uswds](#trussworksreact-uswds)
+  - [Install](#install)
+  - [Usage](#usage)
+    - [Pre-Release](#pre-release)
+  - [Background](#background)
+    - [Non-Goals](#non-goals)
+  - [Active Maintainers](#active-maintainers)
+  - [Contributing](#contributing)
+    - [Quick links:](#quick-links)
+  - [License](#license)
+  - [Contributors ✨](#contributors-)
 
 ## Install
 
@@ -42,35 +45,6 @@ or
 ```
 npm i @trussworks/react-uswds
 ```
-
-### Pre-Release
-
-Pre-release packages are published to GitHub Packages every time code is pushed to the `main` branch. To use, you
-will need a [GitHub access
-token](https://docs.github.com/en/packages/publishing-and-managing-packages/about-github-packages#about-tokens)
-with the `read:packages` scope.
-
-1. Create an `.npmrc` with
-
-```
-//npm.pkg.github.com/:_authToken=YOUR_TOKEN_GOES_HERE
-@trussworks:registry=https://npm.pkg.github.com
-```
-
-or
-
-Create a `.yarnrc` file with
-
-```
-"@trussworks:registry" "https://npm.pkg.github.com"
-```
-
-2. In your `package.json`, use `"@trussworks/react-uswds": "next"`
-
-See [GitHub Packages with npm
-docs](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages)
-for more detailed information.
-
 ## Usage
 
 It is strongly suggested applications use the same version of USWDS that was used to build the version of ReactUSWDS they're using. A version mismatch may result in unexpected markup & CSS combinations.
@@ -93,6 +67,9 @@ If you aren't already using USWDS as a dependency, you also need to import USWDS
 
 Having issues? See [FAQs](./docs/faqs.md).
 
+### Pre-Release
+See [prelease.md](docs/prerelease.md)
+
 ## Background
 
 The primary deliverable is a published npm package that can be included as a dependency in other projects that use USWDS with React. In order for these components to be useful, they should follow best practices for accessible, semantic, markup; be well-tested across browsers and devices; and allow for an appropriate level of customization. We adhere to a set of [development guidelines](./docs/contributing.md#guidelines) as much as possible and use automation to enforce tests, linting, and other standards.
@@ -103,12 +80,11 @@ This is not meant to be a one-size-fits-all front end solution, We are starting 
 
 In the process, we expect to gain learnings around how to best abstract out UI code from implementation; how to better standardize and document front end code practices; and how to develop, maintain, and distribute a shared JS library in alignment with our [company values at Truss](https://truss.works/values).
 
-## Maintainers
+## Active Maintainers
 
-- [@suzubara](https://github.com/suzubara)
-- [@haworku](https://github.com/haworku)
-- [@brandonlenz](https://github.com/brandonlenz)
-- [@sirenaborracha](https://github.com/sirenaborracha)
+TBD
+
+We are starting to rotate Trussel maintainer responsibilities. Check out the [maintainers README](./docs/for_maintainers.md).
 
 ## Contributing
 

--- a/docs/for_maintainers.md
+++ b/docs/for_maintainers.md
@@ -1,4 +1,4 @@
-# For Maintainer
+# For Maintainers
 
 As of Truss TDR #95, Truss staff will be rotating maintainer responsibilities for ReactUSWDS.
 

--- a/docs/for_maintainers.md
+++ b/docs/for_maintainers.md
@@ -1,0 +1,66 @@
+# For Maintainer
+
+As of Truss TDR #95, Truss staff will be rotating maintainer responsibilities for ReactUSWDS.
+
+## Overview
+
+### Basic goal
+
+This role is intended to support sustainable project maintainorship of `@trussworks/react-uswds` and provide standard way to step in and out of leadership. Maintainer responsibilities are outlined below. Please note, maintainers do not need to be the primary contributors to the repository to fulfill these responsibilities.
+
+### Commitment
+
+The rotation lasts for a period of three months (one quarter).  The maintainer is expected to spend 15 hours/monthly on these duties. It is up to the individual to decide when to place this time on their calendars, but it needs to be spread throughout the weeks so that the project receives continuous attention. The recommendation is to spend 3-4 hours per week.
+
+### Billing
+
+This will be Truss billable work for Truss staff, assuming your project teams uses this library in your codebase.
+
+## Responsibilities
+
+### Support users of the library
+
+- Watch and moderate discussions on Github in alignment with [Truss values](https://truss.works/values)
+- Respond to initial issues and questions on the repo, ideally within ~ one week
+- Encourage outside contributors to put up PRs
+- Ensure storybook is deployed and up to date
+- Ensure issues are closed when finished
+- Ensure documentation is up to date and typo-free
+
+### Support developers working on the library
+
+- Advocate for closing long standing pull requests.
+- Triage incoming issues, ensure they have the right labels, and announce issues that are time sensitive to #react-uswds Truss slack channel
+- Watch [@uswds/uswds](https://github.com/uswds/uswds) for updates, create new issues in @trussworks/react-uswds as needed
+
+### Manage our Github tools
+
+- Keep Github-based project management tools up to date – e.g. ensure that Projects board reflects the next priority issues to be worked on.
+- Keep Github labels and milestones up to date - e.g. check that “Good first issue” label has issues ready to work on
+- Check that CI (testing, packaging, and deployment) is running without regular errors. If not, fix or else bring to #react-uswds Truss slack channel to resolve the issue.
+
+### Act as Release Manager for new library releases
+
+- Familiarize yourself with [conventional commits](https://www.conventionalcommits.org). We use this paradigm to automatically generate our release versioning and changelog.
+- Advocate for timely releases, soon after changes merged.
+- Make releases following the steps in our [releasing documentation](./releasing.md).
+- Announce when releases start and finish in #react-uswds Truss slack channel
+
+### If things are slow...
+
+Feel free to contribute to library with your time!
+
+## Tips and tricks
+
+### Onboarding and offboarding
+
+- See [for_trussels.md](for_trussels.md) for detailed onboarding instructions
+- TL;DR Add and remove yourself from "Active Maintainers" list in the [readme](../README.md) at the beginning and end of your term  and announce in #react-uswds
+
+### Addressing Security Alerts
+
+Typically any security alerts we receive will be related to third-party dependencies. This repo is currently configured so that Dependabot will automatically open PRs that fix dependency vulnerabilities, so ideally most of the time manual intervention is not needed. There may also be periods of time during which an alert is issued, but the related dependencies have not yet updated -- in this case, we usually choose to accept the risk of waiting until the updates have been released. However, if an exceptional case comes up -- such as a high severity vulnerability or even a vulnerability within this library -- and you aren't sure how to handle it, you can ask for help in one of the following Truss Slack channels (in order of relevance): #react-uswds, #g-frontend, #infrasec, #engineering
+
+### Merging External PRs
+
+Currently our CI cannot run on external PRs (work from outside the Truss organization) and this prevents merge. Instead, we pull PRs into a separate branch that a CODEOWNER can create [using this script](https://github.com/jklukas/git-push-fork-to-upstream-branch). We then close the external contribution PR [with a comment](https://github.com/trussworks/react-uswds/pull/375#issuecomment-668116811) explaining what's going. This allows automation to run properly.

--- a/docs/for_trussels.md
+++ b/docs/for_trussels.md
@@ -18,7 +18,7 @@ First of all, we’re so excited you want to be an active maintainer on this pro
 - [ ] _For Maintainers:_ Add yourself to main project README "Active Maintainers" list.
 - [ ] _For Maintainers:_ Ping in #react-uswds to request access to the npm org so you can publish new releases
 - [ ] _For Maintainers:_ Ping in #react-uswds to request admin privileges to the [Happo Account](https://happo.io/)
-- [ ] _Optional:_ Add yourself to the `contributors` list in the [package.json](../all-contributorsrc.json),
+- [ ] _Optional:_ Add yourself to the `contributors` list in the [contributors file](../all-contributorsrc.json),
 - [ ] _Optional: Add yourself to [CODEOWNERS](../CODEOWNERS) if you'd like to automatically be requested to review PRs.
 
 If you've completed all of the above and are wondering what to do next, here are some ideas!

--- a/docs/for_trussels.md
+++ b/docs/for_trussels.md
@@ -41,7 +41,7 @@ Please make sure to do the following before you wash your hands of responsibilit
   - [ ] Unassign yourself from any corresponding issues
   - It’s ideal if you are able to help answer any questions that arise from handing off work, but we understand if your new commitments don't allow for it! 
 - [ ] _For Maintainers:_ Open a new PR that removes yourself from the Active Maintainers list in the [readme](../README.md).
-- [] Remove yourself from [CODEOWNERS](../CODEOWNERS) so you don't get PR requests that you won't have time to review.
+- [ ] Remove yourself from [CODEOWNERS](../CODEOWNERS) so you don't get PR requests that you won't have time to review.
 - **_Don't_** remove yourself from `package.json` contributors! You did good work on this project and that should be recognized.
 - [ ] _Optional:_ You don’t need to have npm access revoked, but you can if you want.
 - [ ] _Optional:_ You don’t need to have Happo admin access revoked, but you can if you want.

--- a/docs/for_trussels.md
+++ b/docs/for_trussels.md
@@ -37,7 +37,7 @@ Please make sure to do the following before you wash your hands of responsibilit
 - **If you have any in-progress work that you won't be able to complete:**
   - [ ] Make sure all of your commits have been pushed up to a branch so nothing gets lost on your local machine
   - [ ] Open a draft PR for your branch, and use that to annotate any remaining work, TODOs, open questions, etc. as well as the overarching strategy you had in mind. The more documentation you leave, the easier it will be for someone else to finish your work!
-  - [ ] If there is another active maintainers who are planning to pick up your work, comment on the PR and tag them so it's clear who will be picking it up. If there aren't, or you aren't sure, comment on the PR saying the work needs a new assignee or else it will go stale.
+  - [ ] If there is another active maintainer who is planning to pick up your work, comment on the PR and tag them so it's clear who will be picking it up. If there isn't, or you aren't sure, comment on the PR saying the work needs a new assignee or else it will go stale.
   - [ ] Unassign yourself from any corresponding issues
   - It’s ideal if you are able to help answer any questions that arise from handing off work, but we understand if your new commitments don't allow for it! 
 - [ ] _For Maintainers:_ Open a new PR that removes yourself from the Active Maintainers list in the [readme](../README.md).

--- a/docs/for_trussels.md
+++ b/docs/for_trussels.md
@@ -8,43 +8,18 @@ We have a Truss Slack channel dedicated to discussing this project (**#react-usw
 
 ## Active Maintainers
 
-Anyone may feel free to contribute to this library, regardless of what other projects they may be staffed on. For example, if you are on a client project that happens to use this library, it makes sense that you might want to add new features or make bug fixes as you encounter them in a real-life implementation.
-
-However, in some cases you may find yourself spending a more significant amount of time to help maintain ReactUSWDS, such as if you are on Reserve. In that case, it's helpful to have a designation of **_active maintainer_**, which will indicate certain additional responsibilities and a higher level of involvement than other contributors.
-
-Regardless of whether you are on client work or Reserve, it is _up to each individual_ to delineate themselves as an active maintainer, and perform the following on- or off-boarding tasks as needed.
-
-### Active maintainer responsibilities include:
-
-- Maintain a presence in the #react-uswds channel, especially to answer any implementation questions from Trussels who are _not_ active maintainers
-- Watch [USWDS](https://github.com/uswds/uswds) updates, and create new issues needed to help this project stay up-to-date with them
-- Participate in PR reviews, issue discussion, and project roadmap planning
-- Address any security alerts that come up promptly (see below)
-- Shepherd library releases forward and publish to npm. See [releasing documentation](./releasing.md).
-- Maintain the project board.
-- Prevent PRs and issues from becoming stale, and clean up the ones that do.
-- Moderate discussions to keep alignment with [Truss values](https://truss.works/values)
-- Administrative the repo's [Happo Account](https://happo.io/). Once you have access, log into Happo.io with your Truss email and you will be able to approve/reject changes on PRs. [Happo docs](https://docs.happo.io/docs/getting-started) have more information.
-
-### Addressing Security Alerts
-
-Typically any security alerts we receive will be related to third-party dependencies. This repo is currently configured so that Dependabot will automatically open PRs that fix dependency vulnerabilities, so ideally most of the time manual intervention is not needed. There may also be periods of time during which an alert is issued, but the related dependencies have not yet updated -- in this case, we usually choose to accept the risk of waiting until the updates have been released. However, if an exceptional case comes up -- such as a high severity vulnerability or even a vulnerability within this library -- and you aren't sure how to handle it, you can ask for help in one of the following Truss Slack channels (in order of relevance): #react-uswds, #g-frontend, #infrasec, #engineering
-
-### Merging External PRs
-
-Currently our CI cannot run on external PRs (work from outside the Truss organization) and this prevents merge. Instead, we pull PRs into a separate branch that a CODEOWNER creates [using this script](https://github.com/jklukas/git-push-fork-to-upstream-branch). We then close the external contribution PR [with a comment](https://github.com/trussworks/react-uswds/pull/375#issuecomment-668116811) explaining what's going. This allows automation to run properly. This is temporary solution.
-
+See ["For Maintainers" README](for_maintainers.md). There are also some "For Maintainers" notes below.
 ## Onboarding
 
 First of all, we’re so excited you want to be an active maintainer on this project! Here are the things you should make sure to do:
 
 - [ ] Join the #react-uswds Slack channel.
 - [ ] If you haven't already, be sure to familiarize yourself with this repo, especially the docs on [contributing](./contributing.md) and [releasing](./releasing.md). Also, review [recent releases](https://github.com/trussworks/react-uswds/releases).
-- [ ] Open a new PR that adds yourself to the Active Maintainers list in the [readme](../README.md).
-  - [ ] _Optional:_ Speak with another active maintainer and request admin privileges to the [Happo Account](https://happo.io/)
-  - [ ] _Optional:_ Add yourself to the `contributors` list in the [package.json](../package.json),
-  - [ ] \_Optional: Add yourself to [CODEOWNERS](../CODEOWNERS) if you'd like to automatically be requested to review PRs.
-- [ ] _Optional:_ If you want access to the npm org so you can publish new releases, ping `@npm-admins` in Slack
+- [ ] _For Maintainers:_ Add yourself to main project README "Active Maintainers" list.
+- [ ] _For Maintainers:_ Ping in #react-uswds to request access to the npm org so you can publish new releases
+- [ ] _For Maintainers:_ Ping in #react-uswds to request admin privileges to the [Happo Account](https://happo.io/)
+- [ ] _Optional:_ Add yourself to the `contributors` list in the [package.json](../all-contributorsrc.json),
+- [ ] _Optional: Add yourself to [CODEOWNERS](../CODEOWNERS) if you'd like to automatically be requested to review PRs.
 
 If you've completed all of the above and are wondering what to do next, here are some ideas!
 
@@ -54,21 +29,20 @@ If you've completed all of the above and are wondering what to do next, here are
     - especially any that are labeled `good first issue` if this is your first time contributing to ReactUSWDS
   - Issues in the **Needs requirements** column are undergoing active discussion and would probably benefit from your point of view!
 - Browse [open issues](https://github.com/trussworks/react-uswds/issues) to see if there are any new issues that need to be labeled or prioritized
-- Check in with any other active maintainers about what areas are in need of help
-
+  
 ## Offboarding
 
-We’re equally excited that you’ll be taking something off your plate and moving on to something new! Please make sure to do the following before you wash your hands of responsibilities:
+Please make sure to do the following before you wash your hands of responsibilities:
 
 - **If you have any in-progress work that you won't be able to complete:**
   - [ ] Make sure all of your commits have been pushed up to a branch so nothing gets lost on your local machine
   - [ ] Open a draft PR for your branch, and use that to annotate any remaining work, TODOs, open questions, etc. as well as the overarching strategy you had in mind. The more documentation you leave, the easier it will be for someone else to finish your work!
-  - [ ] If there are other active maintainers who are planning to pick up your work, comment on the PR and tag them so it's clear who will be picking it up. If there aren't, or you aren't sure, comment on the PR saying the work needs a new assignee or else it will go stale.
+  - [ ] If there is another active maintainers who are planning to pick up your work, comment on the PR and tag them so it's clear who will be picking it up. If there aren't, or you aren't sure, comment on the PR saying the work needs a new assignee or else it will go stale.
   - [ ] Unassign yourself from any corresponding issues
-  - It’s ideal if you are able to help answer any questions that arise from handing off work, but we understand if your new commitments don't allow for it! Don't feel pressure to stay available after offboarding.
-- [ ] Open a new PR that removes yourself from the Active Maintainers list in the [readme](../README.md).
-  - You can also remove yourself from [CODEOWNERS](../CODEOWNERS) so you don't get PR requests that you won't have time to review.
-  - **_Don't_** remove yourself from `package.json` contributors! You did good work on this project and that should be recognized.
+  - It’s ideal if you are able to help answer any questions that arise from handing off work, but we understand if your new commitments don't allow for it! 
+- [ ] _For Maintainers:_ Open a new PR that removes yourself from the Active Maintainers list in the [readme](../README.md).
+- [] Remove yourself from [CODEOWNERS](../CODEOWNERS) so you don't get PR requests that you won't have time to review.
+- **_Don't_** remove yourself from `package.json` contributors! You did good work on this project and that should be recognized.
 - [ ] _Optional:_ You don’t need to have npm access revoked, but you can if you want.
 - [ ] _Optional:_ You don’t need to have Happo admin access revoked, but you can if you want.
 - [ ] _Optional: If you want to,_ feel free to leave the #react-uswds Slack channels

--- a/docs/prerelease.md
+++ b/docs/prerelease.md
@@ -1,0 +1,27 @@
+# Pre-release
+
+Pre-release packages are published to GitHub Packages every time code is pushed to the `main` branch. To use, you
+will need a [GitHub access
+token](https://docs.github.com/en/packages/publishing-and-managing-packages/about-github-packages#about-tokens)
+with the `read:packages` scope.
+
+1. Create an `.npmrc` with
+
+```
+//npm.pkg.github.com/:_authToken=YOUR_TOKEN_GOES_HERE
+@trussworks:registry=https://npm.pkg.github.com
+```
+
+or
+
+Create a `.yarnrc` file with
+
+```
+"@trussworks:registry" "https://npm.pkg.github.com"
+```
+
+2. In your `package.json`, use `"@trussworks/react-uswds": "next"`
+
+See [GitHub Packages with npm
+docs](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages)
+for more detailed information.


### PR DESCRIPTION
# Summary
- Add for_maintainers.md doc
- Update for_trussels.md doc accordingly
- Make "Active Maintainers" TBD on README as we start rotating responsibilities 
- Update CODEOWNERS to remove non-trussels
- Move pre-release docs to its own file to have less content on the main README