### PR TITLE
feat: InputGroup component

### DIFF
--- a/src/components/forms/InputGroup/InputGroup.test.tsx
+++ b/src/components/forms/InputGroup/InputGroup.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { InputGroup } from './InputGroup'
+
+describe('InputGroup component', () => {
+  it('renders without errors', () => {
+    const { queryByTestId } = render(<InputGroup>My Input Group</InputGroup>)
+    expect(queryByTestId('inputGroup')).toBeInTheDocument()
+  })
+
+  it('renders its children', () => {
+    const { queryByText } = render(<InputGroup>My Input Group</InputGroup>)
+    expect(queryByText('My Input Group')).toBeInTheDocument()
+  })
+})

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-interface InputGroupProps {
+export interface InputGroupProps {
   children: React.ReactNode
   className?: string
   error?: boolean

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import classnames from 'classnames'
+
+interface InputGroupProps {
+  children: React.ReactNode
+  className?: string
+  error?: boolean
+}
+
+export const InputGroup = ({
+  children,
+  className,
+  error,
+}: InputGroupProps): React.ReactElement => {
+  const classes = classnames(
+    'usa-input-group',
+    { 'usa-input-group--error': error },
+    className
+  )
+
+  return (
+    <div data-testid="inputGroup" className={classes}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/forms/InputPrefix/InputPrefix.stories.tsx
+++ b/src/components/forms/InputPrefix/InputPrefix.stories.tsx
@@ -3,6 +3,7 @@ import { InputPrefix } from './InputPrefix'
 import { Icon } from '../../Icon/Icons'
 import { TextInput } from '../TextInput/TextInput'
 import { InputGroup } from '../InputGroup/InputGroup'
+import { FormGroup } from '../FormGroup/FormGroup'
 
 export default {
   title: 'Components/Input prefix or suffix/InputPrefix',
@@ -21,24 +22,30 @@ Source: https://designsystem.digital.gov/components/input-prefix-suffix/
 }
 
 export const InputWithTextInputPrefix = (): React.ReactElement => (
-  <InputGroup>
-    <InputPrefix>cvc</InputPrefix>
-    <TextInput id="cvc" name="cvc" type="text" />
-  </InputGroup>
+  <FormGroup>
+    <InputGroup>
+      <InputPrefix>cvc</InputPrefix>
+      <TextInput id="cvc" name="cvc" type="text" />
+    </InputGroup>
+  </FormGroup>
 )
 
 export const InputWithTextInputPrefixError = (): React.ReactElement => (
-  <InputGroup error>
-    <InputPrefix>cvc</InputPrefix>
-    <TextInput id="cvc" name="cvc" type="text" validationStatus="error" />
-  </InputGroup>
+  <FormGroup>
+    <InputGroup error>
+      <InputPrefix>cvc</InputPrefix>
+      <TextInput id="cvc" name="cvc" type="text" validationStatus="error" />
+    </InputGroup>
+  </FormGroup>
 )
 
 export const InputWithIconInputPrefix = (): React.ReactElement => (
-  <InputGroup>
-    <InputPrefix>
-      <Icon.CreditCard />
-    </InputPrefix>
-    <TextInput id="card" name="card" type="text" />
-  </InputGroup>
+  <FormGroup>
+    <InputGroup>
+      <InputPrefix>
+        <Icon.CreditCard />
+      </InputPrefix>
+      <TextInput id="card" name="card" type="text" />
+    </InputGroup>
+  </FormGroup>
 )

--- a/src/components/forms/InputPrefix/InputPrefix.stories.tsx
+++ b/src/components/forms/InputPrefix/InputPrefix.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { InputPrefix } from './InputPrefix'
 import { Icon } from '../../Icon/Icons'
 import { TextInput } from '../TextInput/TextInput'
-import { FormGroup } from '../FormGroup/FormGroup'
+import { InputGroup } from '../InputGroup/InputGroup'
 
 export default {
   title: 'Components/Input prefix or suffix/InputPrefix',
@@ -21,30 +21,24 @@ Source: https://designsystem.digital.gov/components/input-prefix-suffix/
 }
 
 export const InputWithTextInputPrefix = (): React.ReactElement => (
-  <FormGroup>
-    <div className="usa-input-group">
-      <InputPrefix>cvc</InputPrefix>
-      <TextInput id="cvc" name="cvc" type="text" />
-    </div>
-  </FormGroup>
+  <InputGroup>
+    <InputPrefix>cvc</InputPrefix>
+    <TextInput id="cvc" name="cvc" type="text" />
+  </InputGroup>
 )
 
 export const InputWithTextInputPrefixError = (): React.ReactElement => (
-  <FormGroup>
-    <div className="usa-input-group usa-input-group--error">
-      <InputPrefix>cvc</InputPrefix>
-      <TextInput id="cvc" name="cvc" type="text" validationStatus="error" />
-    </div>
-  </FormGroup>
+  <InputGroup error>
+    <InputPrefix>cvc</InputPrefix>
+    <TextInput id="cvc" name="cvc" type="text" validationStatus="error" />
+  </InputGroup>
 )
 
 export const InputWithIconInputPrefix = (): React.ReactElement => (
-  <FormGroup>
-    <div className="usa-input-group">
-      <InputPrefix>
-        <Icon.CreditCard />
-      </InputPrefix>
-      <TextInput id="card" name="card" type="text" />
-    </div>
-  </FormGroup>
+  <InputGroup>
+    <InputPrefix>
+      <Icon.CreditCard />
+    </InputPrefix>
+    <TextInput id="card" name="card" type="text" />
+  </InputGroup>
 )

--- a/src/components/forms/InputSuffix/InputSuffix.stories.tsx
+++ b/src/components/forms/InputSuffix/InputSuffix.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { InputSuffix } from './InputSuffix'
 import { InputGroup } from '../InputGroup/InputGroup'
+import { FormGroup } from '../FormGroup/FormGroup'
 import { TextInput } from '../TextInput/TextInput'
 import { Icon } from '../../Icon/Icons'
 
@@ -21,31 +22,37 @@ Source: https://designsystem.digital.gov/components/input-prefix-suffix/
 }
 
 export const InputWithIconInputSuffix = (): React.ReactElement => (
-  <InputGroup>
-    <TextInput id="search" name="search" type="search" />
-    <InputSuffix>
-      <Icon.Search />
-    </InputSuffix>
-  </InputGroup>
+  <FormGroup>
+    <InputGroup>
+      <TextInput id="search" name="search" type="search" />
+      <InputSuffix>
+        <Icon.Search />
+      </InputSuffix>
+    </InputGroup>
+  </FormGroup>
 )
 
 export const InputWithIconInputSuffixError = (): React.ReactElement => (
-  <InputGroup error>
-    <TextInput
-      id="search"
-      name="search"
-      type="search"
-      validationStatus="error"
-    />
-    <InputSuffix>
-      <Icon.Search />
-    </InputSuffix>
-  </InputGroup>
+  <FormGroup>
+    <InputGroup error>
+      <TextInput
+        id="search"
+        name="search"
+        type="search"
+        validationStatus="error"
+      />
+      <InputSuffix>
+        <Icon.Search />
+      </InputSuffix>
+    </InputGroup>
+  </FormGroup>
 )
 
 export const InputWithTextInputSuffix = (): React.ReactElement => (
-  <InputGroup>
-    <TextInput id="weight" name="weight" type="text" />
-    <InputSuffix>lbs.</InputSuffix>
-  </InputGroup>
+  <FormGroup>
+    <InputGroup>
+      <TextInput id="weight" name="weight" type="text" />
+      <InputSuffix>lbs.</InputSuffix>
+    </InputGroup>
+  </FormGroup>
 )

--- a/src/components/forms/InputSuffix/InputSuffix.stories.tsx
+++ b/src/components/forms/InputSuffix/InputSuffix.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { InputSuffix } from './InputSuffix'
-import { FormGroup } from '../FormGroup/FormGroup'
+import { InputGroup } from '../InputGroup/InputGroup'
 import { TextInput } from '../TextInput/TextInput'
 import { Icon } from '../../Icon/Icons'
 
@@ -21,37 +21,31 @@ Source: https://designsystem.digital.gov/components/input-prefix-suffix/
 }
 
 export const InputWithIconInputSuffix = (): React.ReactElement => (
-  <FormGroup>
-    <div className="usa-input-group">
-      <TextInput id="search" name="search" type="search" />
-      <InputSuffix>
-        <Icon.Search />
-      </InputSuffix>
-    </div>
-  </FormGroup>
+  <InputGroup>
+    <TextInput id="search" name="search" type="search" />
+    <InputSuffix>
+      <Icon.Search />
+    </InputSuffix>
+  </InputGroup>
 )
 
 export const InputWithIconInputSuffixError = (): React.ReactElement => (
-  <FormGroup>
-    <div className="usa-input-group usa-input-group--error">
-      <TextInput
-        id="search"
-        name="search"
-        type="search"
-        validationStatus="error"
-      />
-      <InputSuffix>
-        <Icon.Search />
-      </InputSuffix>
-    </div>
-  </FormGroup>
+  <InputGroup error>
+    <TextInput
+      id="search"
+      name="search"
+      type="search"
+      validationStatus="error"
+    />
+    <InputSuffix>
+      <Icon.Search />
+    </InputSuffix>
+  </InputGroup>
 )
 
 export const InputWithTextInputSuffix = (): React.ReactElement => (
-  <FormGroup>
-    <div className="usa-input-group usa-input-group--sm">
-      <TextInput id="weight" name="weight" type="text" />
-      <InputSuffix>lbs.</InputSuffix>
-    </div>
-  </FormGroup>
+  <InputGroup>
+    <TextInput id="weight" name="weight" type="text" />
+    <InputSuffix>lbs.</InputSuffix>
+  </InputGroup>
 )


### PR DESCRIPTION
# Summary

## Related Issues or PRs
Resolves #1692 
<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test
Check unit tests

I did not add a Storybook component for this, but rather updated the `InputPrefix` and `InputSuffix` components to use `InputGroup` instead of a `div`. Happy to come back and add a Storybook component, but wasn't sure how to approach that in this context. Let me know if I need to make that change!
<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)