### PR TITLE
fix: misapplied attribute

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -102,7 +102,7 @@ export const Accordion = ({
     <div
       className={classes}
       data-testid="accordion"
-      aria-multiselectable={multiselectable || undefined}>
+      data-allow-multiple={multiselectable || undefined}>
       {items.map((item, i) => (
         <AccordionItem
           key={`accordionItem_${i}`}


### PR DESCRIPTION
# Summary

USWDS's [accordion](https://designsystem.digital.gov/components/accordion/) component has a 'multiselectable' variant, however that is different from the [aria-multiselectable](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute. The latter is used for elements that are selectable (e.g. in a `<select>`) to some other end, whereas the former is simply toggled open/closed to its own end. As such, I replaced the `aria-multiselectable` attribute with [`data-allow-multiple`](https://designsystem.digital.gov/components/accordion/#using-the-accordion-component-2) as USWDS intended.

## Related Issues or PRs

Resolves #2204 

## How To Test

Open Axe on Chrome and inspect the [multiselectable accordion page](http://localhost:9009/iframe.html?args=&id=components-accordion--multiselectable&viewMode=story) to find no errors:
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/764090/236932093-047a35fb-79bb-4691-ac3d-90b4197ea3c3.png">


### Screenshots (optional)
