### PR TITLE
ci: Improve Happo Consistency

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -14,6 +14,7 @@ export default {
         })
         document.querySelector('.usa-tooltip__trigger').dispatchEvent(event)
       },
+      waitFor: (): Element => document.querySelector('.usa-tooltip__body'),
     },
     docs: {
       description: {

--- a/src/components/forms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/forms/DatePicker/DatePicker.stories.tsx
@@ -90,6 +90,11 @@ export const withDefaultInvalidValue = (): React.ReactElement => (
     minDate="2020-01-01"
   />
 )
+withDefaultValue.parameters = {
+  happo: {
+    waitForCOntent: '1988-05-16',
+  },
+}
 
 export const withMinMaxInSameMonth = (): React.ReactElement => (
   <DatePicker
@@ -117,6 +122,11 @@ export const withRangeDate = (): React.ReactElement => (
     rangeDate="2021-01-08"
   />
 )
+withRangeDate.parameters = {
+  happo: {
+    waitForCOntent: '2021-01-20',
+  },
+}
 
 export const withLocalizations = (): React.ReactElement => (
   <DatePicker id="birthdate" name="birthdate" i18n={sampleLocalization} />


### PR DESCRIPTION
# Summary

Hopefully resolves some spurious diffs we see on almost every PR with tooltips and occasionally with default value DatePicker.

## How To Test

First test will be making sure that happo completes correctly on this branch/PR. It is somewhat unclear how beforeScreenshot and waitFor play together if used simultaneously.
There may also still be happo diffs on this PR (I expect it in fact). I don't think the issue will be resolved until the base branch _and_ PR branches both have this code. 

## References
https://docs.happo.io/docs/storybook#waiting-for-content

### Screenshots (optional)
