### PR TITLE
chore: Remove myself from dependabot review requests for this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       - "suzubara"
       - "haworku"
       - "ahobson"
-      - "brandonlenz"
     labels:
       - 'type: dependencies'
       - 'type: automerge'
@@ -55,7 +54,6 @@ updates:
       - "suzubara"
       - "haworku"
       - "ahobson"
-      - "brandonlenz"
     labels:
       - 'type: dependencies'
       - 'type: automerge'


### PR DESCRIPTION
# Summary

I find being automatically added to dependabot reviews to be too noisy and clogs my notifications where I try to stay on top of project work.

I'm keenly aware that we get ~20+ dependency updates on a regular weekly basis that usually require manual intervention, so the review requests only add noise that is distracting. When I have time to come push things along, I do so and will continue to do so regardless of whether I'm tagged on the dependabot PRs or not