### PR TITLE
ci: Fix Prettier bracket lines

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
-trailingComma: "es5"
+trailingComma: 'es5'
 semi: false
 singleQuote: true
-jsxBracketSameLine: true
+bracketSameLine: true

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -45,8 +45,7 @@ export const AccordionItem = ({
           aria-expanded={expanded}
           aria-controls={id}
           data-testid={`accordionButton_${id}`}
-          onClick={handleToggle}
-        >
+          onClick={handleToggle}>
           {title}
         </button>
       </Heading>
@@ -54,8 +53,7 @@ export const AccordionItem = ({
         id={id}
         data-testid={`accordionItem_${id}`}
         className={contentClasses}
-        hidden={!expanded}
-      >
+        hidden={!expanded}>
         {content}
       </div>
     </>
@@ -102,8 +100,7 @@ export const Accordion = ({
     <div
       className={classes}
       data-testid="accordion"
-      aria-multiselectable={multiselectable || undefined}
-    >
+      aria-multiselectable={multiselectable || undefined}>
       {items.map((item, i) => (
         <AccordionItem
           key={`accordionItem_${i}`}

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -118,8 +118,7 @@ export const withCTA = (): React.ReactElement => (
       <Button type="button" outline>
         Click here
       </Button>
-    }
-  >
+    }>
     {testText}
   </Alert>
 )

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,8 +48,7 @@ export const Button = ({
       className={classes}
       onClick={onClick}
       data-testid="button"
-      {...defaultProps}
-    >
+      {...defaultProps}>
       {children}
     </button>
   )

--- a/src/components/Collection/Collection.stories.tsx
+++ b/src/components/Collection/Collection.stories.tsx
@@ -116,8 +116,7 @@ export const collectionWithThumbnailItems = (): React.ReactElement => (
       <CollectionItem
         variantComponent={
           <CollectionThumbnail src={gearsImage} alt="Alt text" />
-        }
-      >
+        }>
         <CollectionHeading headingLevel="h3">
           <Link href="https://www.performance.gov/presidents-winners-press-release/">
             Gears of Government President’s Award winners
@@ -144,8 +143,7 @@ export const collectionWithThumbnailItems = (): React.ReactElement => (
       <CollectionItem
         variantComponent={
           <CollectionThumbnail src={wosb1Image} alt="Alt text" />
-        }
-      >
+        }>
         <CollectionHeading headingLevel="h3">
           <Link href="https://www.performance.gov/sba-wosb-dashboard/">
             Women-owned small business dashboard
@@ -168,8 +166,7 @@ export const collectionWithThumbnailItems = (): React.ReactElement => (
       <CollectionItem
         variantComponent={
           <CollectionThumbnail src={septImage} alt="Alt text" />
-        }
-      >
+        }>
         <CollectionHeading headingLevel="h3">
           <Link href="https://www.performance.gov/sba-wosb-dashboard/">
             September 2020 updates show progress on cross-agency and agency
@@ -294,8 +291,7 @@ export const collectionWithMixedItems = (): React.ReactElement => (
       <CollectionItem
         variantComponent={
           <CollectionThumbnail src={wosb1Image} alt="Alt text" />
-        }
-      >
+        }>
         <CollectionHeading headingLevel="h3">
           <Link href="https://www.performance.gov/sba-wosb-dashboard/">
             Women-owned small business dashboard
@@ -328,8 +324,7 @@ export const collectionWithMixedItems = (): React.ReactElement => (
       <CollectionItem
         variantComponent={
           <CollectionCalendarDate datetime="2020-09-17T12:00:00+01:00" />
-        }
-      >
+        }>
         <CollectionHeading headingLevel="h3">
           <Link href="https://www.performance.gov/sba-wosb-dashboard/">
             September 2020 updates show progress on cross-agency and agency

--- a/src/components/Identifier/Identifier/Identifier.stories.tsx
+++ b/src/components/Identifier/Identifier/Identifier.stories.tsx
@@ -311,26 +311,27 @@ export const taxDisclaimerSpanish = (): React.ReactElement => (
   </Identifier>
 )
 
-export const taxDisclaimerAndMultipleParentsAndLogos = (): React.ReactElement => (
-  <Identifier>
-    <IdentifierMasthead aria-label="Agency identifier">
-      <IdentifierLogos>
-        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-        <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
-      </IdentifierLogos>
-      <IdentifierIdentity domain="domain.edu.mil.gov">
-        {`An official website of the `}
-        <Link href="#">Test Agency Name</Link>
-        {` and the `}
-        <Link href="#">Other Test Agency Name</Link>
-        {`. Produced and published at taxpayer expense.`}
-      </IdentifierIdentity>
-    </IdentifierMasthead>
-    <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
-      {testLinks}
-    </IdentifierLinks>
-    <IdentifierGov aria-label="U.S. government information and services">
-      {testIdentifierGovContent}
-    </IdentifierGov>
-  </Identifier>
-)
+export const taxDisclaimerAndMultipleParentsAndLogos =
+  (): React.ReactElement => (
+    <Identifier>
+      <IdentifierMasthead aria-label="Agency identifier">
+        <IdentifierLogos>
+          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+          <IdentifierLogo href="#">{testIdentifierLogo}</IdentifierLogo>
+        </IdentifierLogos>
+        <IdentifierIdentity domain="domain.edu.mil.gov">
+          {`An official website of the `}
+          <Link href="#">Test Agency Name</Link>
+          {` and the `}
+          <Link href="#">Other Test Agency Name</Link>
+          {`. Produced and published at taxpayer expense.`}
+        </IdentifierIdentity>
+      </IdentifierMasthead>
+      <IdentifierLinks navProps={{ 'aria-label': 'Important links' }}>
+        {testLinks}
+      </IdentifierLinks>
+      <IdentifierGov aria-label="U.S. government information and services">
+        {testIdentifierGovContent}
+      </IdentifierGov>
+    </Identifier>
+  )

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -57,8 +57,7 @@ export const defaultModal = (): React.ReactElement => {
           ref={modalRef}
           id="example-modal-1"
           aria-labelledby="modal-1-heading"
-          aria-describedby="modal-1-description"
-        >
+          aria-describedby="modal-1-description">
           <ModalHeading id="modal-1-heading">
             Are you sure you want to continue?
           </ModalHeading>
@@ -76,8 +75,7 @@ export const defaultModal = (): React.ReactElement => {
                 modalRef={modalRef}
                 closer
                 unstyled
-                className="padding-105 text-center"
-              >
+                className="padding-105 text-center">
                 Go back
               </ModalToggleButton>
             </ButtonGroup>
@@ -101,8 +99,7 @@ export const largeModal = (): React.ReactElement => {
         isLarge
         aria-labelledby="modal-2-heading"
         aria-describedby="modal-2-description"
-        id="example-modal-2"
-      >
+        id="example-modal-2">
         <ModalHeading id="modal-2-heading">
           Are you sure you want to continue?
         </ModalHeading>
@@ -120,8 +117,7 @@ export const largeModal = (): React.ReactElement => {
               modalRef={modalRef}
               closer
               unstyled
-              className="padding-105 text-center"
-            >
+              className="padding-105 text-center">
               Go back
             </ModalToggleButton>
           </ButtonGroup>
@@ -144,8 +140,7 @@ export const forceActionModal = (): React.ReactElement => {
         forceAction
         aria-labelledby="modal-3-heading"
         aria-describedby="modal-3-description"
-        id="example-modal-3"
-      >
+        id="example-modal-3">
         <ModalHeading id="modal-3-heading">
           Your session will end soon.
         </ModalHeading>
@@ -165,8 +160,7 @@ export const forceActionModal = (): React.ReactElement => {
               modalRef={modalRef}
               closer
               unstyled
-              className="padding-105 text-center"
-            >
+              className="padding-105 text-center">
               Sign out
             </ModalToggleButton>
           </ButtonGroup>
@@ -188,8 +182,7 @@ export const customFocusElementModal = (): React.ReactElement => {
         ref={modalRef}
         id="example-modal-1"
         aria-labelledby="modal-1-heading"
-        aria-describedby="modal-1-description"
-      >
+        aria-describedby="modal-1-description">
         <ModalHeading id="modal-1-heading">
           Are you sure you want to continue?
         </ModalHeading>
@@ -211,8 +204,7 @@ export const customFocusElementModal = (): React.ReactElement => {
               modalRef={modalRef}
               closer
               unstyled
-              className="padding-105 text-center"
-            >
+              className="padding-105 text-center">
               Go back
             </ModalToggleButton>
           </ButtonGroup>
@@ -236,8 +228,7 @@ export const initiallyOpenModal = (): React.ReactElement => {
           id="example-modal-1"
           aria-labelledby="modal-1-heading"
           aria-describedby="modal-1-description"
-          isInitiallyOpen
-        >
+          isInitiallyOpen>
           <ModalHeading id="modal-1-heading">
             Are you sure you want to continue?
           </ModalHeading>
@@ -255,8 +246,7 @@ export const initiallyOpenModal = (): React.ReactElement => {
                 modalRef={modalRef}
                 closer
                 unstyled
-                className="padding-105 text-center"
-              >
+                className="padding-105 text-center">
                 Go back
               </ModalToggleButton>
             </ButtonGroup>

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -64,8 +64,7 @@ const ExampleModal = ({
         aria-labelledby="modal-1-heading"
         aria-describedby="modal-1-description"
         forceAction={forceAction}
-        modalRoot="#modal-root"
-      >
+        modalRoot="#modal-root">
         <ModalHeading id="modal-1-heading">
           Are you sure you want to continue?
         </ModalHeading>
@@ -79,8 +78,7 @@ const ExampleModal = ({
             <Button
               type="button"
               data-close-modal
-              onClick={(e) => modalRef.current?.toggleModal(e, false)}
-            >
+              onClick={(e) => modalRef.current?.toggleModal(e, false)}>
               Continue without saving
             </Button>
             <Button
@@ -88,8 +86,7 @@ const ExampleModal = ({
               data-close-modal
               unstyled
               className="padding-105 text-center"
-              onClick={(e) => modalRef.current?.toggleModal(e, false)}
-            >
+              onClick={(e) => modalRef.current?.toggleModal(e, false)}>
               Go back
             </Button>
           </ButtonGroup>
@@ -112,8 +109,7 @@ const ExampleModalWithFocusElement = (): React.ReactElement => {
         id="example-modal-1"
         aria-labelledby="modal-1-heading"
         aria-describedby="modal-1-description"
-        modalRoot="#modal-root"
-      >
+        modalRoot="#modal-root">
         <ModalHeading id="modal-1-heading">
           Are you sure you want to continue?
         </ModalHeading>
@@ -130,8 +126,7 @@ const ExampleModalWithFocusElement = (): React.ReactElement => {
             <Button
               type="button"
               data-close-modal
-              onClick={(e) => modalRef.current?.toggleModal(e, false)}
-            >
+              onClick={(e) => modalRef.current?.toggleModal(e, false)}>
               Continue without saving
             </Button>
             <Button
@@ -139,8 +134,7 @@ const ExampleModalWithFocusElement = (): React.ReactElement => {
               data-close-modal
               unstyled
               className="padding-105 text-center"
-              onClick={(e) => modalRef.current?.toggleModal(e, false)}
-            >
+              onClick={(e) => modalRef.current?.toggleModal(e, false)}>
               Go back
             </Button>
           </ButtonGroup>
@@ -191,8 +185,7 @@ describe('Modal component', () => {
       <Modal
         id={testModalId}
         aria-labelledby="modal-label"
-        aria-describedby="modal-description"
-      >
+        aria-describedby="modal-description">
         Test modal
       </Modal>
     )

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -172,8 +172,7 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
         data-force-action={forceAction}
         isVisible={isOpen}
         handleClose={closeModal}
-        forceAction={forceAction}
-      >
+        forceAction={forceAction}>
         <ModalWindow
           modalId={id}
           {...divProps}
@@ -181,8 +180,7 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
           isLarge={isLarge}
           forceAction={forceAction}
           tabIndex={-1}
-          handleClose={closeModal}
-        >
+          handleClose={closeModal}>
           {children}
         </ModalWindow>
       </ModalWrapper>

--- a/src/components/Modal/ModalCloseButton/ModalCloseButton.tsx
+++ b/src/components/Modal/ModalCloseButton/ModalCloseButton.tsx
@@ -18,8 +18,7 @@ export const ModalCloseButton = ({
       aria-label="Close this window"
       onClick={handleClose}
       data-close-modal
-      type="button"
-    >
+      type="button">
       <Icon.Close aria-hidden="true" />
     </Button>
   )

--- a/src/components/Modal/ModalOpenLink.test.tsx
+++ b/src/components/Modal/ModalOpenLink.test.tsx
@@ -103,8 +103,7 @@ describe('ModalOpenLink', () => {
       <ModalOpenLink<CustomLinkProps>
         to="#testModal"
         asCustom={CustomLink}
-        modalRef={modalRef}
-      >
+        modalRef={modalRef}>
         Open modal
       </ModalOpenLink>
     )

--- a/src/components/Modal/ModalToggleButton.tsx
+++ b/src/components/Modal/ModalToggleButton.tsx
@@ -53,8 +53,7 @@ export const ModalToggleButton = ({
       {...dataProps}
       type="button"
       aria-controls={modalRef?.current?.modalId}
-      onClick={handleClick}
-    >
+      onClick={handleClick}>
       {children}
     </Button>
   )

--- a/src/components/Modal/ModalWindow/ModalWindow.tsx
+++ b/src/components/Modal/ModalWindow/ModalWindow.tsx
@@ -41,8 +41,7 @@ export const ModalWindowForwardRef: React.ForwardRefRenderFunction<
       data-testid="modalWindow"
       className={classes}
       ref={ref}
-      data-force-action={forceAction}
-    >
+      data-force-action={forceAction}>
       <div className="usa-modal__content">
         <div className="usa-modal__main">{children}</div>
         {!forceAction && (

--- a/src/components/Modal/ModalWrapper/ModalWrapper.test.tsx
+++ b/src/components/Modal/ModalWrapper/ModalWrapper.test.tsx
@@ -10,8 +10,7 @@ describe('ModalWrapper component', () => {
         id="testModal"
         isVisible={false}
         forceAction={false}
-        handleClose={jest.fn()}
-      >
+        handleClose={jest.fn()}>
         children
       </ModalWrapper>
     )

--- a/src/components/Modal/ModalWrapper/ModalWrapper.tsx
+++ b/src/components/Modal/ModalWrapper/ModalWrapper.tsx
@@ -34,8 +34,7 @@ export const ModalWrapperForwardRef: React.ForwardRefRenderFunction<
         data-testid="modalOverlay"
         className="usa-modal-overlay"
         onClick={forceAction ? undefined : handleClose}
-        aria-controls={id}
-      >
+        aria-controls={id}>
         {children}
       </div>
     </div>

--- a/src/components/Modal/OpenModal.stories.tsx
+++ b/src/components/Modal/OpenModal.stories.tsx
@@ -44,13 +44,11 @@ export const defaultModal = (
       handleClose={argTypes.handleClose}
       forceAction={false}
       aria-labelledby="modal-1-heading"
-      aria-describedby="modal-1-description"
-    >
+      aria-describedby="modal-1-description">
       <ModalWindow
         modalId="example-modal-1"
         tabIndex={-1}
-        handleClose={argTypes.handleClose}
-      >
+        handleClose={argTypes.handleClose}>
         <ModalHeading id="modal-1-heading">
           Are you sure you want to continue?
         </ModalHeading>
@@ -68,8 +66,7 @@ export const defaultModal = (
               type="button"
               onClick={argTypes.handleClose}
               unstyled
-              className="padding-105 text-center"
-            >
+              className="padding-105 text-center">
               Go back
             </Button>
           </ButtonGroup>
@@ -90,14 +87,12 @@ export const largeModal = (
       handleClose={argTypes.handleClose}
       forceAction={false}
       aria-labelledby="modal-2-heading"
-      aria-describedby="modal-2-description"
-    >
+      aria-describedby="modal-2-description">
       <ModalWindow
         isLarge
         modalId="example-modal-2"
         tabIndex={-1}
-        handleClose={argTypes.handleClose}
-      >
+        handleClose={argTypes.handleClose}>
         <ModalHeading id="modal-2-heading">
           Are you sure you want to continue?
         </ModalHeading>
@@ -115,8 +110,7 @@ export const largeModal = (
               type="button"
               onClick={argTypes.handleClose}
               unstyled
-              className="padding-105 text-center"
-            >
+              className="padding-105 text-center">
               Go back
             </Button>
           </ButtonGroup>
@@ -137,14 +131,12 @@ export const forceActionModal = (
       handleClose={argTypes.handleClose}
       forceAction={true}
       aria-labelledby="modal-3-heading"
-      aria-describedby="modal-3-description"
-    >
+      aria-describedby="modal-3-description">
       <ModalWindow
         forceAction
         modalId="example-modal-3"
         tabIndex={-1}
-        handleClose={argTypes.handleClose}
-      >
+        handleClose={argTypes.handleClose}>
         <ModalHeading id="modal-3-heading">
           Your session will end soon.
         </ModalHeading>
@@ -164,8 +156,7 @@ export const forceActionModal = (
               type="button"
               onClick={argTypes.handleClose}
               unstyled
-              className="padding-105 text-center"
-            >
+              className="padding-105 text-center">
               Sign out
             </Button>
           </ButtonGroup>

--- a/src/components/Search/Search.test.tsx
+++ b/src/components/Search/Search.test.tsx
@@ -39,8 +39,7 @@ describe('Search component', () => {
       <Search
         onSubmit={mockSubmit}
         label="Buscar"
-        i18n={sampleLocalization}
-      ></Search>
+        i18n={sampleLocalization}></Search>
     )
 
     expect(queryByLabelText('Buscar')).toBeInTheDocument()

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -50,8 +50,7 @@ export const Search = ({
       className={classes}
       role="search"
       search={true}
-      {...formProps}
-    >
+      {...formProps}>
       <Label srOnly={true} htmlFor={inputId}>
         {label}
       </Label>

--- a/src/components/SiteAlert/SiteAlert.stories.tsx
+++ b/src/components/SiteAlert/SiteAlert.stories.tsx
@@ -126,8 +126,7 @@ export const emergencyAlertWithList = (): React.ReactElement => (
   <SiteAlert
     variant="emergency"
     heading={emergencyHeading}
-    aria-label="Site alert"
-  >
+    aria-label="Site alert">
     {emergencyWithList}
   </SiteAlert>
 )
@@ -150,8 +149,7 @@ export const alertWithCustomControls = (
   <SiteAlert
     slim={argTypes.slim}
     showIcon={argTypes.showIcon}
-    variant={argTypes.variant}
-  >
+    variant={argTypes.variant}>
     {shortAlertContent}
   </SiteAlert>
 )

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -74,8 +74,7 @@ export const tooltipWithUtilityClass = (): React.ReactElement => (
     <Tooltip
       wrapperclasses="width-full tablet:width-auto"
       position="right"
-      label="Right"
-    >
+      label="Right">
       Show on right
     </Tooltip>
   </div>
@@ -104,8 +103,7 @@ export const CustomComponent = (): React.ReactElement => {
         <Tooltip<CustomLinkProps>
           label="Follow Link"
           asCustom={CustomLink}
-          to="http://www.truss.works"
-        >
+          to="http://www.truss.works">
           This
         </Tooltip>
         &nbsp;is a custom component link.
@@ -147,8 +145,7 @@ export const tooltipBottomRightWrap = (): React.ReactElement => (
       left: '0',
       paddingRight: '32px',
       textAlign: 'right',
-    }}
-  >
+    }}>
     <Tooltip label="You can only add 10 links to a collection. To add more links, please create a new collection.">
       Default
     </Tooltip>

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -188,8 +188,7 @@ describe('Tooltip component', () => {
           label="Click me"
           asCustom={CustomLink}
           to="http://www.truss.works"
-          className="customTriggerClass"
-        >
+          className="customTriggerClass">
           This is a custom link tooltip
         </Tooltip>
       )

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -238,8 +238,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
           className={tooltipBodyClasses}
           role="tooltip"
           aria-hidden={!isVisible}
-          style={positionStyles}
-        >
+          style={positionStyles}>
           {label}
         </span>
       </span>
@@ -269,8 +268,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
           onFocus={showTooltip}
           onMouseLeave={hideTooltip}
           onBlur={hideTooltip}
-          onKeyDown={hideTooltip}
-        >
+          onKeyDown={hideTooltip}>
           {children}
         </button>
         <span
@@ -281,8 +279,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
           className={tooltipBodyClasses}
           role="tooltip"
           aria-hidden={!isVisible}
-          style={positionStyles}
-        >
+          style={positionStyles}>
           {label}
         </span>
       </span> // the span that wraps the element with have the tooltip class

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -110,12 +110,8 @@ export const CharacterCount = ({
 
   let InputComponent: React.ReactElement
   if (isTextArea) {
-    const {
-      onBlur,
-      onChange,
-      inputRef,
-      ...textAreaProps
-    } = remainingProps as Partial<TextareaCharacterCountProps>
+    const { onBlur, onChange, inputRef, ...textAreaProps } =
+      remainingProps as Partial<TextareaCharacterCountProps>
 
     InputComponent = (
       <Textarea

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -369,8 +369,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
       data-testid="combo-box"
       data-enhanced="true"
       className={containerClasses}
-      ref={containerRef}
-    >
+      ref={containerRef}>
       <select
         {...selectProps}
         className="usa-select usa-sr-only usa-combo-box__select"
@@ -378,8 +377,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
         aria-hidden
         tabIndex={-1}
         defaultValue={state.selectedOption?.value}
-        data-testid="combo-box-select"
-      >
+        data-testid="combo-box-select">
         {options.map((option) => (
           <option key={option.value} value={option.value}>
             {option.label}
@@ -419,8 +417,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
           data-testid="combo-box-clear-button"
           onKeyDown={handleClearKeyDown}
           hidden={!isPristine || isDisabled}
-          disabled={isDisabled}
-        >
+          disabled={isDisabled}>
           &nbsp;
         </button>
       </span>
@@ -439,8 +436,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
                 : ActionTypes.OPEN_LIST,
             })
           }
-          disabled={isDisabled}
-        >
+          disabled={isDisabled}>
           &nbsp;
         </button>
       </span>
@@ -452,8 +448,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
         className="usa-combo-box__list"
         role="listbox"
         ref={listRef}
-        hidden={!state.isOpen}
-      >
+        hidden={!state.isOpen}>
         {state.filteredOptions.map((option, index) => {
           const focused = option === state.focusedOption
           const selected = option === state.selectedOption
@@ -483,8 +478,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
               }
               onClick={(): void => {
                 dispatch({ type: ActionTypes.SELECT_OPTION, option: option })
-              }}
-            >
+              }}>
               {option.label}
             </li>
           )
@@ -502,8 +496,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
       <span
         id={assistiveHintID}
         className="usa-sr-only"
-        data-testid="combo-box-assistive-hint"
-      >
+        data-testid="combo-box-assistive-hint">
         {assistiveHint ||
           `When autocomplete results are available use up and down arrows to review
            and enter to select. Touch device users, explore by touch or with swipe

--- a/src/components/forms/DatePicker/Calendar.tsx
+++ b/src/components/forms/DatePicker/Calendar.tsx
@@ -353,8 +353,7 @@ export const Calendar = ({
       className="usa-date-picker__calendar__date-picker"
       data-testid="calendar-date-picker"
       ref={datePickerEl}
-      onKeyDown={handleDatePickerTab}
-    >
+      onKeyDown={handleDatePickerTab}>
       <div className="usa-date-picker__calendar__row">
         <div className="usa-date-picker__calendar__cell usa-date-picker__calendar__cell--center-items">
           <button
@@ -364,8 +363,7 @@ export const Calendar = ({
             ref={prevYearEl}
             className="usa-date-picker__calendar__previous-year"
             aria-label={backOneYear}
-            disabled={prevButtonsDisabled}
-          >
+            disabled={prevButtonsDisabled}>
             &nbsp;
           </button>
         </div>
@@ -377,8 +375,7 @@ export const Calendar = ({
             ref={prevMonthEl}
             className="usa-date-picker__calendar__previous-month"
             aria-label={backOneMonth}
-            disabled={prevButtonsDisabled}
-          >
+            disabled={prevButtonsDisabled}>
             &nbsp;
           </button>
         </div>
@@ -389,8 +386,7 @@ export const Calendar = ({
             onClick={handleToggleMonthSelection}
             ref={selectMonthEl}
             className="usa-date-picker__calendar__month-selection"
-            aria-label={clickToSelectMonth}
-          >
+            aria-label={clickToSelectMonth}>
             {monthLabel}
           </button>
           <button
@@ -399,8 +395,7 @@ export const Calendar = ({
             onClick={handleToggleYearSelection}
             ref={selectYearEl}
             className="usa-date-picker__calendar__year-selection"
-            aria-label={clickToSelectYear}
-          >
+            aria-label={clickToSelectYear}>
             {focusedYear}
           </button>
         </div>
@@ -412,8 +407,7 @@ export const Calendar = ({
             ref={nextMonthEl}
             className="usa-date-picker__calendar__next-month"
             aria-label={forwardOneMonth}
-            disabled={nextButtonsDisabled}
-          >
+            disabled={nextButtonsDisabled}>
             &nbsp;
           </button>
         </div>
@@ -425,8 +419,7 @@ export const Calendar = ({
             ref={nextYearEl}
             className="usa-date-picker__calendar__next-year"
             aria-label={forwardOneYear}
-            disabled={nextButtonsDisabled}
-          >
+            disabled={nextButtonsDisabled}>
             &nbsp;
           </button>
         </div>
@@ -439,8 +432,7 @@ export const Calendar = ({
                 className="usa-date-picker__calendar__day-of-week"
                 scope="col"
                 aria-label={dayOfWeekLabels[parseInt(`${i}`)]}
-                key={`day-of-week-${d}-${i}`}
-              >
+                key={`day-of-week-${d}-${i}`}>
                 {d}
               </th>
             ))}

--- a/src/components/forms/DatePicker/DatePicker.tsx
+++ b/src/components/forms/DatePicker/DatePicker.tsx
@@ -253,8 +253,7 @@ export const DatePicker = ({
       className={datePickerClasses}
       ref={datePickerEl}
       onBlur={handleFocusOut}
-      onKeyDown={handleEscapeKey}
-    >
+      onKeyDown={handleEscapeKey}>
       <input
         {...inputProps}
         name={name}
@@ -295,8 +294,7 @@ export const DatePicker = ({
           aria-haspopup={true}
           aria-label={toggleCalendar}
           disabled={disabled}
-          onClick={handleToggleClick}
-        >
+          onClick={handleToggleClick}>
           &nbsp;
         </button>
         {/* Ignoring error: "Non-interactive elements should not be assigned mouse or keyboard event listeners." */}
@@ -310,8 +308,7 @@ export const DatePicker = ({
           data-value={calendarDisplayValue && formatDate(calendarDisplayValue)}
           style={{ top: `${calendarPosY}px` }}
           onKeyDown={handleCalendarKeydown}
-          onKeyUp={handleCalendarKeyup}
-        >
+          onKeyUp={handleCalendarKeyup}>
           {showCalendar && (
             <Calendar
               date={calendarDisplayValue}
@@ -330,8 +327,7 @@ export const DatePicker = ({
           data-testid="date-picker-status"
           className="usa-sr-only usa-date-picker__status"
           role="status"
-          aria-live="polite"
-        >
+          aria-live="polite">
           {statuses.join('. ')}
         </div>
       </div>

--- a/src/components/forms/DatePicker/Day.tsx
+++ b/src/components/forms/DatePicker/Day.tsx
@@ -104,8 +104,7 @@ const DayForwardRef: React.ForwardRefRenderFunction<
       aria-selected={isSelected ? true : false}
       disabled={isDisabled}
       onKeyDown={handleKeyDown}
-      onMouseMove={isFocusedMonth ? handleMouseMove : undefined}
-    >
+      onMouseMove={isFocusedMonth ? handleMouseMove : undefined}>
       {day}
     </button>
   )

--- a/src/components/forms/DatePicker/MonthPicker.tsx
+++ b/src/components/forms/DatePicker/MonthPicker.tsx
@@ -140,8 +140,7 @@ export const MonthPicker = ({
         disabled={isDisabled}
         onClick={onClick}
         onKeyDown={handleKeyDownFromMonth}
-        onMouseMove={handleMouseMoveFromMonth}
-      >
+        onMouseMove={handleMouseMoveFromMonth}>
         {month}
       </button>
     )
@@ -156,8 +155,7 @@ export const MonthPicker = ({
       data-testid="calendar-month-picker"
       className="usa-date-picker__calendar__month-picker"
       ref={monthPickerEl}
-      onKeyDown={handleMonthPickerTab}
-    >
+      onKeyDown={handleMonthPickerTab}>
       <table className="usa-date-picker__calendar__table" role="presentation">
         <tbody>{listToTable(months, 3)}</tbody>
       </table>

--- a/src/components/forms/DatePicker/YearPicker.tsx
+++ b/src/components/forms/DatePicker/YearPicker.tsx
@@ -196,8 +196,7 @@ export const YearPicker = ({
         disabled={isDisabled}
         onClick={onClick}
         onKeyDown={handleKeyDownFromYear}
-        onMouseMove={handleMouseMoveFromYear}
-      >
+        onMouseMove={handleMouseMoveFromYear}>
         {yearIterator}
       </button>
     )
@@ -234,8 +233,7 @@ export const YearPicker = ({
       className="usa-date-picker__calendar__year-picker"
       data-testid="calendar-year-picker"
       ref={yearPickerEl}
-      onKeyDown={handleYearPickerTab}
-    >
+      onKeyDown={handleYearPickerTab}>
       <table className="usa-date-picker__calendar__table" role="presentation">
         <tbody>
           <tr>
@@ -247,16 +245,14 @@ export const YearPicker = ({
                 aria-label={`Navigate back ${YEAR_CHUNK} years`}
                 disabled={prevYearChunkDisabled}
                 onClick={handlePreviousYearChunkClick}
-                ref={prevYearChunkEl}
-              >
+                ref={prevYearChunkEl}>
                 &nbsp;
               </button>
             </td>
             <td colSpan={3}>
               <table
                 className="usa-date-picker__calendar__table"
-                role="presentation"
-              >
+                role="presentation">
                 <tbody>{listToTable(years, 3)}</tbody>
               </table>
             </td>
@@ -268,8 +264,7 @@ export const YearPicker = ({
                 aria-label={`Navigate forward ${YEAR_CHUNK} years`}
                 disabled={nextYearChunkDisabled}
                 onClick={handleNextYearChunkClick}
-                ref={nextYearChunkEl}
-              >
+                ref={nextYearChunkEl}>
                 &nbsp;
               </button>
             </td>

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -154,20 +154,17 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     <div
       data-testid="file-input"
       className={fileInputClasses}
-      aria-disabled={disabled}
-    >
+      aria-disabled={disabled}>
       <div
         data-testid="file-input-droptarget"
         className={targetClasses}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
+        onDrop={handleDrop}>
         {filePreviews.length > 0 && (
           <div
             data-testid="file-input-preview-heading"
-            className="usa-file-input__preview-heading"
-          >
+            className="usa-file-input__preview-heading">
             {previewHeaderText}{' '}
             <span className="usa-file-input__choose">
               Change file{filePreviews.length > 1 && 's'}
@@ -177,8 +174,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
         <div
           data-testid="file-input-instructions"
           className={instructionClasses}
-          aria-hidden="true"
-        >
+          aria-hidden="true">
           {!hideDragText && (
             <span className="usa-file-input__drag-text">{dragText}</span>
           )}
@@ -189,8 +185,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
         {showError && (
           <div
             data-testid="file-input-error"
-            className="usa-file-input__accepted-files-message"
-          >
+            className="usa-file-input__accepted-files-message">
             This is not a valid file type.
           </div>
         )}

--- a/src/components/forms/Form/Form.stories.tsx
+++ b/src/components/forms/Form/Form.stories.tsx
@@ -219,8 +219,7 @@ export const signInForm = (): React.ReactElement => {
             aria-controls="password-sign-in"
             onClick={(): void =>
               setShowPassword((showPassword) => !showPassword)
-            }
-          >
+            }>
             {showPassword ? 'Hide password' : 'Show password'}
           </a>
         </p>
@@ -273,8 +272,7 @@ export const passwordResetForm = (): React.ReactElement => {
             aria-controls="newPassword confirmPassword"
             onClick={(): void =>
               setShowPassword((showPassword) => !showPassword)
-            }
-          >
+            }>
             {showPassword ? 'Hide my typing' : 'Show my typing'}
           </a>
         </p>

--- a/src/components/forms/InputPrefix/InputPrefix.tsx
+++ b/src/components/forms/InputPrefix/InputPrefix.tsx
@@ -18,8 +18,7 @@ export const InputPrefix = ({
       className={classes}
       aria-hidden="true"
       {...divProps}
-      data-testid="InputPrefix"
-    >
+      data-testid="InputPrefix">
       {children}
     </div>
   )

--- a/src/components/forms/InputSuffix/InputSuffix.tsx
+++ b/src/components/forms/InputSuffix/InputSuffix.tsx
@@ -18,8 +18,7 @@ export const InputSuffix = ({
       className={classes}
       aria-hidden="true"
       {...divProps}
-      data-testid="InputSuffix"
-    >
+      data-testid="InputSuffix">
       {children}
     </div>
   )

--- a/src/components/forms/Validation/Validation.stories.tsx
+++ b/src/components/forms/Validation/Validation.stories.tsx
@@ -61,15 +61,13 @@ export const Default = (): React.ReactElement => {
     <Form
       onSubmit={(): void => {
         console.log('submit')
-      }}
-    >
+      }}>
       <Fieldset legend="Enter a code" legendStyle="large">
         <Alert
           type="info"
           validation
           heading="Code Requirements"
-          headingLevel="h4"
-        >
+          headingLevel="h4">
           <ValidationChecklist id="validate-code">
             <ValidationItem id="uppercase" isValid={validations.uppercase}>
               Use at least one uppercase character

--- a/src/components/grid/Grid.stories.tsx
+++ b/src/components/grid/Grid.stories.tsx
@@ -41,7 +41,9 @@ const CustomGrid: React.FunctionComponent<CustomGridProps> = ({
 
 type CustomGridContainerProps = JSX.IntrinsicElements['ul']
 
-const CustomGridContainer: React.FunctionComponent<CustomGridContainerProps> = ({
+const CustomGridContainer: React.FunctionComponent<
+  CustomGridContainerProps
+> = ({
   children,
   className,
   ...ulProps

--- a/src/components/grid/Grid/Grid.tsx
+++ b/src/components/grid/Grid/Grid.tsx
@@ -3,10 +3,9 @@ import classnames from 'classnames'
 
 import { GridItemProps, BreakpointKeys, breakpoints } from '../types'
 
-export type GridProps = GridItemProps &
-  {
-    [P in BreakpointKeys]?: GridItemProps
-  }
+export type GridProps = GridItemProps & {
+  [P in BreakpointKeys]?: GridItemProps
+}
 
 export type GridComponentProps<T> = GridProps & { className?: string } & T
 
@@ -138,7 +137,7 @@ export function Grid<FCProps = DefaultGridProps>(
   if (isCustomProps(otherProps)) {
     const { asCustom, ...remainingProps } = otherProps
 
-    const gridProps: FCProps = (remainingProps as unknown) as FCProps
+    const gridProps: FCProps = remainingProps as unknown as FCProps
     return React.createElement(
       asCustom,
       {

--- a/src/components/grid/GridContainer/GridContainer.test.tsx
+++ b/src/components/grid/GridContainer/GridContainer.test.tsx
@@ -40,7 +40,9 @@ describe('GridContainer component', () => {
   describe('custom component', () => {
     type CustomGridContainerProps = JSX.IntrinsicElements['ul']
 
-    const CustomGridContainer: React.FunctionComponent<CustomGridContainerProps> = ({
+    const CustomGridContainer: React.FunctionComponent<
+      CustomGridContainerProps
+    > = ({
       children,
       className,
       ...ulProps

--- a/src/components/grid/GridContainer/GridContainer.tsx
+++ b/src/components/grid/GridContainer/GridContainer.tsx
@@ -48,14 +48,9 @@ export function GridContainer<FCProps = DefaultGridContainerProps>(
   props: DefaultGridContainerProps | CustomGridContainerProps<FCProps>
 ): React.ReactElement {
   if (isCustomProps(props)) {
-    const {
-      className,
-      containerSize,
-      asCustom,
-      children,
-      ...remainingProps
-    } = props
-    const gridContainerProps: FCProps = (remainingProps as unknown) as FCProps
+    const { className, containerSize, asCustom, children, ...remainingProps } =
+      props
+    const gridContainerProps: FCProps = remainingProps as unknown as FCProps
     const classes = gridContainerClasses(className, containerSize)
     return React.createElement(
       asCustom,

--- a/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
@@ -145,8 +145,7 @@ describe('StepIndicator component', () => {
     const { queryByRole, queryByTestId } = render(
       <StepIndicator
         headingLevel="h4"
-        headingProps={{ id: 'my-id', className: 'my-custom-className' }}
-      >
+        headingProps={{ id: 'my-id', className: 'my-custom-className' }}>
         <StepIndicatorStep label={step1} status="complete" />
         <StepIndicatorStep label={step2} status="current" />
         <StepIndicatorStep label={step3} status="incomplete" />

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -76,8 +76,7 @@ export const StepIndicator = (
       className={divClasses}
       data-testid="step-indicator"
       aria-label="progress"
-      {...remainingDivProps}
-    >
+      {...remainingDivProps}>
       <ol className={listClasses} {...remainingListProps}>
         {children}
       </ol>

--- a/src/stories/templates/createaccount.stories.tsx
+++ b/src/stories/templates/createaccount.stories.tsx
@@ -78,36 +78,31 @@ const footerSecondary = (
             <a
               key="facebook"
               className="usa-social-link usa-social-link--facebook"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>Facebook</span>
             </a>,
             <a
               key="twitter"
               className="usa-social-link usa-social-link--twitter"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>Twitter</span>
             </a>,
             <a
               key="youtube"
               className="usa-social-link usa-social-link--youtube"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>YouTube</span>
             </a>,
             <a
               key="instagram"
               className="usa-social-link usa-social-link--instagram"
-              href="#"
-            >
+              href="#">
               <span>Instagram</span>
             </a>,
             <a
               key="rss"
               className="usa-social-link usa-social-link--rss"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>RSS</span>
             </a>,
           ]}
@@ -181,8 +176,7 @@ export const CreateAccount = (): React.ReactElement => {
                 mobileLg={{ col: 10 }}
                 tablet={{ col: 8 }}
                 desktop={{ col: 6 }}
-                className="padding-x-205 margin-bottom-4"
-              >
+                className="padding-x-205 margin-bottom-4">
                 <h1 className="desktop:display-none font-sans-lg margin-bottom-4 tablet:margin-top-neg-3">
                   A tagline that explains the benefit of creating an account.
                 </h1>
@@ -194,8 +188,7 @@ export const CreateAccount = (): React.ReactElement => {
                       <p>
                         <abbr
                           title="required"
-                          className="usa-hint usa-hint--required"
-                        >
+                          className="usa-hint usa-hint--required">
                           *
                         </abbr>{' '}
                         indicates a required field.
@@ -239,8 +232,7 @@ export const CreateAccount = (): React.ReactElement => {
                           aria-controls="password-create-account password-create-account-confirm"
                           onClick={(): void =>
                             setShowPassword((showPassword) => !showPassword)
-                          }
-                        >
+                          }>
                           {showPassword ? 'Hide password' : 'Show password'}
                         </a>
                       </p>
@@ -284,8 +276,7 @@ export const CreateAccount = (): React.ReactElement => {
                 mobileLg={{ col: 10 }}
                 tablet={{ col: 8 }}
                 desktop={{ col: 6 }}
-                className="padding-x-205"
-              >
+                className="padding-x-205">
                 <div className="border-top border-base-lighter padding-top-4 desktop:border-0 desktop:padding-top-0">
                   <h2 className="display-none desktop:display-block">
                     A tagline that explains the benefit of creating an account.

--- a/src/stories/templates/documentation.stories.tsx
+++ b/src/stories/templates/documentation.stories.tsx
@@ -163,36 +163,31 @@ export const DocumentationPage = (): React.ReactElement => {
               <a
                 key="facebook"
                 className="usa-social-link usa-social-link--facebook"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Facebook</span>
               </a>,
               <a
                 key="twitter"
                 className="usa-social-link usa-social-link--twitter"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Twitter</span>
               </a>,
               <a
                 key="youtube"
                 className="usa-social-link usa-social-link--youtube"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>YouTube</span>
               </a>,
               <a
                 key="instagram"
                 className="usa-social-link usa-social-link--instagram"
-                href="#"
-              >
+                href="#">
                 <span>Instagram</span>
               </a>,
               <a
                 key="rss"
                 className="usa-social-link usa-social-link--rss"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>RSS</span>
               </a>,
             ]}
@@ -239,8 +234,7 @@ export const DocumentationPage = (): React.ReactElement => {
             aria-label="Primary navigation"
             items={primaryNavItems}
             onToggleMobileNav={toggleMobileNav}
-            mobileExpanded={mobileNavOpen}
-          >
+            mobileExpanded={mobileNavOpen}>
             <Search size="small" onSubmit={handleSearch} />
           </PrimaryNav>
         </div>
@@ -256,8 +250,7 @@ export const DocumentationPage = (): React.ReactElement => {
             </Grid>
             <main
               className="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs"
-              id="main-content"
-            >
+              id="main-content">
               <h1>Page heading (h1)</h1>
 
               <p className="usa-intro">

--- a/src/stories/templates/landing.stories.tsx
+++ b/src/stories/templates/landing.stories.tsx
@@ -134,36 +134,31 @@ export const LandingPage = (): React.ReactElement => {
               <a
                 key="facebook"
                 className="usa-social-link usa-social-link--facebook"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Facebook</span>
               </a>,
               <a
                 key="twitter"
                 className="usa-social-link usa-social-link--twitter"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Twitter</span>
               </a>,
               <a
                 key="youtube"
                 className="usa-social-link usa-social-link--youtube"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>YouTube</span>
               </a>,
               <a
                 key="instagram"
                 className="usa-social-link usa-social-link--instagram"
-                href="#"
-              >
+                href="#">
                 <span>Instagram</span>
               </a>,
               <a
                 key="rss"
                 className="usa-social-link usa-social-link--rss"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>RSS</span>
               </a>,
             ]}
@@ -210,8 +205,7 @@ export const LandingPage = (): React.ReactElement => {
           primaryItems={primaryNavItems}
           secondaryItems={secondaryNavItems}
           onToggleMobileNav={toggleMobileNav}
-          mobileExpanded={mobileNavOpen}
-        >
+          mobileExpanded={mobileNavOpen}>
           <Search size="small" onSubmit={handleSearch} />
         </ExtendedNav>
       </Header>

--- a/src/stories/templates/mutliplesignin.stories.tsx
+++ b/src/stories/templates/mutliplesignin.stories.tsx
@@ -73,36 +73,31 @@ const footerSecondary = (
             <a
               key="facebook"
               className="usa-social-link usa-social-link--facebook"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>Facebook</span>
             </a>,
             <a
               key="twitter"
               className="usa-social-link usa-social-link--twitter"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>Twitter</span>
             </a>,
             <a
               key="youtube"
               className="usa-social-link usa-social-link--youtube"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>YouTube</span>
             </a>,
             <a
               key="instagram"
               className="usa-social-link usa-social-link--instagram"
-              href="#"
-            >
+              href="#">
               <span>Instagram</span>
             </a>,
             <a
               key="rss"
               className="usa-social-link usa-social-link--rss"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>RSS</span>
             </a>,
           ]}
@@ -157,15 +152,13 @@ export const MultipleSignInOptions = (): React.ReactElement => {
           <GridContainer className="usa-section">
             <Grid
               row={true}
-              className="margin-x-neg-205 margin-bottom-7 flex-justify-center"
-            >
+              className="margin-x-neg-205 margin-bottom-7 flex-justify-center">
               <Grid
                 col={12}
                 mobileLg={{ col: 10 }}
                 tablet={{ col: 8 }}
                 desktop={{ col: 6 }}
-                className="padding-x-205 margin-bottom-7"
-              >
+                className="padding-x-205 margin-bottom-7">
                 <h1 className="desktop:display-none font-sans-lg margin-bottom-4 tablet:margin-top-neg-3">
                   A tagline that explains the benefit of creating an account.
                 </h1>
@@ -221,8 +214,7 @@ export const MultipleSignInOptions = (): React.ReactElement => {
                 mobileLg={{ col: 10 }}
                 tablet={{ col: 8 }}
                 desktop={{ col: 6 }}
-                className="padding-x-205"
-              >
+                className="padding-x-205">
                 <div className="border-top border-base-lighter padding-top-4 desktop:border-0 desktop:padding-top-0">
                   <h2 className="display-none desktop:display-block">
                     A tagline that explains the benefit of creating an account.

--- a/src/stories/templates/notfound.stories.tsx
+++ b/src/stories/templates/notfound.stories.tsx
@@ -154,36 +154,31 @@ export const NotFoundPage = (): React.ReactElement => {
               <a
                 key="facebook"
                 className="usa-social-link usa-social-link--facebook"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Facebook</span>
               </a>,
               <a
                 key="twitter"
                 className="usa-social-link usa-social-link--twitter"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Twitter</span>
               </a>,
               <a
                 key="youtube"
                 className="usa-social-link usa-social-link--youtube"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>YouTube</span>
               </a>,
               <a
                 key="instagram"
                 className="usa-social-link usa-social-link--instagram"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>Instagram</span>
               </a>,
               <a
                 key="rss"
                 className="usa-social-link usa-social-link--rss"
-                href="javascript:void(0);"
-              >
+                href="javascript:void(0);">
                 <span>RSS</span>
               </a>,
             ]}
@@ -232,8 +227,7 @@ export const NotFoundPage = (): React.ReactElement => {
             aria-label="Primary navigation"
             items={primaryNavItems}
             onToggleMobileNav={toggleMobileNav}
-            mobileExpanded={mobileNavOpen}
-          >
+            mobileExpanded={mobileNavOpen}>
             <Search size="small" onSubmit={handleSearch} />
           </PrimaryNav>
         </div>
@@ -244,8 +238,7 @@ export const NotFoundPage = (): React.ReactElement => {
           <Grid row gap>
             <main
               className="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs"
-              id="main-content"
-            >
+              id="main-content">
               <h1>Page not found</h1>
 
               <p className="usa-intro">

--- a/src/stories/templates/signin.stories.tsx
+++ b/src/stories/templates/signin.stories.tsx
@@ -77,36 +77,31 @@ const footerSecondary = (
             <a
               key="facebook"
               className="usa-social-link usa-social-link--facebook"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>Facebook</span>
             </a>,
             <a
               key="twitter"
               className="usa-social-link usa-social-link--twitter"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>Twitter</span>
             </a>,
             <a
               key="youtube"
               className="usa-social-link usa-social-link--youtube"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>YouTube</span>
             </a>,
             <a
               key="instagram"
               className="usa-social-link usa-social-link--instagram"
-              href="#"
-            >
+              href="#">
               <span>Instagram</span>
             </a>,
             <a
               key="rss"
               className="usa-social-link usa-social-link--rss"
-              href="javascript:void(0);"
-            >
+              href="javascript:void(0);">
               <span>RSS</span>
             </a>,
           ]}
@@ -199,8 +194,7 @@ export const SignIn = (): React.ReactElement => {
                           aria-controls="password-create-account password-create-account-confirm"
                           onClick={(): void =>
                             setShowPassword((showPassword) => !showPassword)
-                          }
-                        >
+                          }>
                           {showPassword ? 'Hide password' : 'Show password'}
                         </a>
                       </p>


### PR DESCRIPTION
# Summary

Prettier was using a deprecated prop `jsxSameLine` in `.prettierrc`, which the VS Code prettier extension no longer respected. This means that the extension would format files differently than code linting tools

Source: 
- [bracketSameLine](https://prettier.io/docs/en/options.html#bracket-line)
- [jsxBracketSameLine [Deprecated]](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets)

## How To Test

- Verify visually, the bracket styling is still the library's preferred style.
- Since this runs as a pre-commit hook, and I did not bypass hooks, what is committed is how prettier would format files on anyone's machine
