### PR TITLE
fix: Fix FileInput in SSR

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -222,6 +222,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "sawyerh",
+      "name": "sawyerh",
+      "avatar_url": "https://avatars.githubusercontent.com/u/371943?v=4",
+      "profile": "https://github.com/sawyerh",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -222,15 +222,6 @@
       "contributions": [
         "code"
       ]
-    },
-    {
-      "login": "sawyerh",
-      "name": "sawyerh",
-      "avatar_url": "https://avatars.githubusercontent.com/u/371943?v=4",
-      "profile": "https://github.com/sawyerh",
-      "contributions": [
-        "code"
-      ]
     }
   ],
   "contributorsPerLine": 7

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -1,4 +1,10 @@
-import React, { useState, forwardRef, useRef, useImperativeHandle } from 'react'
+import React, {
+  useState,
+  forwardRef,
+  useRef,
+  useImperativeHandle,
+  useEffect,
+} from 'react'
 import classnames from 'classnames'
 
 import { FilePreview } from './FilePreview'
@@ -41,6 +47,17 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
   const [isDragging, setIsDragging] = useState(false)
   const [showError, setShowError] = useState(false)
   const [files, setFiles] = useState<File[]>([])
+  const [hideDragText, setHideDragText] = useState(false)
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return
+
+    const hideDragText =
+      /rv:11.0/i.test(navigator?.userAgent) ||
+      /Edge\/\d./i.test(navigator?.userAgent)
+
+    setHideDragText(hideDragText)
+  }, [typeof navigator])
 
   useImperativeHandle(
     ref,
@@ -64,11 +81,6 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     'usa-file-input--drag': isDragging,
     'has-invalid-file': showError,
   })
-
-  const hideDragText =
-    typeof navigator === 'undefined' ||
-    /rv:11.0/i.test(navigator.userAgent) ||
-    /Edge\/\d./i.test(navigator.userAgent)
 
   const dragText = multiple ? 'Drag files here or ' : 'Drag file here or '
 

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -66,6 +66,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
   })
 
   const hideDragText =
+    typeof navigator === 'undefined' ||
     /rv:11.0/i.test(navigator.userAgent) ||
     /Edge\/\d./i.test(navigator.userAgent)
 


### PR DESCRIPTION
# Summary

`navigator` is only available in a browser environment, and calling it on the server causes an exception. 

Checking if `navigator` is defined isn't enough however, since that causes a different React error:

```
Error: Text content does not match server-rendered HTML.

See more info here: https://nextjs.org/docs/messages/react-hydration-error
```

To resolve both issues, I've followed the suggestion in the link above, to run the check in `useEffect`.

## Related Issues or PRs

Resolves #2366

## How To Test

I tested this locally with a Next.js app by:

1. Running `yarn build`
1. Running `npm link` in the library's directory
1. Running `npm link @trussworks/react-uswds` in the Next.js project
1. Rendering `FileInput` in the Next.js project
1. Running `npm run dev` in the Next.js project and confirming no errors occur

### Screenshots

<img width="511" alt="CleanShot 2023-04-30 at 10 17 43@2x" src="https://user-images.githubusercontent.com/371943/235366947-1c610112-cd2b-4e59-9563-87df4f32ec7c.png">

