### PR TITLE
build: version 3.7.10 broke build rolling back to 3.7.9

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v3.7.8
         with:
           release-type: node
           package-name: '@trussworks/react-uswds'


### PR DESCRIPTION
# Summary

Latest release of release please is failing, not sure why. Rolling back to a working version to unblock releases for now. 

https://github.com/trussworks/react-uswds/actions/runs/5548198197/jobs/10130859807
https://github.com/USSF-ORBIT/ussf-portal-client/actions/runs/5512846343/jobs/10050194817
https://github.com/USSF-ORBIT/ussf-portal-client/actions/runs/5535147685/jobs/10101056417