### PR TITLE
fix: export ModalToggleButton

### DIFF
--- a/src/components/Modal/ModalToggleButton.tsx
+++ b/src/components/Modal/ModalToggleButton.tsx
@@ -58,3 +58,5 @@ export const ModalToggleButton = ({
     </Button>
   )
 }
+
+export default ModalToggleButton


### PR DESCRIPTION
Without these `export default` statements, I get these errors in my application:

```
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
    at ReactDOMServerRenderer.render (/srcnode_modules/react-dom/cjs/react-dom-server.node.development.js:4053:17)
    at ReactDOMServerRenderer.read (/srcnode_modules/react-dom/cjs/react-dom-server.node.development.js:3690:29)
    at renderToString (/srcnode_modules/react-dom/cjs/react-dom-server.node.development.js:4298:27)
    at handleRequest (/srcapp/entry.server.tsx:11:16)
    at handleDocumentRequest (/srcnode_modules/@remix-run/server-runtime/server.js:393:18)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at requestHandler (/srcnode_modules/@remix-run/server-runtime/server.js:49:18)
    at /srcnode_modules/@remix-run/architect/server.js:42:20
```

Perhaps this workaround suggests some problem with the TypeScript compilation?

# Summary

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
