### PR TITLE
chore(release): 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.1.1](https://github.com/trussworks/react-uswds/compare/4.1.0...4.1.1) (2023-02-23)
+
 ## [4.1.0](https://github.com/trussworks/react-uswds/compare/4.0.0...4.1.0) (2023-02-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trussworks/react-uswds",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "React USWDS 3.0 component library",
   "keywords": [
     "react",
@@ -130,7 +130,6 @@
     "glob-parent": "5.1.2",
     "trim": "0.0.3",
     "trim-newlines": "3.0.1"
-
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### [4.1.1](https://github.com/trussworks/react-uswds/compare/4.1.0...4.1.1) (2023-02-23)

Various dependency updates, including ones to resolve critical security warnings

[Preview differences since 4.1.0](https://github.com/trussworks/react-uswds/compare/4.1.0...9d0e5c5229b1f6b744c52fd29a6e935e598b6d9f)