### PR TITLE
Select Deprecation edits

### DIFF
--- a/src/components/forms/Dropdown/Dropdown.test.tsx
+++ b/src/components/forms/Dropdown/Dropdown.test.tsx
@@ -1,18 +1,24 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+jest.mock('../../../deprecation')
+import { deprecationWarning } from '../../../deprecation'
 
-import { Select } from '../Select/Select'
+import { Dropdown } from './Dropdown'
 
 describe('Dropdown component', () => {
-  it('renders without errors', () => {
+  it('renders without errors, displaying a deprecation warning', () => {
     const { queryByTestId } = render(
-      <Select id="input-type-text" name="input-type-text">
+      <Dropdown id="input-type-text" name="input-type-text">
         <option>- Select - </option>
         <option value="value1">Option A</option>
         <option value="value2">Option B</option>
         <option value="value3">Option C</option>
-      </Select>
+      </Dropdown>
     )
     expect(queryByTestId('Select')).toBeInTheDocument()
+    expect(deprecationWarning).toHaveBeenCalledTimes(1)
+    expect(deprecationWarning).toHaveBeenCalledWith(
+      'Dropdown is deprecated and will be removed in the future. Please use the Select component instead.'
+    )
   })
 })

--- a/src/components/forms/Dropdown/Dropdown.tsx
+++ b/src/components/forms/Dropdown/Dropdown.tsx
@@ -1,52 +1,11 @@
 /*
-  @deprecated Make updates to the Select component instead
-  @todo Remove this component
+  TODO: Remove this component
 */
 
-import React from 'react'
 import { Select } from '../Select/Select'
 import { withDeprecationWarning } from '../../hoc/withDeprecationWarning'
-import { ValidationStatus } from '../../../types/validationStatus'
 
-type DropdownProps = {
-  id: string
-  name: string
-  className?: string
-  children: React.ReactNode
-  validationStatus?: ValidationStatus
-  inputRef?:
-    | string
-    | ((instance: HTMLSelectElement | null) => void)
-    | React.RefObject<HTMLSelectElement>
-    | null
-    | undefined
-}
-
-export const Dropdown = ({
-  id,
-  name,
-  className,
-  inputRef,
-  children,
-  validationStatus,
-  ...inputProps
-}: DropdownProps & JSX.IntrinsicElements['select']): React.ReactElement => {
-  const deprecationWarningMessage = 'Dropdown is deprecated and will be removed in the future. Please use the Select component instead.'
-  const DeprecatedDropdown = withDeprecationWarning(
-    Select,
-    deprecationWarningMessage
-  )
-  return (
-    <DeprecatedDropdown
-      validationStatus={validationStatus}
-      className={className}
-      id={id}
-      name={name}
-      ref={inputRef}
-      {...inputProps}>
-      {children}
-    </DeprecatedDropdown>
-  )
-}
-
-export default Dropdown
+export const Dropdown = withDeprecationWarning(
+  Select,
+  'Dropdown is deprecated and will be removed in the future. Please use the Select component instead.'
+)

--- a/src/components/forms/Select/Select.tsx
+++ b/src/components/forms/Select/Select.tsx
@@ -48,5 +48,3 @@ export const Select = ({
     </select>
   )
 }
-
-export default Select


### PR DESCRIPTION
# Summary

Batched PR feedback/suggestions for #2415 

## How To Test

Unit tests, storybook

### Screenshots (optional)

Dropdown still works, and displays deprecation warning:
<img width="1085" alt="image" src="https://github.com/trussworks/react-uswds/assets/15805554/49c34575-d89d-4e23-8478-ab215c3f6de2">

Select of course also works, does not display deprecation warning:
<img width="1082" alt="image" src="https://github.com/trussworks/react-uswds/assets/15805554/9faec1ba-79d7-4bef-8736-7f97ef473c5a">

