### PR TITLE
docs: Update old references from USWDS 2.0 to USWDS 3.0

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Accordion component
+### USWDS 3.0 Accordion component
 
 Source: https://designsystem.digital.gov/components/accordion/
 `,

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -10,7 +10,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Alert component
+### USWDS 3.0 Alert component
 
 Source: https://designsystem.digital.gov/components/alert/
 `,

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Button component
+### USWDS 3.0 Button component
 
 Source: https://designsystem.digital.gov/components/button/
 `,

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -10,7 +10,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 ButtonGroup component
+### USWDS 3.0 ButtonGroup component
 
 Source: https://designsystem.digital.gov/components/button-groups/
 `,

--- a/src/components/Collection/Collection.stories.tsx
+++ b/src/components/Collection/Collection.stories.tsx
@@ -26,7 +26,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.10.0 Collection component
+### USWDS 3.0 Collection component
         `,
       },
     },

--- a/src/components/Footer/Address/Address.stories.tsx
+++ b/src/components/Footer/Address/Address.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-Display address items (most likely links or simple text) in a row, wrapped in address tag.  Used in USWDS 2.0 Footer component.
+Display address items (most likely links or simple text) in a row, wrapped in address tag.  Used in USWDS 3.0 Footer component.
 
 Source: https://designsystem.digital.gov/components/footer
 `,

--- a/src/components/Footer/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer/Footer.stories.tsx
@@ -21,7 +21,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Footer component
+### USWDS 3.0 Footer component
 
 Source: https://designsystem.digital.gov/components/footer
 `,

--- a/src/components/Footer/FooterNav/FooterNav.stories.tsx
+++ b/src/components/Footer/FooterNav/FooterNav.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-Display single list of nav items, or grouped nav items in an extended nav. Used in USWDS 2.0 Footer component.
+Display single list of nav items, or grouped nav items in an extended nav. Used in USWDS 3.0 Footer component.
 
 Source: https://designsystem.digital.gov/components/footer
 `,

--- a/src/components/Footer/Logo/Logo.stories.tsx
+++ b/src/components/Footer/Logo/Logo.stories.tsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component: `
-Display logo image with optional heading.  Used in USWDS 2.0 Footer component.
+Display logo image with optional heading.  Used in USWDS 3.0 Footer component.
 
 Source: https://designsystem.digital.gov/components/footer
 `,

