### PR TITLE
ci: exclude ios-safari from happo on Tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -6,6 +6,8 @@ export default {
   component: Tooltip,
   parameters: {
     happo: {
+      // Comparing on ios-safari causes spurious diffs.
+      targets: ['chrome', 'firefox', 'internet explorer', 'safari'],
       beforeScreenshot: (): void => {
         const event = new MouseEvent('mouseover', {
           view: window,


### PR DESCRIPTION
# Summary

Exclude Happo from checking Tooltip on ios-safari, which has frequently caused problems with ci checks

