### PR TITLE
chore: Update CODEOWNERS and active maintainer list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for all files
-* @suzubara @gidjin @haworku @ahobson @brandonlenz @sirenaborracha @kylehilltruss
+* @suzubara @gidjin @haworku @ahobson @brandonlenz @sirenaborracha @kylehilltruss @rogeruiz
 
 # Owners for PRs that change ONLY package.json and/or yarn.lock
 # Note: Reviewers for dependabot PRs that change these files are configured in .github/dependabot.yml  under `reviewers` 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In the process, we expect to gain learnings around how to best abstract out UI c
 
 ## Active Maintainers
 
-- [Kyle Hill](https://github.com/kylehilltruss)
+- [Roger Steve Ruiz](https://github.com/rogeruiz)
 
 We are starting to rotate Trussel maintainer responsibilities. Check out the [maintainers README](./docs/for_maintainers.md).
 


### PR DESCRIPTION
# Summary

I'm adding my GitHub username and information to the documentation and `CODEOWNERS` file.

## How To Test

You can test this by verifying that I've followed the documentation around maintainer-ship.