--- a/src/components/Footer/SocialLinks/SocialLinks.stories.tsx
+++ b/src/components/Footer/SocialLinks/SocialLinks.stories.tsx
@@ -9,7 +9,7 @@ export default {
     docs: {
       description: {
         component: `
-Display social links in styled row. Used in USWDS 2.0 Footer component.
+Display social links in styled row. Used in USWDS 3.0 Footer component.
 
 Source: https://designsystem.digital.gov/components/footer
 `,

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -13,7 +13,8 @@ export default {
     docs: {
       description: {
         component: `
-###USWDS 2.0 Icon component
+###USWDS 3.0 Icon component
+
 Source: https://designsystem.digital.gov/components/icon/
 `,
       },

--- a/src/components/Icon/Icons.stories.tsx
+++ b/src/components/Icon/Icons.stories.tsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component: `
-###USWDS 2.0 Icon component
+###USWDS 3.0 Icon component
 Source: https://designsystem.digital.gov/components/icon/
 `,
       },

--- a/src/components/IconList/IconList.stories.tsx
+++ b/src/components/IconList/IconList.stories.tsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component: `
-###USWDS 2.0 Icon list component
+###USWDS 3.0 Icon list component
 Source: https://designsystem.digital.gov/components/icon-list/
 `,
       },

--- a/src/components/Identifier/Identifier/Identifier.stories.tsx
+++ b/src/components/Identifier/Identifier/Identifier.stories.tsx
@@ -22,7 +22,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Identifier component
+### USWDS 3.0 Identifier component
         
 Source: https://designsystem.digital.gov/components/identifier/
 `,

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -14,7 +14,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Modal component
+### USWDS 3.0 Modal component
 
 Source: http://designsystem.digital.gov/components/modal
 

--- a/src/components/Modal/OpenModal.stories.tsx
+++ b/src/components/Modal/OpenModal.stories.tsx
@@ -24,7 +24,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Modal component
+### USWDS 3.0 Modal component
 
 Source: http://designsystem.digital.gov/components/modal
 `,

--- a/src/components/ProcessList/ProcessList/ProcessList.stories.tsx
+++ b/src/components/ProcessList/ProcessList/ProcessList.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 ProcessList component
+### USWDS 3.0 ProcessList component
 
 Source: https://designsystem.digital.gov/components/process-list
 `,

--- a/src/components/Search/Search/Search.stories.tsx
+++ b/src/components/Search/Search/Search.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Search component
+### USWDS 3.0 Search component
 
 Source: https://designsystem.digital.gov/components/search/
 `,

--- a/src/components/Search/SearchButton/SearchButton.stories.tsx
+++ b/src/components/Search/SearchButton/SearchButton.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Search component
+### USWDS 3.0 Search component
 
 Source: https://designsystem.digital.gov/components/search/
 `,
@@ -21,9 +21,7 @@ const sampleLocalization = {
   buttonText: 'Buscar',
 }
 
-export const defaultSearchButton = (): React.ReactElement => (
-  <SearchButton  />
-)
+export const defaultSearchButton = (): React.ReactElement => <SearchButton />
 
 export const bigSearchButton = (): React.ReactElement => (
   <SearchButton size="big" />

--- a/src/components/Search/SearchField/SearchField.stories.tsx
+++ b/src/components/Search/SearchField/SearchField.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Search Field component
+### USWDS 3.0 Search Field component
 
 Source: https://designsystem.digital.gov/components/search/
 `,
@@ -17,11 +17,10 @@ Source: https://designsystem.digital.gov/components/search/
   },
 }
 
-
 export const defaultSearchField = (): React.ReactElement => (
-  <SearchField placeholder='Search...' />
+  <SearchField placeholder="Search..." />
 )
 
 export const bigSearchField = (): React.ReactElement => (
-  <SearchField placeholder='Type something here...' isBig />
+  <SearchField placeholder="Type something here..." isBig />
 )

--- a/src/components/SiteAlert/SiteAlert.stories.tsx
+++ b/src/components/SiteAlert/SiteAlert.stories.tsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 SiteAlert component
+### USWDS 3.0 SiteAlert component
 
 Source: http://designsystem.digital.gov/components/site-alert
 `,

--- a/src/components/SummaryBox/SummaryBox/SummaryBox.stories.tsx
+++ b/src/components/SummaryBox/SummaryBox/SummaryBox.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 SummaryBox component
+### USWDS 3.0 SummaryBox component
 
 Source: https://designsystem.digital.gov/components/summary-box
 `,

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Table component
+### USWDS 3.0 Table component
 
 Source: https://designsystem.digital.gov/components/table/
 `,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 
 import styles from './Table.module.css'
 
-interface TableProps {
+type TableProps = {
   bordered?: boolean
   caption?: React.ReactNode
   children: React.ReactNode

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Tag component
+### USWDS 3.0 Tag component
 
 Source: https://designsystem.digital.gov/components/tag/
 `,

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -22,7 +22,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Tooltip component
+### USWDS 3.0 Tooltip component
 
 Source: https://designsystem.digital.gov/components/tooltip/
 `,

--- a/src/components/banner/CustomBanner.stories.tsx
+++ b/src/components/banner/CustomBanner.stories.tsx
@@ -73,7 +73,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Banner component
+### USWDS 3.0 Banner component
 
 Source: https://designsystem.digital.gov/components/banner/
 `,

--- a/src/components/banner/GovBanner/GovBanner.stories.tsx
+++ b/src/components/banner/GovBanner/GovBanner.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Banner component
+### USWDS 3.0 Banner component
 
 Source: https://designsystem.digital.gov/components/banner/
 `,

--- a/src/components/breadcrumb/BreadcrumbBar/BreadcrumbBar.stories.tsx
+++ b/src/components/breadcrumb/BreadcrumbBar/BreadcrumbBar.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Breadcrumb component
+### USWDS 3.0 Breadcrumb component
 
 Provide secondary navigation to help users understand where they are in a website.
     

--- a/src/components/card/Card.stories.tsx
+++ b/src/components/card/Card.stories.tsx
@@ -30,7 +30,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Card components
+### USWDS 3.0 Card components
 
 Source: https://designsystem.digital.gov/components/card/
 `,

--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Character count component
+### USWDS 3.0 Character count component
 
 Source: https://designsystem.digital.gov/components/character-count
 `,

--- a/src/components/forms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/forms/Checkbox/Checkbox.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Checkbox component
+### USWDS 3.0 Checkbox component
 
 Source: https://designsystem.digital.gov/components/checkbox
 `,

--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -14,7 +14,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 ComboBox component
+### USWDS 3.0 ComboBox component
 
 Source: https://designsystem.digital.gov/components/combo-box
 `,

--- a/src/components/forms/DateInput/DateInput.stories.tsx
+++ b/src/components/forms/DateInput/DateInput.stories.tsx
@@ -10,7 +10,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 DateInput component
+### USWDS 3.0 DateInput component
 
 Source: https://designsystem.digital.gov/components/date-input
 `,

--- a/src/components/forms/DateInput/DateInput.stories.tsx
+++ b/src/components/forms/DateInput/DateInput.stories.tsx
@@ -12,7 +12,7 @@ export default {
         component: `
 ### USWDS 3.0 DateInput component
 
-Source: https://designsystem.digital.gov/components/date-input
+Source: https://designsystem.digital.gov/components/text-input/
 `,
       },
     },

