### PR TITLE
chore(ci): Perform linting and formatting in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,3 @@ updates:
         versions:
           - '>=7.0.0'
       - dependency-name: 'uswds'
-      - dependency-name: 'husky'
-        versions:
-          - '>=5.0.0'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version-file: '.node-version'
           cache: 'yarn'
 
       # The yarn cache is not node_modules

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Lint code
         run: yarn lint
 
+      - name: Check format
+        run: yarn format:check
+
       - name: Happo
         run: yarn happo-ci
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
 
       # The yarn cache is not node_modules

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -15,12 +15,12 @@ jobs:
       url: ${{ steps.build-publish.outputs.page_url }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version-file: '.node-version'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -16,12 +16,12 @@ jobs:
       
     steps: 
       - name: Checkout out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version-file: '.node-version'
           cache: 'yarn'
       
       # The yarn cache is not node_modules

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -11,12 +11,12 @@ jobs:
     name: Publish next to Github Packages
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version-file: '.node-version'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -36,10 +36,10 @@ jobs:
 
       # Setup .npmrc file to publish to GitHub Packages
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           registry-url: 'https://npm.pkg.github.com'
-          node-version: '16.x'
+          node-version-file: '.node-version'
 
       # Publish to GitHub Packages
       - run: yarn publish --no-git-tag-version --prerelease --preid alpha-$(date +%Y%m%d%H%M%S) --tag next

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,10 +74,20 @@ More guidance for preferred React practices can be found in the [adding new comp
 
 ### Linting, formatting, & automated tests
 
-Because this project exports a library that will be used by other projects, it is important that updates follow a set of standard practices. When you commit your changes, several hooks will run to check and format staged files. In order to be eligible for merging, all branches must pass the following automation.
+Because this project exports a library that will be used by other projects, it is important that updates follow a set of standard practices. When you PR your changes, several hooks will run to check and format changed files. In order to be eligible for merging, all branches must pass the following automation.
 
-- [Prettier](https://prettier.io/), [TypeScript compilation](https://www.typescriptlang.org/), [eslint](https://eslint.org/) and [stylelint](https://stylelint.io/) are run on _staged files_ as a pre-commit hook/
+- Code format and linting are enforced with automations.
+  - We use the following tools: 
+    - [Prettier](https://prettier.io/)
+    - [TypeScript compilation](https://www.typescriptlang.org/)
+    - [eslint](https://eslint.org/)
+    - [stylelint](https://stylelint.io/)
+  - GitHub Actions are used to check each PR for format and linting compliance
   - For an optimal developer experience, it's recommended that you configure your editor to run linting & formatting inline.
+  - It is also possible to invoke the tools manually
+    - To check code format compliance, run `yarn format:check`
+    - To auto-fix code format, run `yarn format:fix`
+    - To check typescript complication, eslint, and stylelint, run `yarn lint`
 - [dangerjs](https://github.com/danger/danger-js) is used to enforce several pull request standards, including:
   - Changes to package source code should include changes to tests.
   - New `src/components` files should include changes to storybook.

--- a/package.json
+++ b/package.json
@@ -96,9 +96,7 @@
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "happo-plugin-storybook": "^3.0.0",
     "happo.io": "^8.3.1",
-    "husky": "^8.0.3",
     "jest": "^26.1.0",
-    "lint-staged": "^13.0.3",
     "mini-css-extract-plugin": "^2.6.1",
     "prettier": "^2.7.1",
     "react": "^17.0.1",
@@ -130,22 +128,6 @@
     "glob-parent": "5.1.2",
     "trim": "0.0.3",
     "trim-newlines": "3.0.1"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc && lint-staged",
-      "pre-push": "yarn danger local -b main --failOnErrors"
-    }
-  },
-  "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json,md}": [
-      "prettier --write",
-      "eslint"
-    ],
-    "src/**/*.{css,scss}": [
-      "prettier --write",
-      "stylelint"
-    ]
   },
   "standard-version": {
     "skip": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "build": "tsc -p tsconfig.build.json && webpack --progress",
     "build:watch": "tsc -p tsconfig.build.json && webpack --watch",
     "lint": "tsc && eslint --ext js,jsx,ts,tsx src && stylelint \"src/**/*.{css,scss}\"",
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
+    "format:fix": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
     "release": "standard-version -t ''",
     "prepare": "yarn build",
     "prepublishOnly": "yarn test && yarn lint",

--- a/src/components/Footer/SocialLinks/SocialLinks.tsx
+++ b/src/components/Footer/SocialLinks/SocialLinks.tsx
@@ -54,6 +54,8 @@ export const SocialLink = ({
   }
 
   return (
-    <a className="usa-social-link" {...props} title={name}>{icon}</a>
+    <a className="usa-social-link" {...props} title={name}>
+      {icon}
+    </a>
   )
 }

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -235,17 +235,12 @@ describe('Pagination component', () => {
     expect(screen.getAllByText('…')).toHaveLength(1)
   })
 
-  it('doesn\'t render last page when unbounded', () => {
-    const randomPage = Math.random()*1000
-    render(
-      <Pagination
-        currentPage={randomPage}
-        pathname={testPathname}
-      />
-    )
-    expect(screen.getByLabelText(`Page ${randomPage+1}`)).toHaveAttribute(
+  it("doesn't render last page when unbounded", () => {
+    const randomPage = Math.random() * 1000
+    render(<Pagination currentPage={randomPage} pathname={testPathname} />)
+    expect(screen.getByLabelText(`Page ${randomPage + 1}`)).toHaveAttribute(
       'href',
-      `${testPathname}?page=${randomPage+1}`
+      `${testPathname}?page=${randomPage + 1}`
     )
   })
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -92,13 +92,16 @@ export const Pagination = ({
   const showOverflow = totalPages ? totalPages > maxSlots : true // If more pages than slots, use overflow indicator(s)
 
   const middleSlot = Math.round(maxSlots / 2) // 4 if maxSlots is 7
-  const isBeforeMiddleSlot = !!(totalPages && totalPages - currentPage >= middleSlot)
+  const isBeforeMiddleSlot = !!(
+    totalPages && totalPages - currentPage >= middleSlot
+  )
   const showPrevOverflow = showOverflow && currentPage > middleSlot
   const showNextOverflow = isBeforeMiddleSlot || !totalPages
   // Assemble array of page numbers to be shown
-  const currentPageRange: Array<number | 'overflow'> = showOverflow || !totalPages
-    ? [currentPage]
-    : Array.from({ length: totalPages }).map((_, i) => i + 1)
+  const currentPageRange: Array<number | 'overflow'> =
+    showOverflow || !totalPages
+      ? [currentPage]
+      : Array.from({ length: totalPages }).map((_, i) => i + 1)
 
   if (showOverflow) {
     // Determine range of pages to show based on current page & number of slots
@@ -151,7 +154,8 @@ export const Pagination = ({
     if (showPrevOverflow) currentPageRange.unshift('overflow')
     if (currentPage !== 1) currentPageRange.unshift(1)
     if (showNextOverflow) currentPageRange.push('overflow')
-    if (totalPages && currentPage !== totalPages) currentPageRange.push(totalPages)
+    if (totalPages && currentPage !== totalPages)
+      currentPageRange.push(totalPages)
   }
 
   const prevPage = !isOnFirstPage && currentPage - 1

--- a/src/components/Search/Search/Search.test.tsx
+++ b/src/components/Search/Search/Search.test.tsx
@@ -42,10 +42,7 @@ describe('Search component', () => {
     const { queryByTestId } = render(
       <Search onSubmit={mockSubmit} defaultValue={defaultValue}></Search>
     )
-    expect(queryByTestId('textInput')).toHaveAttribute(
-      'value',
-      defaultValue
-    )
+    expect(queryByTestId('textInput')).toHaveAttribute('value', defaultValue)
   })
 
   it('renders a label', () => {
@@ -72,13 +69,19 @@ describe('Search component', () => {
   it('adds small class when size prop is small', () => {
     const mockSubmit = jest.fn()
     const { container } = render(<Search onSubmit={mockSubmit} size="small" />)
-    expect(container.querySelector('div.usa-search--small button')).toBeInTheDocument()
+    expect(
+      container.querySelector('div.usa-search--small button')
+    ).toBeInTheDocument()
   })
 
   it('adds big class when size prop is big', () => {
     const mockSubmit = jest.fn()
     const { container } = render(<Search onSubmit={mockSubmit} size="big" />)
-    expect(container.querySelector('div.usa-search--big button')).toBeInTheDocument()
-    expect(container.querySelector('div.usa-search--big input')).toBeInTheDocument()
+    expect(
+      container.querySelector('div.usa-search--big button')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('div.usa-search--big input')
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/Search/Search/Search.tsx
+++ b/src/components/Search/Search/Search.tsx
@@ -34,11 +34,7 @@ export const Search = ({
   inputProps,
   ...formProps
 }: SearchInputProps & OptionalFormProps): React.ReactElement => {
-
-  const classes = classnames(
-    'usa-search',
-    className
-  )
+  const classes = classnames('usa-search', className)
 
   return (
     <Form
@@ -47,7 +43,7 @@ export const Search = ({
       role="search"
       search={true}
       {...formProps}>
-      <SearchField 
+      <SearchField
         {...inputProps}
         isBig={size == 'big'}
         inputId={inputId}

--- a/src/components/Search/SearchButton/SearchButton.test.tsx
+++ b/src/components/Search/SearchButton/SearchButton.test.tsx
@@ -8,24 +8,18 @@ const sampleLocalization = {
 
 describe('SearchButton component', () => {
   it('renders without errors', () => {
-    const { queryByRole } = render(
-      <SearchButton />
-    )
+    const { queryByRole } = render(<SearchButton />)
     expect(queryByRole('button')).toHaveTextContent('Search')
   })
 
   it('does not render button text when small', () => {
-    const { queryByRole } = render(
-      <SearchButton size="small" />
-    )
+    const { queryByRole } = render(<SearchButton size="small" />)
 
     expect(queryByRole('button')).not.toHaveTextContent('Search')
   })
 
   it('internationalization', () => {
-    const { queryByText } = render(
-      <SearchButton i18n={sampleLocalization} />
-    )
+    const { queryByText } = render(<SearchButton i18n={sampleLocalization} />)
 
     expect(queryByText('Buscar')).toBeInTheDocument()
   })

--- a/src/components/Search/SearchButton/SearchButton.tsx
+++ b/src/components/Search/SearchButton/SearchButton.tsx
@@ -18,7 +18,7 @@ type SearchButtonProps = {
 export const SearchButton = ({
   size,
   className,
-  i18n
+  i18n,
 }: SearchButtonProps): React.ReactElement => {
   const buttonText = i18n?.buttonText || 'Search'
   const isSmall = size === 'small'
@@ -33,12 +33,16 @@ export const SearchButton = ({
   )
   return (
     <div className={classes}>
-        <Button type="submit">
-            {!isSmall && (
-                <span className="usa-search__submit-text">{buttonText}</span>
-            )}
-            <Icon.Search className="usa-search__submit-icon" name={buttonText} size={3}/>
-        </Button>
+      <Button type="submit">
+        {!isSmall && (
+          <span className="usa-search__submit-text">{buttonText}</span>
+        )}
+        <Icon.Search
+          className="usa-search__submit-icon"
+          name={buttonText}
+          size={3}
+        />
+      </Button>
     </div>
   )
 }

--- a/src/components/Search/SearchField/SearchField.test.tsx
+++ b/src/components/Search/SearchField/SearchField.test.tsx
@@ -4,17 +4,13 @@ import { SearchField } from './SearchField'
 
 describe('SearchField component', () => {
   it('renders without errors', () => {
-    const { queryByTestId } = render(
-      <SearchField />
-    )
+    const { queryByTestId } = render(<SearchField />)
     expect(queryByTestId('textInput')).toBeInTheDocument()
   })
 
   it('renders a placeholder', () => {
     const placeholder = 'SearchFieldhere'
-    const { queryByTestId } = render(
-      <SearchField placeholder={placeholder} />
-    )
+    const { queryByTestId } = render(<SearchField placeholder={placeholder} />)
     expect(queryByTestId('textInput')).toHaveAttribute(
       'placeholder',
       placeholder
@@ -26,10 +22,7 @@ describe('SearchField component', () => {
     const { queryByTestId } = render(
       <SearchField defaultValue={defaultValue} />
     )
-    expect(queryByTestId('textInput')).toHaveAttribute(
-      'value',
-      defaultValue
-    )
+    expect(queryByTestId('textInput')).toHaveAttribute('value', defaultValue)
   })
 
   it('passes input props', () => {
@@ -39,13 +32,11 @@ describe('SearchField component', () => {
     const input = getByTestId('textInput')
 
     expect(input).toHaveAttribute('required')
-    expect(input).toHaveAttribute('minLength', "6")
+    expect(input).toHaveAttribute('minLength', '6')
   })
 
   it('renders a label', () => {
-    const { queryByLabelText } = render(
-      <SearchField label="Buscar" />
-    )
+    const { queryByLabelText } = render(<SearchField label="Buscar" />)
 
     expect(queryByLabelText('Buscar')).toBeInTheDocument()
   })

--- a/src/components/Search/SearchField/SearchField.tsx
+++ b/src/components/Search/SearchField/SearchField.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { Label } from '../../forms/Label/Label'
-import { TextInput, OptionalTextInputProps } from '../../forms/TextInput/TextInput'
-
+import {
+  TextInput,
+  OptionalTextInputProps,
+} from '../../forms/TextInput/TextInput'
 
 type SearchFieldProps = {
   isBig?: boolean
@@ -24,7 +26,7 @@ export const SearchField = ({
   inputName = 'search',
   label = 'Search',
   inputId = 'search-field',
-  inputProps
+  inputProps,
 }: SearchFieldProps & OptionalTextInputProps): React.ReactElement => {
   const classes = classnames(
     {
@@ -34,7 +36,7 @@ export const SearchField = ({
   )
 
   return (
-    <div className={classes} data-testid='searchField'>
+    <div className={classes} data-testid="searchField">
       <Label srOnly={true} htmlFor={inputId}>
         {label}
       </Label>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -28,15 +28,17 @@ export const Table = ({
   compact,
   stackedStyle = 'none',
 }: TableProps): React.ReactElement => {
-  const classes = classnames('usa-table', {
-    'usa-table--borderless': !bordered,
-    'width-full': fullWidth,
-    [`${styles.fixed}`]: fixed,
-    'usa-table--striped': striped,
-    'usa-table--compact': compact,
-    'usa-table--stacked': stackedStyle === 'default',
-    'usa-table--stacked-header': stackedStyle === 'headers',
-  }, 
+  const classes = classnames(
+    'usa-table',
+    {
+      'usa-table--borderless': !bordered,
+      'width-full': fullWidth,
+      [`${styles.fixed}`]: fixed,
+      'usa-table--striped': striped,
+      'usa-table--compact': compact,
+      'usa-table--stacked': stackedStyle === 'default',
+      'usa-table--stacked-header': stackedStyle === 'headers',
+    },
     className
   )
 

--- a/src/components/banner/CustomBanner.stories.tsx
+++ b/src/components/banner/CustomBanner.stories.tsx
@@ -51,10 +51,13 @@ const CustomBanner = (): ReactElement => {
             <MediaBlockBody>
               <p>
                 <strong>Secure .gov websites use HTTPS</strong>
-                <br />A <strong>lock (<Icon.Lock aria-label="Locked padlock icon" />)</strong> or{' '}
-                <strong>https://</strong> means you&apos;ve safely connected to
-                the .gov website. Share sensitive information only on official,
-                secure websites.
+                <br />A{' '}
+                <strong>
+                  lock (<Icon.Lock aria-label="Locked padlock icon" />)
+                </strong>{' '}
+                or <strong>https://</strong> means you&apos;ve safely connected
+                to the .gov website. Share sensitive information only on
+                official, secure websites.
               </p>
             </MediaBlockBody>
           </BannerGuidance>

--- a/src/components/banner/GovBanner/GovBanner.tsx
+++ b/src/components/banner/GovBanner/GovBanner.tsx
@@ -57,9 +57,13 @@ const getCopy = (language: Language, tld: TLD): GovBannerCopy => {
         httpsSectionHeader: `Secure ${tld} websites use HTTPS`,
         httpsSectionContent: (
           <>
-            A <strong>lock (<Icon.Lock aria-label="Locked padlock icon"/>)</strong> or <strong>https://</strong>{' '}
-            means you’ve safely connected to the {tld} website. Share sensitive
-            information only on official, secure websites.
+            A{' '}
+            <strong>
+              lock (<Icon.Lock aria-label="Locked padlock icon" />)
+            </strong>{' '}
+            or <strong>https://</strong> means you’ve safely connected to the{' '}
+            {tld} website. Share sensitive information only on official, secure
+            websites.
           </>
         ),
       }
@@ -90,10 +94,13 @@ const getCopy = (language: Language, tld: TLD): GovBannerCopy => {
         httpsSectionHeader: `Los sitios web seguros ${tld} usan HTTPS`,
         httpsSectionContent: (
           <>
-            Un <strong>candado (<Icon.Lock aria-label="Icono de candado cerrado" />)</strong> o <strong>https://</strong>{' '}
-            significa que usted se conectó de forma segura a un sitio web {tld}.
-            Comparta información sensible sólo en sitios web oficiales y
-            seguros.
+            Un{' '}
+            <strong>
+              candado (<Icon.Lock aria-label="Icono de candado cerrado" />)
+            </strong>{' '}
+            o <strong>https://</strong> significa que usted se conectó de forma
+            segura a un sitio web {tld}. Comparta información sensible sólo en
+            sitios web oficiales y seguros.
           </>
         ),
       }

--- a/src/components/banner/GovBanner/__snapshots__/GovBanner.test.tsx.snap
+++ b/src/components/banner/GovBanner/__snapshots__/GovBanner.test.tsx.snap
@@ -111,7 +111,8 @@ exports[`GovBanner component static content renders consistently in English for 
                 Secure .gov websites use HTTPS
               </strong>
               <br />
-              A 
+              A
+               
               <strong>
                 lock (
                 <svg
@@ -122,12 +123,13 @@ exports[`GovBanner component static content renders consistently in English for 
                 />
                 )
               </strong>
-               or 
+               
+              or 
               <strong>
                 https://
               </strong>
+               means you’ve safely connected to the
                
-              means you’ve safely connected to the 
               .gov
                website. Share sensitive information only on official, secure websites.
             </p>
@@ -250,7 +252,8 @@ exports[`GovBanner component static content renders consistently in English for 
                 Secure .mil websites use HTTPS
               </strong>
               <br />
-              A 
+              A
+               
               <strong>
                 lock (
                 <svg
@@ -261,12 +264,13 @@ exports[`GovBanner component static content renders consistently in English for 
                 />
                 )
               </strong>
-               or 
+               
+              or 
               <strong>
                 https://
               </strong>
+               means you’ve safely connected to the
                
-              means you’ve safely connected to the 
               .mil
                website. Share sensitive information only on official, secure websites.
             </p>
@@ -389,7 +393,8 @@ exports[`GovBanner component static content renders consistently in Spanish for 
                 Los sitios web seguros .gov usan HTTPS
               </strong>
               <br />
-              Un 
+              Un
+               
               <strong>
                 candado (
                 <svg
@@ -400,12 +405,12 @@ exports[`GovBanner component static content renders consistently in Spanish for 
                 />
                 )
               </strong>
-               o 
+               
+              o 
               <strong>
                 https://
               </strong>
-               
-              significa que usted se conectó de forma segura a un sitio web 
+               significa que usted se conectó de forma segura a un sitio web 
               .gov
               . Comparta información sensible sólo en sitios web oficiales y seguros.
             </p>
@@ -528,7 +533,8 @@ exports[`GovBanner component static content renders consistently in Spanish for 
                 Los sitios web seguros .mil usan HTTPS
               </strong>
               <br />
-              Un 
+              Un
+               
               <strong>
                 candado (
                 <svg
@@ -539,12 +545,12 @@ exports[`GovBanner component static content renders consistently in Spanish for 
                 />
                 )
               </strong>
-               o 
+               
+              o 
               <strong>
                 https://
               </strong>
-               
-              significa que usted se conectó de forma segura a un sitio web 
+               significa que usted se conectó de forma segura a un sitio web 
               .mil
               . Comparta información sensible sólo en sitios web oficiales y seguros.
             </p>
@@ -667,7 +673,8 @@ exports[`GovBanner component static content renders consistently with default pr
                 Secure .gov websites use HTTPS
               </strong>
               <br />
-              A 
+              A
+               
               <strong>
                 lock (
                 <svg
@@ -678,12 +685,13 @@ exports[`GovBanner component static content renders consistently with default pr
                 />
                 )
               </strong>
-               or 
+               
+              or 
               <strong>
                 https://
               </strong>
+               means you’ve safely connected to the
                
-              means you’ve safely connected to the 
               .gov
                website. Share sensitive information only on official, secure websites.
             </p>

--- a/src/components/forms/CharacterCount/CharacterCount.test.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.test.tsx
@@ -154,7 +154,10 @@ describe('CharacterCount component', () => {
         </>
       )
       const textareaDefaultValue = getByDisplayValue('Prefilled defaultValue')
-      expect(textareaDefaultValue).toHaveAttribute('name', 'character-count-defaultValue')
+      expect(textareaDefaultValue).toHaveAttribute(
+        'name',
+        'character-count-defaultValue'
+      )
       expect(textareaDefaultValue).toHaveAttribute('rows', '5')
       expect(textareaDefaultValue).toBe(tRef.current)
       const textareaValue = getByDisplayValue('Prefilled value')

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -120,13 +120,15 @@ export const CharacterCount = ({
       id: id,
       name: name,
       className: classes,
-      ...(value ? {value: value} : {defaultValue: defaultValue}),
-      onBlur: (e: React.FocusEvent<HTMLTextAreaElement, Element>): void => handleBlur(e, onBlur),
-      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>): void => handleChange(e, onChange),
+      ...(value ? { value: value } : { defaultValue: defaultValue }),
+      onBlur: (e: React.FocusEvent<HTMLTextAreaElement, Element>): void =>
+        handleBlur(e, onBlur),
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>): void =>
+        handleChange(e, onChange),
       inputRef: inputRef,
       ...textAreaProps,
     }
-    InputComponent = (<Textarea {...attributes} />)
+    InputComponent = <Textarea {...attributes} />
   } else {
     const {
       onBlur,
@@ -140,13 +142,15 @@ export const CharacterCount = ({
       type: type,
       name: name,
       className: classes,
-      ...(value ? {value: value} : {defaultValue: defaultValue}),
-      onBlur: (e: React.FocusEvent<HTMLInputElement, Element>): void => handleBlur(e, onBlur),
-      onChange: (e: React.ChangeEvent<HTMLInputElement>): void => handleChange(e, onChange),
+      ...(value ? { value: value } : { defaultValue: defaultValue }),
+      onBlur: (e: React.FocusEvent<HTMLInputElement, Element>): void =>
+        handleBlur(e, onBlur),
+      onChange: (e: React.ChangeEvent<HTMLInputElement>): void =>
+        handleChange(e, onChange),
       inputRef: inputRef,
       ...inputProps,
     }
-    InputComponent = (<TextInput {...attributes} />)
+    InputComponent = <TextInput {...attributes} />
   }
 
   return (

--- a/src/components/forms/DatePicker/Calendar.tsx
+++ b/src/components/forms/DatePicker/Calendar.tsx
@@ -31,7 +31,7 @@ const CalendarModes = {
   YEAR_PICKER: 'YEAR_PICKER',
 } as const
 
-type CalendarMode = typeof CalendarModes[keyof typeof CalendarModes]
+type CalendarMode = (typeof CalendarModes)[keyof typeof CalendarModes]
 
 import { Day } from './Day'
 import { MonthPicker } from './MonthPicker'

--- a/src/components/forms/DatePicker/DatePicker.test.tsx
+++ b/src/components/forms/DatePicker/DatePicker.test.tsx
@@ -1,5 +1,11 @@
 import React, { ComponentProps } from 'react'
-import { render, fireEvent, createEvent, waitFor, screen } from '@testing-library/react'
+import {
+  render,
+  fireEvent,
+  createEvent,
+  waitFor,
+  screen,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { DatePicker } from './DatePicker'
@@ -26,7 +32,7 @@ describe('DatePicker component', () => {
   ) => {
     const allProps = {
       ...testProps,
-      ...props
+      ...props,
     }
     const rendered = render(<DatePicker {...allProps} />)
     const queryForDatePicker = () => screen.queryByTestId('date-picker')
@@ -106,7 +112,7 @@ describe('DatePicker component', () => {
 
   // https://github.com/uswds/uswds/blob/develop/spec/unit/date-picker/date-picker.spec.js#L933
   it('prevents default action if keyup doesn’t originate within the calendar', async () => {
-    const { getByTestId } = renderDatePicker({defaultValue: "2021-01-20"})
+    const { getByTestId } = renderDatePicker({ defaultValue: '2021-01-20' })
 
     const calendarEl = getByTestId('date-picker-calendar')
     await userEvent.click(getByTestId('date-picker-button'))
@@ -131,7 +137,9 @@ describe('DatePicker component', () => {
     })
 
     it('shows the calendar when the toggle button is clicked and focuses on the selected date', async () => {
-      const { getByTestId, getByText } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId, getByText } = renderDatePicker({
+        defaultValue: '2021-01-20',
+      })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).toBeVisible()
       expect(getByTestId('date-picker')).toHaveClass('usa-date-picker--active')
@@ -189,7 +197,9 @@ describe('DatePicker component', () => {
     })
 
     it('adds Selected date to the status text if the selected date and the focused date are the same', async () => {
-      const { getByTestId, getByText } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId, getByText } = renderDatePicker({
+        defaultValue: '2021-01-20',
+      })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).toBeVisible()
       expect(getByTestId('date-picker')).toHaveClass('usa-date-picker--active')
@@ -205,9 +215,9 @@ describe('DatePicker component', () => {
 
     it('coerces the display date to a valid value', async () => {
       const { getByTestId, getByLabelText } = renderDatePicker({
-        defaultValue: "2021-01-06",
-        minDate: "2021-01-10",
-        maxDate: "2021-01-20",
+        defaultValue: '2021-01-06',
+        minDate: '2021-01-10',
+        maxDate: '2021-01-20',
       })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByLabelText('6 January 2021 Wednesday')).not.toHaveFocus()
@@ -236,7 +246,7 @@ describe('DatePicker component', () => {
 
   describe('status text', () => {
     it('shows instructions in the status text when the calendar is opened', async () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId } = renderDatePicker({ defaultValue: '2021-01-20' })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).toBeVisible()
       expect(getByTestId('date-picker')).toHaveClass('usa-date-picker--active')
@@ -259,7 +269,9 @@ describe('DatePicker component', () => {
     })
 
     it('removes instructions from the status text when the calendar is already open and the displayed date changes', async () => {
-      const { getByTestId, getByLabelText } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId, getByLabelText } = renderDatePicker({
+        defaultValue: '2021-01-20',
+      })
 
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).toBeVisible()
@@ -312,7 +324,9 @@ describe('DatePicker component', () => {
     })
 
     it('does not add Selected date to the status text if the selected date and the focused date are not the same', async () => {
-      const { getByTestId, getByLabelText } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId, getByLabelText } = renderDatePicker({
+        defaultValue: '2021-01-20',
+      })
 
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).toBeVisible()
@@ -343,7 +357,7 @@ describe('DatePicker component', () => {
 
   describe('with the required prop', () => {
     it('the external input is required, and the internal input is not required', () => {
-      const { getByTestId } = renderDatePicker({required: true})
+      const { getByTestId } = renderDatePicker({ required: true })
       expect(getByTestId('date-picker-external-input')).toBeRequired()
       expect(getByTestId('date-picker-internal-input')).not.toBeRequired()
     })
@@ -351,14 +365,14 @@ describe('DatePicker component', () => {
 
   describe('with the disabled prop', () => {
     it('the toggle button and external inputs are disabled, and the internal input is not disabled', () => {
-      const { getByTestId } = renderDatePicker({disabled: true})
+      const { getByTestId } = renderDatePicker({ disabled: true })
       expect(getByTestId('date-picker-button')).toBeDisabled()
       expect(getByTestId('date-picker-external-input')).toBeDisabled()
       expect(getByTestId('date-picker-internal-input')).not.toBeDisabled()
     })
 
     it('does not show the calendar when the toggle button is clicked', async () => {
-      const { getByTestId } = renderDatePicker({disabled: true})
+      const { getByTestId } = renderDatePicker({ disabled: true })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).not.toBeVisible()
       expect(getByTestId('date-picker')).not.toHaveClass(
@@ -369,7 +383,7 @@ describe('DatePicker component', () => {
 
   describe('with a default value prop', () => {
     it('the internal input value is the date string, and the external input value is the formatted date', () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "1988-05-16"})
+      const { getByTestId } = renderDatePicker({ defaultValue: '1988-05-16' })
       expect(getByTestId('date-picker-external-input')).toHaveValue(
         '05/16/1988'
       )
@@ -379,12 +393,15 @@ describe('DatePicker component', () => {
     })
 
     it('validates a valid default value', () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "1988-05-16"})
+      const { getByTestId } = renderDatePicker({ defaultValue: '1988-05-16' })
       expect(getByTestId('date-picker-external-input')).toBeValid()
     })
 
     it('validates an invalid default value', () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "1990-01-01", minDate: "2020-01-01"})
+      const { getByTestId } = renderDatePicker({
+        defaultValue: '1990-01-01',
+        minDate: '2020-01-01',
+      })
 
       expect(getByTestId('date-picker-external-input')).toBeInvalid()
     })
@@ -392,14 +409,19 @@ describe('DatePicker component', () => {
 
   describe('with localization props', () => {
     it('displays abbreviated translations for days of the week', async () => {
-      const { getByText, getByTestId } = renderDatePicker({i18n: sampleLocalization})
+      const { getByText, getByTestId } = renderDatePicker({
+        i18n: sampleLocalization,
+      })
       await userEvent.click(getByTestId('date-picker-button'))
       sampleLocalization.daysOfWeekShort.forEach((translation) => {
         expect(getByText(translation)).toBeInTheDocument()
       })
     })
     it('displays translation for month', async () => {
-      const { getByText, getByTestId } = renderDatePicker({defaultValue: "2020-02-01", i18n: sampleLocalization})
+      const { getByText, getByTestId } = renderDatePicker({
+        defaultValue: '2020-02-01',
+        i18n: sampleLocalization,
+      })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByText('febrero')).toBeInTheDocument()
     })
@@ -408,7 +430,10 @@ describe('DatePicker component', () => {
   describe('selecting a date', () => {
     it('clicking a date button selects that date and closes the calendar and focuses the external input', async () => {
       const mockOnChange = jest.fn()
-      const { getByText, getByTestId } = renderDatePicker({defaultValue: "2021-01-20", onChange: mockOnChange})
+      const { getByText, getByTestId } = renderDatePicker({
+        defaultValue: '2021-01-20',
+        onChange: mockOnChange,
+      })
       await userEvent.click(getByTestId('date-picker-button'))
       const dateButton = getByText('15')
       expect(dateButton).toHaveClass('usa-date-picker__calendar__date')
@@ -449,7 +474,9 @@ describe('DatePicker component', () => {
   describe('typing in a date', () => {
     it('typing a date in the external input updates the selected date', async () => {
       const mockOnChange = jest.fn()
-      const { getByTestId, getByText } = renderDatePicker({onChange: mockOnChange})
+      const { getByTestId, getByText } = renderDatePicker({
+        onChange: mockOnChange,
+      })
       await userEvent.type(
         getByTestId('date-picker-external-input'),
         '05/16/1988'
@@ -479,7 +506,9 @@ describe('DatePicker component', () => {
     })
 
     it('typing a date with the calendar open updates the calendar to the entered date', async () => {
-      const { getByTestId, getByText } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId, getByText } = renderDatePicker({
+        defaultValue: '2021-01-20',
+      })
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('select-month')).toHaveTextContent('January')
       expect(getByTestId('select-year')).toHaveTextContent('2021')
@@ -497,7 +526,7 @@ describe('DatePicker component', () => {
 
     it('implements a custom onBlur handler', async () => {
       const mockOnBlur = jest.fn()
-      const { getByTestId } = renderDatePicker({onBlur: mockOnBlur})
+      const { getByTestId } = renderDatePicker({ onBlur: mockOnBlur })
 
       await userEvent.type(
         getByTestId('date-picker-external-input'),
@@ -509,7 +538,10 @@ describe('DatePicker component', () => {
 
     // TODO - this is an outstanding difference in behavior from USWDS. Fails because validation happens onChange.
     it.skip('typing in the external input does not validate until blurring', async () => {
-      const { getByTestId } = renderDatePicker({minDate: "2021-01-20", maxDate: "2021-02-14"})
+      const { getByTestId } = renderDatePicker({
+        minDate: '2021-01-20',
+        maxDate: '2021-02-14',
+      })
 
       const externalInput = getByTestId('date-picker-external-input')
       expect(externalInput).toBeValid()
@@ -521,7 +553,10 @@ describe('DatePicker component', () => {
 
     // TODO - this can be implemented if the above test case is implemented
     it.skip('pressing the Enter key in the external input validates the date', async () => {
-      const { getByTestId } = renderDatePicker({minDate: "2021-01-20", maxDate: "2021-02-14"})
+      const { getByTestId } = renderDatePicker({
+        minDate: '2021-01-20',
+        maxDate: '2021-02-14',
+      })
 
       const externalInput = getByTestId('date-picker-external-input')
       expect(externalInput).toBeValid()
@@ -547,7 +582,7 @@ describe('DatePicker component', () => {
 
     it('entering a non-date value sets a validation message', async () => {
       const mockOnChange = jest.fn()
-      const { getByTestId } = renderDatePicker({onChange: mockOnChange})
+      const { getByTestId } = renderDatePicker({ onChange: mockOnChange })
       const externalInput = getByTestId(
         'date-picker-external-input'
       ) as HTMLInputElement
@@ -565,7 +600,7 @@ describe('DatePicker component', () => {
 
     it('entering a non-date value sets a validation message', async () => {
       const mockOnChange = jest.fn()
-      const { getByTestId } = renderDatePicker({onChange: mockOnChange})
+      const { getByTestId } = renderDatePicker({ onChange: mockOnChange })
       const externalInput = getByTestId(
         'date-picker-external-input'
       ) as HTMLInputElement
@@ -578,7 +613,9 @@ describe('DatePicker component', () => {
 
     it('entering an invalid date sets a validation message and becomes valid when selecting a date in the calendar', async () => {
       const mockOnChange = jest.fn()
-      const { getByTestId, getByLabelText } = renderDatePicker({onChange: mockOnChange})
+      const { getByTestId, getByLabelText } = renderDatePicker({
+        onChange: mockOnChange,
+      })
       const externalInput = getByTestId(
         'date-picker-external-input'
       ) as HTMLInputElement
@@ -601,8 +638,8 @@ describe('DatePicker component', () => {
     it('entering a valid date outside of the min/max date sets a validation message', async () => {
       const mockOnChange = jest.fn()
       const { getByTestId } = renderDatePicker({
-        minDate: "2021-01-20",
-        maxDate: "2021-02-14",
+        minDate: '2021-01-20',
+        maxDate: '2021-02-14',
         onChange: mockOnChange,
       })
       const externalInput = getByTestId(
@@ -629,7 +666,7 @@ describe('DatePicker component', () => {
 
   describe('year selection', () => {
     it('clicking the selected year updates the status text', async () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId } = renderDatePicker({ defaultValue: '2021-01-20' })
       await userEvent.click(getByTestId('date-picker-button'))
       await userEvent.click(getByTestId('select-year'))
 
@@ -641,7 +678,7 @@ describe('DatePicker component', () => {
     })
 
     it('clicking previous year chunk updates the status text', async () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId } = renderDatePicker({ defaultValue: '2021-01-20' })
       await userEvent.click(getByTestId('date-picker-button'))
       await userEvent.click(getByTestId('select-year'))
       await userEvent.click(getByTestId('previous-year-chunk'))
@@ -654,7 +691,7 @@ describe('DatePicker component', () => {
     })
 
     it('clicking next year chunk navigates the year picker forward one chunk', async () => {
-      const { getByTestId } = renderDatePicker({defaultValue: "2021-01-20"})
+      const { getByTestId } = renderDatePicker({ defaultValue: '2021-01-20' })
       await userEvent.click(getByTestId('date-picker-button'))
       await userEvent.click(getByTestId('select-year'))
       await userEvent.click(getByTestId('next-year-chunk'))
@@ -670,14 +707,22 @@ describe('DatePicker component', () => {
   describe('validationStatus', () => {
     it('renders with error styling', () => {
       const { getByTestId } = renderDatePicker({ validationStatus: 'error' })
-      expect(getByTestId('date-picker-external-input')).toBeInstanceOf(HTMLInputElement)
-      expect(getByTestId('date-picker-external-input')).toHaveClass('usa-input--error')
+      expect(getByTestId('date-picker-external-input')).toBeInstanceOf(
+        HTMLInputElement
+      )
+      expect(getByTestId('date-picker-external-input')).toHaveClass(
+        'usa-input--error'
+      )
     })
 
     it('renders with success styling', () => {
       const { getByTestId } = renderDatePicker({ validationStatus: 'success' })
-      expect(getByTestId('date-picker-external-input')).toBeInstanceOf(HTMLInputElement)
-      expect(getByTestId('date-picker-external-input')).toHaveClass('usa-input--success')
+      expect(getByTestId('date-picker-external-input')).toBeInstanceOf(
+        HTMLInputElement
+      )
+      expect(getByTestId('date-picker-external-input')).toHaveClass(
+        'usa-input--success'
+      )
     })
   })
 })

--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -162,9 +162,9 @@ export const withRefAndCustomHandlers = (
 export const customText = (): React.ReactElement => (
   <FormGroup>
     <Label htmlFor="file-input-single">La entrada acepta un solo archivo</Label>
-    <FileInput 
-      id="file-input-single" 
-      name="file-input-single" 
+    <FileInput
+      id="file-input-single"
+      name="file-input-single"
       dragText="Arrastre el archivo aquí o "
       chooseText="elija de una carpeta"
     />

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -92,14 +92,22 @@ describe('FileInput component', () => {
   })
 
   it('displays custom text when given', () => {
-    const customProps = {...testProps, dragText: "Custom dragText", chooseText: "Custom chooseText"}
+    const customProps = {
+      ...testProps,
+      dragText: 'Custom dragText',
+      chooseText: 'Custom chooseText',
+    }
     const { getByTestId } = render(<FileInput {...customProps} />)
-    
-    const dragText = within(getByTestId('file-input-instructions')).getByText(customProps.dragText)
+
+    const dragText = within(getByTestId('file-input-instructions')).getByText(
+      customProps.dragText
+    )
     expect(dragText).toBeInTheDocument()
     expect(dragText).toHaveClass('usa-file-input__drag-text')
 
-    const chooseText = within(getByTestId('file-input-instructions')).getByText(customProps.chooseText)
+    const chooseText = within(getByTestId('file-input-instructions')).getByText(
+      customProps.chooseText
+    )
     expect(chooseText).toBeInTheDocument()
     expect(chooseText).toHaveClass('usa-file-input__choose')
   })

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -86,7 +86,9 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     'has-invalid-file': showError,
   })
 
-  const defaultDragText = multiple ? 'Drag files here or ' : 'Drag file here or '
+  const defaultDragText = multiple
+    ? 'Drag files here or '
+    : 'Drag file here or '
   const defaultChooseText = 'choose from folder'
 
   const filePreviews = []
@@ -194,9 +196,13 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
           className={instructionClasses}
           aria-hidden="true">
           {!hideDragText && (
-            <span className="usa-file-input__drag-text">{dragText || defaultDragText}</span>
+            <span className="usa-file-input__drag-text">
+              {dragText || defaultDragText}
+            </span>
           )}
-          <span className="usa-file-input__choose">{chooseText || defaultChooseText}</span>
+          <span className="usa-file-input__choose">
+            {chooseText || defaultChooseText}
+          </span>
         </div>
         {filePreviews}
         <div data-testid="file-input-box" className="usa-file-input__box"></div>

--- a/src/stories/swatches.stories.tsx
+++ b/src/stories/swatches.stories.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 
 export default {
   title: 'Design tokens/Swatches',
-  parameters: { 
-    options: { 
-      showPanel: false
-    }
-  }
+  parameters: {
+    options: {
+      showPanel: false,
+    },
+  },
 }
 
 export const BackgroundColors = (): React.ReactElement => (

--- a/src/stories/templates/createaccount.stories.tsx
+++ b/src/stories/templates/createaccount.stories.tsx
@@ -37,8 +37,8 @@ import { MediaBlockBody } from '../../components/mediablock/MediaBlockBody/Media
 export default {
   title: 'Page Templates/Authentication Pages',
   parameters: {
-    options: { 
-      showPanel: false
+    options: {
+      showPanel: false,
     },
     layout: 'fullscreen',
     docs: {

--- a/src/stories/templates/documentation.stories.tsx
+++ b/src/stories/templates/documentation.stories.tsx
@@ -28,8 +28,8 @@ import { SideNav } from '../../components/SideNav/SideNav'
 export default {
   title: 'Page Templates/Documentation Page',
   parameters: {
-    options: { 
-      showPanel: false
+    options: {
+      showPanel: false,
     },
     docs: {
       description: {

--- a/src/stories/templates/landing.stories.tsx
+++ b/src/stories/templates/landing.stories.tsx
@@ -28,8 +28,8 @@ import {
 export default {
   title: 'Page Templates/Landing Page',
   parameters: {
-    options: { 
-      showPanel: false
+    options: {
+      showPanel: false,
     },
     docs: {
       description: {

--- a/src/stories/templates/mutliplesignin.stories.tsx
+++ b/src/stories/templates/mutliplesignin.stories.tsx
@@ -32,8 +32,8 @@ import circleSvg from '@uswds/uswds/src/img/circle-gray-20.svg'
 export default {
   title: 'Page Templates/Authentication Pages',
   parameters: {
-    options: { 
-      showPanel: false
+    options: {
+      showPanel: false,
     },
     layout: 'fullscreen',
     docs: {

--- a/src/stories/templates/notfound.stories.tsx
+++ b/src/stories/templates/notfound.stories.tsx
@@ -37,8 +37,8 @@ import {
 export default {
   title: 'Page Templates/Not Found Page',
   parameters: {
-    options: { 
-      showPanel: false
+    options: {
+      showPanel: false,
     },
     docs: {
       description: {

--- a/src/stories/templates/signin.stories.tsx
+++ b/src/stories/templates/signin.stories.tsx
@@ -35,8 +35,8 @@ import circleSvg from '@uswds/uswds/src/img/circle-gray-20.svg'
 export default {
   title: 'Page Templates/Authentication Pages',
   parameters: {
-    options: { 
-      showPanel: false
+    options: {
+      showPanel: false,
     },
     layout: 'fullscreen',
     docs: {

--- a/src/stories/type.stories.tsx
+++ b/src/stories/type.stories.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 
 export default {
   title: 'Components/Typography/Type Styles',
-  parameters: { 
-    options: { 
-      showPanel: false
-    }
+  parameters: {
+    options: {
+      showPanel: false,
+    },
   },
 }
 

--- a/src/stories/welcome.stories.tsx
+++ b/src/stories/welcome.stories.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 
 export default {
   title: 'Welcome',
-  parameters: { 
-    options: { 
-      showPanel: false
-    }
-  }
+  parameters: {
+    options: {
+      showPanel: false,
+    },
+  },
 }
 
 export const Welcome = (): React.ReactElement => {
@@ -43,7 +43,10 @@ export const Welcome = (): React.ReactElement => {
       </div>
       <div className="display-flex flex-align-center flex-justify-center padding-top-4">
         <div className="margin-right-3" style={{ width: '150px' }}>
-          <img src="https://raw.githubusercontent.com/uswds/uswds-site/main/img/uswds-logo/4c-lg-white.svg" alt="USWDS logo" />
+          <img
+            src="https://raw.githubusercontent.com/uswds/uswds-site/main/img/uswds-logo/4c-lg-white.svg"
+            alt="USWDS logo"
+          />
         </div>
         <div>
           <h1 className="margin-y-0" style={{ maxWidth: '527px' }}>
@@ -52,7 +55,17 @@ export const Welcome = (): React.ReactElement => {
         </div>
       </div>
       <p className="line-height-sans-4">
-        This is a frontend component library built by <a href="https://truss.works">Truss</a>, using <a href="https://reactjs.org/">React</a> with <a href="https://www.typescriptlang.org/">Typescript</a>, based on design patterns defined by the <a href="https://designsystem.digital.gov/">United States Web Design System (USWDS)</a>. Our primary goal is to document and provide common UI components following the USWDS specification. This library removes a significant amount of overhead UI development for projects based on this standard.
+        This is a frontend component library built by{' '}
+        <a href="https://truss.works">Truss</a>, using{' '}
+        <a href="https://reactjs.org/">React</a> with{' '}
+        <a href="https://www.typescriptlang.org/">Typescript</a>, based on
+        design patterns defined by the{' '}
+        <a href="https://designsystem.digital.gov/">
+          United States Web Design System (USWDS)
+        </a>
+        . Our primary goal is to document and provide common UI components
+        following the USWDS specification. This library removes a significant
+        amount of overhead UI development for projects based on this standard.
       </p>
       <h2 className="margin-bottom-0">See also</h2>
       <ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4682,7 +4682,7 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
+ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -4709,11 +4709,6 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -4732,11 +4727,6 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
-
-ansi-styles@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.1.0.tgz#87313c102b8118abd57371afab34618bf7350ed3"
-  integrity sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==
 
 ansi-to-html@^0.6.11:
   version "0.6.15"
@@ -5819,11 +5809,6 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-chalk@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
-
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -6009,22 +5994,6 @@ cli-table3@^0.6.1:
   optionalDependencies:
     colors "1.4.0"
 
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
-  dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
-
-cli-truncate@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
-  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
-  dependencies:
-    slice-ansi "^5.0.0"
-    string-width "^5.0.0"
-
 cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
@@ -6128,7 +6097,7 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
-colorette@^2.0.14, colorette@^2.0.19:
+colorette@^2.0.14:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
@@ -6150,7 +6119,7 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@^10.0.0, commander@^10.0.1:
+commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
@@ -8037,21 +8006,6 @@ execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-execa@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-7.1.1.tgz#3eb3c83d239488e7b409d48e8813b76bb55c9c43"
-  integrity sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^6.0.1"
-    human-signals "^4.3.0"
-    is-stream "^3.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^5.1.0"
-    onetime "^6.0.0"
-    signal-exit "^3.0.7"
-    strip-final-newline "^3.0.0"
-
 execall@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/execall/-/execall-2.0.0.tgz#16a06b5fe5099df7d00be5d9c06eecded1663b45"
@@ -8798,7 +8752,7 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0, get-stream@^6.0.1:
+get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -9488,16 +9442,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-human-signals@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
-  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
-
-husky@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
-
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
@@ -9898,11 +9842,6 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-fullwidth-code-point@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
-  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
-
 is-function@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
@@ -10042,11 +9981,6 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
-
-is-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
-  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -11040,48 +10974,10 @@ li@^1.3.0:
   resolved "https://registry.yarnpkg.com/li/-/li-1.3.0.tgz#22c59bcaefaa9a8ef359cf759784e4bf106aea1b"
   integrity sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=
 
-lilconfig@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
-  integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
-
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
-
-lint-staged@^13.0.3:
-  version "13.2.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.3.tgz#f899aad6c093473467e9c9e316e3c2d8a28f87a7"
-  integrity sha512-zVVEXLuQIhr1Y7R7YAWx4TZLdvuzk7DnmrsTNL0fax6Z3jrpFcas+vKbzxhhvp6TA55m1SQuWkpzI1qbfDZbAg==
-  dependencies:
-    chalk "5.2.0"
-    cli-truncate "^3.1.0"
-    commander "^10.0.0"
-    debug "^4.3.4"
-    execa "^7.0.0"
-    lilconfig "2.1.0"
-    listr2 "^5.0.7"
-    micromatch "^4.0.5"
-    normalize-path "^3.0.0"
-    object-inspect "^1.12.3"
-    pidtree "^0.6.0"
-    string-argv "^0.3.1"
-    yaml "^2.2.2"
-
-listr2@^5.0.7:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-5.0.8.tgz#a9379ffeb4bd83a68931a65fb223a11510d6ba23"
-  integrity sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==
-  dependencies:
-    cli-truncate "^2.1.0"
-    colorette "^2.0.19"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rfdc "^1.3.0"
-    rxjs "^7.8.0"
-    through "^2.3.8"
-    wrap-ansi "^7.0.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -11257,16 +11153,6 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
-
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
-  dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
 
 loglevelnext@^1.0.1:
   version "1.0.5"
@@ -11653,7 +11539,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -11700,11 +11586,6 @@ mimic-fn@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
-
-mimic-fn@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
-  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 mimic-response@^1.0.0:
   version "1.0.1"
@@ -12096,13 +11977,6 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npm-run-path@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
-  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
-  dependencies:
-    path-key "^4.0.0"
-
 npmlog@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
@@ -12156,7 +12030,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.12.0, object-inspect@^1.12.2, object-inspect@^1.12.3, object-inspect@^1.9.0:
+object-inspect@^1.12.0, object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
@@ -12282,13 +12156,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-onetime@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
-  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
-  dependencies:
-    mimic-fn "^4.0.0"
 
 open@^7.0.3:
   version "7.4.2"
@@ -12674,11 +12541,6 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-key@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
-  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
-
 path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -12745,11 +12607,6 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.0, picomatc
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-pidtree@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
-  integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -13986,11 +13843,6 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rfdc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
-  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
-
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -14043,13 +13895,6 @@ rxjs@^6.6.0:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
-
-rxjs@^7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
-  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
-  dependencies:
-    tslib "^2.1.0"
 
 safe-buffer@5.1.1:
   version "5.1.1"
@@ -14391,15 +14236,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -14408,14 +14244,6 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
-
-slice-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
-  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
-  dependencies:
-    ansi-styles "^6.0.0"
-    is-fullwidth-code-point "^4.0.0"
 
 snake-case@^3.0.4:
   version "3.0.4"
@@ -14723,11 +14551,6 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
-string-argv@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
-  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -14753,15 +14576,6 @@ string-width@^4.2.2:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.0.1.tgz#0d8158335a6cfd8eb95da9b6b262ce314a036ffd"
-  integrity sha512-5ohWO/M4//8lErlUUtrFy3b11GtNOuMOU0ysKCDXFcfXuuvUXu95akgj/i8ofmaGdN0hCqyl6uu9i8dS/mQp5g==
-  dependencies:
-    emoji-regex "^9.2.2"
-    is-fullwidth-code-point "^4.0.0"
-    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.0, "string.prototype.matchall@^4.0.0 || ^3.0.1", string.prototype.matchall@^4.0.8:
   version "4.0.8"
@@ -14869,13 +14683,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
-  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
-  dependencies:
-    ansi-regex "^6.0.1"
-
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -14902,11 +14709,6 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-
-strip-final-newline@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
-  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -15348,7 +15150,7 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -15514,7 +15316,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -16496,11 +16298,6 @@ yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
-  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@20.x, yargs-parser@^20.2.3:
   version "20.2.7"


### PR DESCRIPTION
# Summary

- Removes Husky and lint-staged which are not used (pre-commit is not configured, and Husky did not have a solution suitable for our needs as a component library)
  - If we want to set up precommit checks again with these tools, no problem, we can bring them back at that time. 
- Updates our actions to newer versions (particularly checkout and setup-node)
  - Also updates setup-node to use the `node-version-file` property rather than explicitly re-declaring the node version across files. Should make our node upgrade process easier
- The code changes are from running `yarn format:fix` to get us caught up in this PR.


## Related issues or PRs

Resolves #2377


## How To Test

It ran on this PR. Before updating the format of noncompliant files:
<img width="653" alt="image" src="https://github.com/trussworks/react-uswds/assets/15805554/6bdab2c6-3c66-4e59-bb57-2d64a3d1879d">
