### PR TITLE
chore(release): 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* Fixes an issue where Type definitions were not properly packaged [#2053](https://github.com/trussworks/react-uswds/issues/2053) [febcd65](https://github.com/trussworks/react-uswds/commit/febcd65d1d2bf8ff84f558b4d14013ba8328cc38)
+* Fixes an issue where Type definitions were not properly packaged ([#2053](https://github.com/trussworks/react-uswds/issues/2053)) ([febcd65](https://github.com/trussworks/react-uswds/commit/febcd65d1d2bf8ff84f558b4d14013ba8328cc38))
 
 ### [3.0.1](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.1) (2022-05-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [3.0.2](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.2) (2022-05-13)
 
+
+### Bug Fixes
+
+* Fixes an issue where Type definitions were not properly packaged [#2053]https://github.com/trussworks/react-uswds/issues/2053) [febcd65](https://github.com/trussworks/react-uswds/commit/febcd65d1d2bf8ff84f558b4d14013ba8328cc38)
+
 ### [3.0.1](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.1) (2022-05-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [3.0.2](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.2) (2022-05-13)
+### [3.0.2](https://github.com/trussworks/react-uswds/compare/3.0.1...3.0.2) (2022-05-13)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* Fixes an issue where Type definitions were not properly packaged [#2053]https://github.com/trussworks/react-uswds/issues/2053) [febcd65](https://github.com/trussworks/react-uswds/commit/febcd65d1d2bf8ff84f558b4d14013ba8328cc38)
+* Fixes an issue where Type definitions were not properly packaged [#2053](https://github.com/trussworks/react-uswds/issues/2053) [febcd65](https://github.com/trussworks/react-uswds/commit/febcd65d1d2bf8ff84f558b4d14013ba8328cc38)
 
 ### [3.0.1](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.1) (2022-05-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.0.2](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.2) (2022-05-13)
+
 ### [3.0.1](https://github.com/trussworks/react-uswds/compare/3.0.0...3.0.1) (2022-05-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* Fixes an issue where Type definitions were not properly packaged
+* Attempted to fixes an issue where Type definitions were not properly packaged
 
 ## [3.0.0](https://github.com/trussworks/react-uswds/compare/2.9.0...3.0.0) (2022-04-25)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trussworks/react-uswds",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React USWDS 2.0 component library",
   "keywords": [
     "react",


### PR DESCRIPTION
### [3.0.2](https://github.com/trussworks/react-uswds/compare/3.0.1...3.0.2) (2022-05-13)


### Bug Fixes

* Fixes an issue where Type definitions were not properly packaged [#2053](https://github.com/trussworks/react-uswds/issues/2053) [febcd65](https://github.com/trussworks/react-uswds/commit/febcd65d1d2bf8ff84f558b4d14013ba8328cc38)

---
[Compare](https://github.com/trussworks/react-uswds/compare/3.0.1...release-3.0.2)