### PR TITLE
feat(ci): add automerge priority label for Kodiak

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -4,6 +4,7 @@ version = 1
 automerge_label= "type: automerge"
 require_automerge_label = true
 delete_branch_on_merge = true
+priority_merge_label= "type: automerge-priority"
 
 [approve]
 auto_approve_usernames = ["dependabot"]


### PR DESCRIPTION
# Summary

Adds a label association for Kodiak to prioritize PRs in its automerge queue

https://kodiakhq.com/docs/config-reference#mergepriority_merge_label