--- a/src/components/forms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/forms/DatePicker/DatePicker.stories.tsx
@@ -18,7 +18,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 DatePicker component
+### USWDS 3.0 DatePicker component
 
 Source: https://designsystem.digital.gov/components/date-picker
 

--- a/src/components/forms/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.stories.tsx
@@ -23,7 +23,7 @@ export default {
     docs: {
       description: {
         component: `
-  ### USWDS 2.0 Date Range Picker component
+  ### USWDS 3.0 Date Range Picker component
   Source: https://designsystem.digital.gov/components/date-range-picker
         `,
       },

--- a/src/components/forms/Dropdown/Dropdown.stories.tsx
+++ b/src/components/forms/Dropdown/Dropdown.stories.tsx
@@ -12,7 +12,7 @@ export default {
         component: `
 ### USWDS 3.0 Dropdown component
 
-Source: https://designsystem.digital.gov/components/dropdown
+Source: https://designsystem.digital.gov/components/select/
 `,
       },
     },

--- a/src/components/forms/Dropdown/Dropdown.stories.tsx
+++ b/src/components/forms/Dropdown/Dropdown.stories.tsx
@@ -10,7 +10,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Dropdown component
+### USWDS 3.0 Dropdown component
 
 Source: https://designsystem.digital.gov/components/dropdown
 `,

--- a/src/components/forms/ErrorMessage/ErrorMessage.stories.tsx
+++ b/src/components/forms/ErrorMessage/ErrorMessage.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 ErrorMessage component
+### USWDS 3.0 ErrorMessage component
 
 Source: https://designsystem.digital.gov/components/form-controls/
 `,

--- a/src/components/forms/Fieldset/Fieldset.stories.tsx
+++ b/src/components/forms/Fieldset/Fieldset.stories.tsx
@@ -13,7 +13,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Fieldset component
+### USWDS 3.0 Fieldset component
 
 Source: https://designsystem.digital.gov/components/form-controls/
 `,

--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -16,7 +16,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 FileInput component
+### USWDS 3.0 FileInput component
 Source: https://designsystem.digital.gov/components/file-input
 `,
       },

--- a/src/components/forms/Form/Form.stories.tsx
+++ b/src/components/forms/Form/Form.stories.tsx
@@ -19,7 +19,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Form component
+### USWDS 3.0 Form component
 
 Source: https://designsystem.digital.gov/components/form-templates/
 `,

--- a/src/components/forms/FormGroup/FormGroup.stories.tsx
+++ b/src/components/forms/FormGroup/FormGroup.stories.tsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 FormGroup component
+### USWDS 3.0 FormGroup component
 
 Source: https://designsystem.digital.gov/components/form-templates/
 `,

--- a/src/components/forms/InputPrefix/InputPrefix.stories.tsx
+++ b/src/components/forms/InputPrefix/InputPrefix.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 InputPrefix component
+### USWDS 3.0 InputPrefix component
 
 Source: https://designsystem.digital.gov/components/input-prefix-suffix/
 `,

--- a/src/components/forms/InputSuffix/InputSuffix.stories.tsx
+++ b/src/components/forms/InputSuffix/InputSuffix.stories.tsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 InputSuffix component
+### USWDS 3.0 InputSuffix component
 
 Source: https://designsystem.digital.gov/components/input-prefix-suffix/
 `,

--- a/src/components/forms/Label/Label.stories.tsx
+++ b/src/components/forms/Label/Label.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Label component
+### USWDS 3.0 Label component
 
 Source: https://designsystem.digital.gov/components/form-controls/
 `,

--- a/src/components/forms/Radio/Radio.stories.tsx
+++ b/src/components/forms/Radio/Radio.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Radio component
+### USWDS 3.0 Radio component
 
 Source: https://designsystem.digital.gov/components/radio-buttons
 `,

--- a/src/components/forms/RangeInput/RangeInput.stories.tsx
+++ b/src/components/forms/RangeInput/RangeInput.stories.tsx
@@ -9,7 +9,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 RangeInput component
+### USWDS 3.0 RangeInput component
 
 Source: https://designsystem.digital.gov/components/range-slider
 `,

--- a/src/components/forms/TextInput/TextInput.stories.tsx
+++ b/src/components/forms/TextInput/TextInput.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 TextInput component
+### USWDS 3.0 TextInput component
 
 Source: https://designsystem.digital.gov/components/text-input
 `,

