### PR TITLE
build: disable include-v-in-tag option

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
           release-type: node
           package-name: '@trussworks/react-uswds'
           release-labels: 'type: release'
+          include-v-in-tag: false
           changelog-types: >
             { "types":
               [


### PR DESCRIPTION
# Summary

Forgot to turn off the option that adds a v to the version tag name. Disabling it because we haven't been having one in the past and didn't want to change the pattern.