### PR TITLE
fix: Emit headingLevel type and do not emit type declarations for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "test:serverside": "yarn build && node src/serverSideTest.js",
     "storybook": "start-storybook -p 9009",
     "storybook:deploy": "storybook-to-ghpages",
-    "build": "tsc && webpack --progress",
+    "build": "tsc -p tsconfig.build.json && webpack --progress",
     "build:watch": "tsc && webpack --watch",
-    "lint": "tsc --noEmit --emitDeclarationOnly false && eslint --ext js,jsx,ts,tsx src && stylelint \"src/**/*.{css,scss}\"",
+    "lint": "tsc && eslint --ext js,jsx,ts,tsx src && stylelint \"src/**/*.{css,scss}\"",
     "release": "standard-version -t ''",
     "prepare": "yarn build",
     "prepublishOnly": "yarn test && yarn lint",
@@ -127,7 +127,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "tsc --noEmit --emitDeclarationOnly false && lint-staged",
+      "pre-commit": "tsc && lint-staged",
       "pre-push": "yarn danger local -b main --failOnErrors"
     }
   },

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
 import { Accordion, AccordionItemProps } from './Accordion'
+import { HeadingLevel } from '../../types/headingLevel'
 
 const firstAmendment = (
   <p>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import classnames from 'classnames'
 
+import { HeadingLevel } from '../../types/headingLevel'
+
 export interface AccordionItemProps {
   title: React.ReactNode | string
   content: React.ReactNode

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -13,7 +13,7 @@ export interface AccordionItemProps {
   handleToggle?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-interface AccordionProps {
+type AccordionProps = {
   bordered?: boolean
   multiselectable?: boolean
   items: AccordionItemProps[]
@@ -67,7 +67,7 @@ export const Accordion = ({
   items,
   className,
   multiselectable = false,
-}: AccordionProps): React.ReactElement => {
+}: AccordionProps & JSX.IntrinsicElements['div']): React.ReactElement => {
   const [openItems, setOpenState] = useState(
     items.filter((i) => !!i.expanded).map((i) => i.id)
   )

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import { Alert } from './Alert'
+import { HeadingLevel } from '../../types/headingLevel'
 
 describe('Alert component', () => {
   beforeEach(() => {

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import classnames from 'classnames'
 
+import { HeadingLevel } from '../../types/headingLevel'
+
 import styles from './Alert.module.css'
 
 export interface AlertProps {

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -5,7 +5,7 @@ import { HeadingLevel } from '../../types/headingLevel'
 
 import styles from './Alert.module.css'
 
-export interface AlertProps {
+type AlertProps = {
   type: 'success' | 'warning' | 'error' | 'info'
   heading?: React.ReactNode
   headingLevel: HeadingLevel

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-export interface ButtonProps {
+export type ButtonProps = {
   type: 'button' | 'submit' | 'reset'
   children: React.ReactNode
   secondary?: boolean

--- a/src/components/Collection/Collection.tsx
+++ b/src/components/Collection/Collection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface CollectionProps {
+type CollectionProps = {
   condensed?: boolean
 }
 

--- a/src/components/Collection/CollectionHeading.test.tsx
+++ b/src/components/Collection/CollectionHeading.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { CollectionHeading } from './CollectionHeading'
+import { HeadingLevel } from '../../types/headingLevel'
 
 describe('CollectionHeading component', () => {
   beforeEach(() => {

--- a/src/components/Collection/CollectionHeading.tsx
+++ b/src/components/Collection/CollectionHeading.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import { HeadingLevel } from '../../types/headingLevel'
 interface CollectionHeadingProps {
   headingLevel: HeadingLevel
 }

--- a/src/components/GovBanner/GovBanner.tsx
+++ b/src/components/GovBanner/GovBanner.tsx
@@ -103,7 +103,7 @@ const getCopy = (language: Language, tld: TLD): GovBannerCopy => {
   }
 }
 
-interface GovBannerProps {
+type GovBannerProps = {
   tld?: TLD
   language?: Language
 }

--- a/src/components/IconList/IconListTitle/IconListTitle.tsx
+++ b/src/components/IconList/IconListTitle/IconListTitle.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import classnames from 'classnames'
+import { HeadingLevel } from '../../../types/headingLevel'
 
 interface BaseIconListTitleProps {
   type: string

--- a/src/components/Identifier/Identifier/Identifier.tsx
+++ b/src/components/Identifier/Identifier/Identifier.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface IdentifierProps {
+type IdentifierProps = {
   className?: string
   children: React.ReactNode
 }

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -45,7 +45,7 @@ You can also use the provided ModalToggleButton and/or ModalOpenLink components,
 }
 
 export const defaultModal = (): React.ReactElement => {
-  const modalRef = useRef<ModalRef>()
+  const modalRef = useRef<ModalRef>(null)
 
   return (
     <div>
@@ -87,7 +87,7 @@ export const defaultModal = (): React.ReactElement => {
 }
 
 export const largeModal = (): React.ReactElement => {
-  const modalRef = useRef<ModalRef>()
+  const modalRef = useRef<ModalRef>(null)
 
   return (
     <>
@@ -128,7 +128,7 @@ export const largeModal = (): React.ReactElement => {
 }
 
 export const forceActionModal = (): React.ReactElement => {
-  const modalRef = useRef<ModalRef>()
+  const modalRef = useRef<ModalRef>(null)
 
   return (
     <>
@@ -171,7 +171,7 @@ export const forceActionModal = (): React.ReactElement => {
 }
 
 export const customFocusElementModal = (): React.ReactElement => {
-  const modalRef = useRef<ModalRef>()
+  const modalRef = useRef<ModalRef>(null)
 
   return (
     <>
@@ -215,7 +215,7 @@ export const customFocusElementModal = (): React.ReactElement => {
 }
 
 export const initiallyOpenModal = (): React.ReactElement => {
-  const modalRef = useRef<ModalRef>()
+  const modalRef = useRef<ModalRef>(null)
 
   return (
     <div>

--- a/src/components/ProcessList/ProcessList/ProcessList.tsx
+++ b/src/components/ProcessList/ProcessList/ProcessList.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 import { ProcessListItemProps } from '../ProcessListItem/ProcessListItem'
 
-interface ProcessListProps {
+type ProcessListProps = {
   className?: string
   children: React.ReactElement<ProcessListItemProps>[]
 }

--- a/src/components/ProcessList/ProcessListHeading/ProcessListHeading.tsx
+++ b/src/components/ProcessList/ProcessListHeading/ProcessListHeading.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import { HeadingLevel } from '../../../types/headingLevel'
 
 interface BaseProcessListHeadingProps {
   type: string

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -5,11 +5,11 @@ import { Form, OptionalFormProps } from '../forms/Form/Form'
 import { Label } from '../forms/Label/Label'
 import { TextInput } from '../forms/TextInput/TextInput'
 
-interface SearchLocalization {
+type SearchLocalization = {
   buttonText: string
 }
 
-interface SearchInputProps {
+type SearchInputProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   size?: 'big' | 'small'
   className?: string

--- a/src/components/SiteAlert/SiteAlert.tsx
+++ b/src/components/SiteAlert/SiteAlert.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface SiteAlertProps {
+type SiteAlertProps = {
   variant: 'info' | 'emergency'
   children: string | React.ReactNode | React.ReactNode[]
   heading?: string

--- a/src/components/SummaryBox/SummaryBox/SummaryBox.tsx
+++ b/src/components/SummaryBox/SummaryBox/SummaryBox.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classnames from 'classnames'
 
-interface SummaryBoxProps {
+type SummaryBoxProps = {
   children?: React.ReactNode
   className?: string
 }

--- a/src/components/SummaryBox/SummaryBoxHeading/SummaryBoxHeading.tsx
+++ b/src/components/SummaryBox/SummaryBoxHeading/SummaryBoxHeading.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 import classnames from 'classnames'
+import { HeadingLevel } from '../../../types/headingLevel'
 
 interface SummaryBoxHeadingProps {
   children: ReactNode

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface TagProps {
+type TagProps = {
   children: React.ReactNode
   background?: string
 }

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -14,9 +14,9 @@ export default {
           bubbles: true,
           cancelable: true,
         })
-        document.querySelector('.usa-tooltip__trigger').dispatchEvent(event)
+        document.querySelector('.usa-tooltip__trigger')?.dispatchEvent(event)
       },
-      waitFor: <E extends Element>(): E =>
+      waitFor: <E extends Element>(): E | null =>
         document.querySelector('.usa-tooltip__body.is-visible.is-set'),
     },
     docs: {

--- a/src/components/breadcrumb/BreadcrumbBar/BreadcrumbBar.tsx
+++ b/src/components/breadcrumb/BreadcrumbBar/BreadcrumbBar.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react'
 import classnames from 'classnames'
 import { BreadcrumbProps } from '../Breadcrumb/Breadcrumb'
 
-interface BreadcrumbBarProps {
+type BreadcrumbBarProps = {
   children: ReactElement<BreadcrumbProps> | ReactElement<BreadcrumbProps>[]
   variant?: 'default' | 'wrap'
   className?: string

--- a/src/components/card/Card/Card.tsx
+++ b/src/components/card/Card/Card.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 
 import { GridLayoutProp, applyGridClasses } from '../../grid/Grid/Grid'
 
-interface CardProps {
+type CardProps = {
   layout?: 'standardDefault' | 'flagDefault' | 'flagMediaRight'
   headerFirst?: boolean
   containerProps?: React.HTMLAttributes<HTMLDivElement>

--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -66,11 +66,11 @@ const withCustomCharacterCount = (): React.ReactElement => {
 
   const customEmojiMessage = (count: number, maxCount: number): string => {
     const remainingCount = maxCount - count
-    if (remainingCount >= 0) return `${remainingCount} of ${maxCount} remain`
+    return remainingCount >= 0 ? `${remainingCount} of ${maxCount} remain` : ''
   }
 
   const twitterStyleMessage = (count: number, maxCount: number): string => {
-    if (maxCount - count < 5) return `${maxCount - count}`
+    return maxCount - count < 5 ? `${maxCount - count}` : ''
   }
 
   return (

--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -6,6 +6,7 @@ import { Label } from '../Label/Label'
 
 export default {
   title: 'Components/CharacterCount',
+  component: CharacterCount,
   parameters: {
     docs: {
       description: {

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -33,7 +33,7 @@ const defaultMessage = (count: number, max: number): string => {
 }
 
 /* Types */
-interface BaseCharacterCountProps {
+type BaseCharacterCountProps = {
   id: string
   name: string
   maxLength: number
@@ -44,9 +44,10 @@ interface BaseCharacterCountProps {
   getMessage?: (remainingCount: number, max: number) => string
 }
 
-type TextInputCharacterCountProps = BaseCharacterCountProps & TextInputProps
+export type TextInputCharacterCountProps = BaseCharacterCountProps &
+  TextInputProps
 
-type TextareaCharacterCountProps = BaseCharacterCountProps &
+export type TextareaCharacterCountProps = BaseCharacterCountProps &
   TextareaProps &
   JSX.IntrinsicElements['textarea']
 

--- a/src/components/forms/Checkbox/Checkbox.tsx
+++ b/src/components/forms/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface CheckboxProps {
+type CheckboxProps = {
   id: string
   name: string
   className?: string

--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -121,15 +121,15 @@ export const withOtherFields = (): React.ReactElement => {
 }
 
 export const exposedRefMethods = (): React.ReactElement => {
-  const ref = useRef<ComboBoxRef>()
+  const ref = useRef<ComboBoxRef>(null)
 
   const fruitList = Object.entries(fruits).map(([value, key]) => ({
     value: value,
     label: key,
   }))
 
-  const handleClearSelection = (): void => ref.current.clearSelection()
-  const handleFocus = (): void => ref.current.focus()
+  const handleClearSelection = (): void => ref.current?.clearSelection()
+  const handleFocus = (): void => ref.current?.focus()
 
   return (
     <Form onSubmit={noop}>

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -40,7 +40,7 @@ export interface CustomizableFilter {
   extras?: Record<string, string>
 }
 
-interface ComboBoxProps {
+type ComboBoxProps = {
   id: string
   name: string
   className?: string

--- a/src/components/forms/DateInput/DateInput.tsx
+++ b/src/components/forms/DateInput/DateInput.tsx
@@ -5,7 +5,7 @@ import { TextInput, OptionalTextInputProps } from '../TextInput/TextInput'
 import { Label } from '../Label/Label'
 import { FormGroup } from '../FormGroup/FormGroup'
 
-interface DateInputElementProps {
+type DateInputElementProps = {
   id: string
   name: string
   label: string

--- a/src/components/forms/DatePicker/Calendar.stories.tsx
+++ b/src/components/forms/DatePicker/Calendar.stories.tsx
@@ -63,7 +63,7 @@ export const minAndMax = (argTypes: StorybookArguments): React.ReactElement => (
     handleSelectDate={argTypes.handleSelectDate}
     setStatuses={argTypes.setStatuses}
     date={new Date('January 15 2021')}
-    minDate={parseDateString('2021-01-10')}
+    minDate={parseDateString('2021-01-10') as Date}
     maxDate={parseDateString('2021-01-20')}
   />
 )

--- a/src/components/forms/DatePicker/DatePicker.tsx
+++ b/src/components/forms/DatePicker/DatePicker.tsx
@@ -25,7 +25,7 @@ import {
 } from './utils'
 import { Calendar } from './Calendar'
 
-interface BaseDatePickerProps {
+type BaseDatePickerProps = {
   id: string
   name: string
   className?: string

--- a/src/components/forms/DatePicker/MonthPicker.stories.tsx
+++ b/src/components/forms/DatePicker/MonthPicker.stories.tsx
@@ -34,7 +34,7 @@ export const withMinAndMax = (
   <MonthPicker
     {...testProps}
     handleSelectMonth={argTypes.handleSelectMonth}
-    minDate={parseDateString('2021-04-01')}
+    minDate={parseDateString('2021-04-01') as Date}
     maxDate={parseDateString('2021-08-01')}
   />
 )

--- a/src/components/forms/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.tsx
@@ -6,7 +6,7 @@ import { formatDate, parseDateString } from '../DatePicker/utils'
 import { FormGroup } from '../FormGroup/FormGroup'
 import { Label } from '../Label/Label'
 
-interface DateRangePickerProps {
+type DateRangePickerProps = {
   startDateLabel?: string
   startDateHint?: string
   startDatePickerProps: Omit<DatePickerProps, 'rangeDate'>

--- a/src/components/forms/Dropdown/Dropdown.tsx
+++ b/src/components/forms/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface DropdownProps {
+type DropdownProps = {
   id: string
   name: string
   className?: string

--- a/src/components/forms/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/forms/ErrorMessage/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface ErrorMessageProps {
+type ErrorMessageProps = {
   children: React.ReactNode
   id?: string
   className?: string

--- a/src/components/forms/Fieldset/Fieldset.tsx
+++ b/src/components/forms/Fieldset/Fieldset.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface FieldsetProps {
+type FieldsetProps = {
   children: React.ReactNode
   legend?: React.ReactNode
   legendStyle?: 'default' | 'large' | 'srOnly'

--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -116,8 +116,8 @@ export const disabled = (): React.ReactElement => (
 export const withRefAndCustomHandlers = (
   argTypes: StorybookArguments
 ): React.ReactElement => {
-  const [files, setFiles] = useState<FileList>()
-  const fileInputRef = useRef<FileInputRef>()
+  const [files, setFiles] = useState<FileList | null>(null)
+  const fileInputRef = useRef<FileInputRef>(null)
 
   const handleClearFiles = (): void => fileInputRef.current?.clearFiles()
 
@@ -127,8 +127,10 @@ export const withRefAndCustomHandlers = (
   }
 
   const fileList = []
-  for (let i = 0; i < files?.length; i++) {
-    fileList.push(<li key={`file_${i}`}>{files[Number(i)].name}</li>)
+  if (files) {
+    for (let i = 0; i < files?.length; i++) {
+      fileList.push(<li key={`file_${i}`}>{files?.[Number(i)].name}</li>)
+    }
   }
 
   return (

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import { FilePreview } from './FilePreview'
 import { makeSafeForID } from './utils'
 
-interface FileInputProps {
+type FileInputProps = {
   id: string
   name: string
   disabled?: boolean

--- a/src/components/forms/Form/Form.tsx
+++ b/src/components/forms/Form/Form.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface RequiredFormProps {
+type RequiredFormProps = {
   children: React.ReactNode
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
 }
 
-interface CustomFormProps {
+type CustomFormProps = {
   className?: string
   large?: boolean
   search?: boolean

--- a/src/components/forms/FormGroup/FormGroup.tsx
+++ b/src/components/forms/FormGroup/FormGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface FormGroupProps {
+type FormGroupProps = {
   children: React.ReactNode
   className?: string
   error?: boolean

--- a/src/components/forms/Label/Label.tsx
+++ b/src/components/forms/Label/Label.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface LabelProps {
+type LabelProps = {
   children: React.ReactNode
   htmlFor: string
   className?: string

--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface RadioProps {
+type RadioProps = {
   id: string
   name: string
   className?: string

--- a/src/components/forms/RangeInput/RangeInput.tsx
+++ b/src/components/forms/RangeInput/RangeInput.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface RangeInputProps {
+type RangeInputProps = {
   id: string
   name: string
   min?: number

--- a/src/components/forms/TextInput/TextInput.tsx
+++ b/src/components/forms/TextInput/TextInput.tsx
@@ -8,13 +8,13 @@ type TextInputRef =
   | null
   | undefined
 
-interface RequiredTextInputProps {
+type RequiredTextInputProps = {
   id: string
   name: string
   type: 'text' | 'email' | 'number' | 'password' | 'search' | 'tel' | 'url'
 }
 
-interface CustomTextInputProps {
+type CustomTextInputProps = {
   className?: string
   validationStatus?: 'error' | 'success'
   inputSize?: 'small' | 'medium'

--- a/src/components/forms/TimePicker/TimePicker.tsx
+++ b/src/components/forms/TimePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ import {
   TIME_PICKER_CUSTOM_FILTER,
 } from './constants'
 
-interface BaseTimePickerProps {
+type BaseTimePickerProps = {
   id: string
   name: string
   onChange: (val?: string) => void

--- a/src/components/forms/Validation/Validation.stories.tsx
+++ b/src/components/forms/Validation/Validation.stories.tsx
@@ -26,7 +26,7 @@ Source: https://designsystem.digital.gov/components/validation
 }
 
 //This could be a third party util or any function that returns boolean for a specific validation
-const validate = (type, value): boolean => {
+const validate = (type: string, value: string): boolean => {
   switch (type) {
     case 'uppercase':
       return /[A-Z]/.test(value)
@@ -48,7 +48,7 @@ export const Default = (): React.ReactElement => {
     const {
       target: { value },
     } = event
-    const updatedValidations = {}
+    const updatedValidations: Record<string, boolean> = {}
 
     Object.keys(validations).forEach((validator) => {
       // eslint-disable-next-line security/detect-object-injection

--- a/src/components/forms/Validation/ValidationChecklist.tsx
+++ b/src/components/forms/Validation/ValidationChecklist.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface ValidationChecklistProps {
+type ValidationChecklistProps = {
   id: string
   children: React.ReactNode
 }

--- a/src/components/forms/Validation/ValidationItem.tsx
+++ b/src/components/forms/Validation/ValidationItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface ValidationItemProps {
+type ValidationItemProps = {
   children: React.ReactNode
   id: string
   isValid: boolean

--- a/src/components/header/Header/Header.tsx
+++ b/src/components/header/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface HeaderProps {
+type HeaderProps = {
   basic?: boolean
   extended?: boolean
   basicWithMegaMenu?: boolean

--- a/src/components/header/NavList/NavList.tsx
+++ b/src/components/header/NavList/NavList.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface CustomNavListProps {
+type CustomNavListProps = {
   items: React.ReactNode[]
   type?: 'primary' | 'secondary' | 'subnav' | 'megamenu' | 'footerSecondary'
 }

--- a/src/components/header/NavMenuButton/NavMenuButton.tsx
+++ b/src/components/header/NavMenuButton/NavMenuButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-interface NavMenuButtonProps {
+type NavMenuButtonProps = {
   label: React.ReactNode
 }
 

--- a/src/components/header/Title/Title.tsx
+++ b/src/components/header/Title/Title.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface TitleProps {
+type TitleProps = {
   children: React.ReactNode
 }
 

--- a/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { StepIndicatorStep } from '../StepIndicatorStep/StepIndicatorStep'
 import { StepIndicator } from '../StepIndicator/StepIndicator'
+import { HeadingLevel } from '../../../types/headingLevel'
 
 const step1 = 'Step 1'
 const step2 = 'Step 2'

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { StepIndicatorStepProps } from '../StepIndicatorStep/StepIndicatorStep'
+import { HeadingLevel } from '../../../types/headingLevel'
 
 interface StepIndicatorProps {
   showLabels?: boolean

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 import { StepIndicatorStepProps } from '../StepIndicatorStep/StepIndicatorStep'
 import { HeadingLevel } from '../../../types/headingLevel'
 
-interface StepIndicatorProps {
+type StepIndicatorProps = {
   showLabels?: boolean
   counters?: 'none' | 'default' | 'small'
   centered?: boolean

--- a/src/stories/templates/documentation.stories.tsx
+++ b/src/stories/templates/documentation.stories.tsx
@@ -194,7 +194,7 @@ export const DocumentationPage = (): React.ReactElement => {
           />
           <h3 className="usa-footer__contact-heading">Agency Contact Center</h3>
           <Address
-            medium
+            size="medium"
             items={[
               <a key="telephone" href="tel:1-800-555-5555">
                 (800) CALL-GOVT

--- a/src/stories/templates/mutliplesignin.stories.tsx
+++ b/src/stories/templates/mutliplesignin.stories.tsx
@@ -104,7 +104,7 @@ const footerSecondary = (
         />
         <h3 className="usa-footer__contact-heading">Agency Contact Center</h3>
         <Address
-          medium
+          size="medium"
           items={[
             <a key="telephone" href="tel:1-800-555-5555">
               (800) CALL-GOVT

--- a/src/types/headingLevel.d.ts
+++ b/src/types/headingLevel.d.ts
@@ -1,1 +1,0 @@
-type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'

--- a/src/types/headingLevel.ts
+++ b/src/types/headingLevel.ts
@@ -1,0 +1,1 @@
+export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{ 
+  "extends": "./tsconfig.json",
+  "noEmit": false,
+  "emitDeclarationOnly": true,
+  "exclude": [
+    "**/*.test.tsx",
+    "**/*.stories.tsx"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "emitDeclarationOnly": true,
+    "noEmit": true,
     "jsx": "react",
     "noImplicitAny": true,
     "declaration": true,
@@ -19,8 +19,4 @@
     "isolatedModules": true,
   },
   "include": ["src/**/*", "custom.d.ts"],
-  "exclude": [
-    "node_modules",
-    "**/*.stories.tsx"
-  ]
 }


### PR DESCRIPTION
# Summary

Accomplishes https://github.com/trussworks/react-uswds/pull/2133 while also making sure that tsconfig checks compilation of test and story files, without emitting them on build (so they will not be included in `lib`). Previously, empty *.test.d.ts files were being emitted when I removed tests from the `tsconfig.json` `exclude`.

Here We use a standard `tsconfig.json` for development which _does_ look at tests and stories for typescript compilation (big win for us because we were not doing this previously, so our storybook examples had typescript errors in them). 

We also use a new `tsconfig.build.json` which extends the development `tsconfig.json` to emit types (which we need to do), as well as excludes tests and stories, since we do not need to be concerned with either of those types of files for release packaging.

- [ ] `@reviewers` There's an issue I could use some help with debugging. There's a _massive_ .png file (larger than all of the code exported combined) being emitted into `lib` on build. Any idea where it is coming from and how to stop that from happening?:
<img width="2475" alt="image" src="https://user-images.githubusercontent.com/15805554/170763710-1ee8af95-2678-4f98-badd-2adf642f35ac.png"> 


- [ ] Also, do we need all those woff and ttf font files in there?

## How to test

1. clear your local environment of transient files, and rebuild the project (`yarn` or `yarn install` runs `yarn build` after the install)
   ```
   rm --rf lib
   rm --rf node_modules
   yarn
   ```
1. check the `lib` folder that gets generated to verify that no test or story type files are present and that `types/headingLevel.d.ts` is included

## Review notes:

You might note a lot of props `interface`s changing to `type`s. This is to fix the following TS error that shows up in storybook files: https://stackoverflow.com/questions/64703203/typescript-problem-with-storybook-migration-to-csf

## Related Issues or PRs

replaces:  https://github.com/trussworks/react-uswds/pull/2133


