### PR TITLE
ci: Support Node@18

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14', '16']
 
     name: Node ${{ matrix.node }} tests
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['14', '16']
+        node: ['14', '16', '18']
 
     name: Node ${{ matrix.node }} tests
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lib"
   ],
   "engines": {
-    "node": "10.x - 16.x"
+    "node": "10.x - 18.x"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
# Summary

Node@12 has reached end of life and is no longer maintained. Node@18 was just released as the current version of Node. This PR replaces Node@12 with Node@18 in our build tests