### PR TITLE
ci: change expected date format for DatePicker in Happo

### DIFF
--- a/src/components/forms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/forms/DatePicker/DatePicker.stories.tsx
@@ -92,7 +92,7 @@ export const withDefaultInvalidValue = (): React.ReactElement => (
 )
 withDefaultValue.parameters = {
   happo: {
-    waitForContent: '1988-05-16',
+    waitForContent: '05/16/1988',
   },
 }
 
@@ -124,7 +124,7 @@ export const withRangeDate = (): React.ReactElement => (
 )
 withRangeDate.parameters = {
   happo: {
-    waitForContent: '2021-01-20',
+    waitForContent: '01/20/2021',
   },
 }
 


### PR DESCRIPTION
# Summary

Expects to find `MM/DD/YYYY` in Happo screenshots instead of `YYYY-MM-DD`

Even though the component returns the selected date in `yyyy-mm-dd` format, it displays as `mm/dd/yyyy`, so I believe we should use that format in the `waitforcontent` preceding the happo check.

### Screenshots (optional)
<img width="513" alt="image" src="https://user-images.githubusercontent.com/7664177/163497499-f9fca595-f8a4-4d89-a932-437ee37a2371.png">

