### PR TITLE
build: allow manual triggering of build checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '[1-9].*'
+  workflow_dispatch:
 
 jobs:
   deploy-storybook:


### PR DESCRIPTION
# Summary

To make it easier to approve 3rd party PRs and debug the build checks, this PR is making it so we can manually trigger the build checks workflow.

Also allow manual trigger of storybook deploy to allow for debugging of that workflow when changes are needed.

## How To Test

Not possible until merged, sadly.