### PR TITLE
chore: Remove Suz from CODEOWNERS and dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       separator: '-'
     open-pull-requests-limit: 10
     reviewers:
-      - "suzubara"
       - "haworku"
       - "ahobson"
     labels:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for all files
-* @suzubara @gidjin @haworku @ahobson @brandonlenz @sirenaborracha @kylehilltruss @rogeruiz
+* @gidjin @haworku @ahobson @brandonlenz @sirenaborracha @kylehilltruss @rogeruiz
 
 # Owners for PRs that change ONLY package.json and/or yarn.lock
 # Note: Reviewers for dependabot PRs that change these files are configured in .github/dependabot.yml  under `reviewers` 


### PR DESCRIPTION
# Summary

Removes Suz from stuff that automatically assigned her to things

@suzubara of course, being an open source project, we welcome your contributions should you ever feel like taking a trip down memory lane with react-uswds in the future!