--- a/src/components/forms/Textarea/Textarea.stories.tsx
+++ b/src/components/forms/Textarea/Textarea.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Textarea component
+### USWDS 3.0 Textarea component
 
 Source: https://designsystem.digital.gov/components/text-input
 `,

--- a/src/components/forms/TimePicker/TimePicker.stories.tsx
+++ b/src/components/forms/TimePicker/TimePicker.stories.tsx
@@ -14,7 +14,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 TimePicker component
+### USWDS 3.0 TimePicker component
 
 https://designsystem.digital.gov/components/time-picker/
 `,

--- a/src/components/forms/Validation/Validation.stories.tsx
+++ b/src/components/forms/Validation/Validation.stories.tsx
@@ -16,7 +16,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Validation component
+### USWDS 3.0 Validation component
 
 Source: https://designsystem.digital.gov/components/validation
 `,

--- a/src/components/grid/Grid.stories.tsx
+++ b/src/components/grid/Grid.stories.tsx
@@ -10,7 +10,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Grid components
+### USWDS 3.0 Grid components
 
 Source: https://designsystem.digital.gov/utilities/layout-grid/
 `,

--- a/src/components/header/ExtendedNav/ExtendedNav.stories.tsx
+++ b/src/components/header/ExtendedNav/ExtendedNav.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 ExtendedNav component used within the Header component
+### USWDS 3.0 ExtendedNav component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/Header/Header.stories.tsx
+++ b/src/components/header/Header/Header.stories.tsx
@@ -17,7 +17,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Header component
+### USWDS 3.0 Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/MegaMenu/MegaMenu.stories.tsx
+++ b/src/components/header/MegaMenu/MegaMenu.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 MegaMenu component used within the Header component
+### USWDS 3.0 MegaMenu component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/Menu/Menu.stories.tsx
+++ b/src/components/header/Menu/Menu.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Menu component used within the Header component
+### USWDS 3.0 Menu component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/NavCloseButton/NavCloseButton.stories.tsx
+++ b/src/components/header/NavCloseButton/NavCloseButton.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 NavCloseButton Component used within the Header component
+### USWDS 3.0 NavCloseButton Component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/NavDropDownButton/NavDropDownButton.stories.tsx
+++ b/src/components/header/NavDropDownButton/NavDropDownButton.stories.tsx
@@ -10,7 +10,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 NavDropDownButton component used within the Header component
+### USWDS 3.0 NavDropDownButton component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/NavList/NavList.stories.tsx
+++ b/src/components/header/NavList/NavList.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 NavList component used within the Header component
+### USWDS 3.0 NavList component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/NavMenuButton/NavMenuButton.stories.tsx
+++ b/src/components/header/NavMenuButton/NavMenuButton.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 NavMenuButton used within the Header component
+### USWDS 3.0 NavMenuButton used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/PrimaryNav/PrimaryNav.stories.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 PrimaryNav component used within the Header component
+### USWDS 3.0 PrimaryNav component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/header/Title/Title.stories.tsx
+++ b/src/components/header/Title/Title.stories.tsx
@@ -8,7 +8,7 @@ export default {
     docs: {
       description: {
         component: `
-### USWDS 2.0 Title component used within the Header component
+### USWDS 3.0 Title component used within the Header component
 
 Source: https://designsystem.digital.gov/components/header/
 `,

--- a/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
@@ -6,12 +6,17 @@ export default {
   title: 'Components/Step Indicator',
   component: StepIndicator,
   parameters: {
-    info: `
-    ### USWDS 3.0 Step Indicator component
-    Source: https://designsystem.digital.gov/components/step-indicator/
+    docs: {
+      description: {
+        component: `
+### USWDS 3.0 Step Indicator component
 
-    Updates users on their progress through a multi-step process.
+Source: https://designsystem.digital.gov/components/step-indicator/
+
+Updates users on their progress through a multi-step process.
     `,
+      },
+    },
   },
 }
 

--- a/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
@@ -7,7 +7,7 @@ export default {
   component: StepIndicator,
   parameters: {
     info: `
-    ### USWDS 2.0 Step Indicator component
+    ### USWDS 3.0 Step Indicator component
     Source: https://designsystem.digital.gov/components/step-indicator/
 
     Updates users on their progress through a multi-step process.


### PR DESCRIPTION
# Summary
- Update Storybook components to reference USWDS 3.0
- Fix broken links for `DateInput` and `Dropdown` components
- Fix type error in `Table` component
- Fix component description in `StepIndicator` component
## Related Issues or PRs
https://github.com/trussworks/react-uswds/issues/2236
<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
