### PR TITLE
added customizable text control to file input

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -158,3 +158,15 @@ export const withRefAndCustomHandlers = (
     </>
   )
 }
+
+export const customText = (): React.ReactElement => (
+  <FormGroup>
+    <Label htmlFor="file-input-single">La entrada acepta un solo archivo</Label>
+    <FileInput 
+      id="file-input-single" 
+      name="file-input-single" 
+      dragText="Arrastre el archivo aquí o "
+      folderText="elija de una carpeta"
+    />
+  </FormGroup>
+)

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -13,6 +13,8 @@ import { makeSafeForID } from './utils'
 type FileInputProps = {
   id: string
   name: string
+  dragText?: string
+  folderText?: string
   disabled?: boolean
   multiple?: boolean
   accept?: string
@@ -33,6 +35,8 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
   {
     name,
     id,
+    dragText,
+    folderText,
     disabled,
     multiple,
     className,
@@ -82,7 +86,8 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     'has-invalid-file': showError,
   })
 
-  const dragText = multiple ? 'Drag files here or ' : 'Drag file here or '
+  const defaultDragText = multiple ? 'Drag files here or ' : 'Drag file here or '
+  const defaultFolderText = 'choose from folder'
 
   const filePreviews = []
   if (files) {
@@ -189,9 +194,9 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
           className={instructionClasses}
           aria-hidden="true">
           {!hideDragText && (
-            <span className="usa-file-input__drag-text">{dragText}</span>
+            <span className="usa-file-input__drag-text">{dragText || defaultDragText}</span>
           )}
-          <span className="usa-file-input__choose">choose from folder</span>
+          <span className="usa-file-input__choose">{folderText || defaultFolderText}</span>
         </div>
         {filePreviews}
         <div data-testid="file-input-box" className="usa-file-input__box"></div>


### PR DESCRIPTION
# Summary

Adds property to FileInput component to allow text inside component to be customized. Before, it was hardcoded making it inappropriate for mobile and non-English contexts.

## Related Issues or PRs

Resolves #2399 

## How To Test

* Give custom text to either or both `dragText` and `folderText`
* Ensure all other file input functions behave as before

### Screenshots (optional)
<img width="764" alt="image" src="https://github.com/trussworks/react-uswds/assets/764090/764bef97-8fd7-4a2a-bff6-539f2a7b8a0a">