### PR TITLE
fix: added error param, test, story

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -168,6 +168,7 @@ export const customText = (): React.ReactElement => (
       dragText="Arrastre el archivo aquí o "
       chooseText="elija de una carpeta"
       errorText="Este no es un tipo de archivo válido."
+      accept=".no"
     />
   </FormGroup>
 )

--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -167,6 +167,7 @@ export const customText = (): React.ReactElement => (
       name="file-input-single"
       dragText="Arrastre el archivo aquí o "
       chooseText="elija de una carpeta"
+      errorText="Este no es un tipo de archivo válido."
     />
   </FormGroup>
 )

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -112,7 +112,7 @@ describe('FileInput component', () => {
     )
     expect(chooseText).toBeInTheDocument()
     expect(chooseText).toHaveClass('usa-file-input__choose')
-    
+
     const targetEl = getByTestId('file-input-droptarget')
     fireEvent.drop(targetEl, {
       dataTransfer: {

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -96,6 +96,7 @@ describe('FileInput component', () => {
       ...testProps,
       dragText: 'Custom dragText',
       chooseText: 'Custom chooseText',
+      errorText: 'Custom errorText',
     }
     const { getByTestId } = render(<FileInput {...customProps} />)
 
@@ -110,6 +111,12 @@ describe('FileInput component', () => {
     )
     expect(chooseText).toBeInTheDocument()
     expect(chooseText).toHaveClass('usa-file-input__choose')
+
+    const errorText = within(getByTestId('file-input-instructions')).getByText(
+      customProps.errorText
+    )
+    expect(errorText).toBeInTheDocument()
+    expect(errorText).toHaveClass('file-input-error')
   })
 
   describe('when disabled', () => {

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -97,6 +97,7 @@ describe('FileInput component', () => {
       dragText: 'Custom dragText',
       chooseText: 'Custom chooseText',
       errorText: 'Custom errorText',
+      accept: '.no',
     }
     const { getByTestId } = render(<FileInput {...customProps} />)
 
@@ -111,12 +112,18 @@ describe('FileInput component', () => {
     )
     expect(chooseText).toBeInTheDocument()
     expect(chooseText).toHaveClass('usa-file-input__choose')
-
-    const errorText = within(getByTestId('file-input-instructions')).getByText(
+    
+    const targetEl = getByTestId('file-input-droptarget')
+    fireEvent.drop(targetEl, {
+      dataTransfer: {
+        files: [TEST_PNG_FILE],
+      },
+    })
+    const errorText = within(getByTestId('file-input-error')).getByText(
       customProps.errorText
     )
     expect(errorText).toBeInTheDocument()
-    expect(errorText).toHaveClass('file-input-error')
+    expect(errorText).toHaveClass('usa-file-input__accepted-files-message')
   })
 
   describe('when disabled', () => {

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -15,6 +15,7 @@ type FileInputProps = {
   name: string
   dragText?: string
   chooseText?: string
+  errorText?: string
   disabled?: boolean
   multiple?: boolean
   accept?: string
@@ -37,6 +38,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     id,
     dragText,
     chooseText,
+    errorText,
     disabled,
     multiple,
     className,
@@ -90,6 +92,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     ? 'Drag files here or '
     : 'Drag file here or '
   const defaultChooseText = 'choose from folder'
+  const defaultErrorText = 'This is not a valid file type.'
 
   const filePreviews = []
   if (files) {
@@ -210,7 +213,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
           <div
             data-testid="file-input-error"
             className="usa-file-input__accepted-files-message">
-            This is not a valid file type.
+            {errorText || defaultErrorText}
           </div>
         )}
         <input


### PR DESCRIPTION
# Summary

Adds property to FileInput component to allow error text inside component to be customized. Before, it was hardcoded making it inappropriate for mobile and non-English contexts.

## Related Issues or PRs

Resolves #2456

## How To Test

* Give custom text to `errorText`
* Ensure all other file input functions behave as before
* Or run storybook, go [here](http://localhost:9009/?path=/story/components-file-input--custom-text) and try drag-dropping anything to the field

### Screenshots (optional)
<img width="502" alt="Screenshot 2023-07-10 at 2 42 09 PM" src="https://github.com/trussworks/react-uswds/assets/764090/ddb1b6d7-6222-464b-b336-b80b305360ea">
