### PR TITLE
fix: Set alternative text on SVG img icon in menu close button

### DIFF
--- a/src/components/header/NavCloseButton/NavCloseButton.tsx
+++ b/src/components/header/NavCloseButton/NavCloseButton.tsx
@@ -16,9 +16,8 @@ export const NavCloseButton = ({
       onClick={onClick}
       data-testid="navCloseButton"
       {...buttonProps}
-      type="button"
-      aria-label="Close">
-      <Icon.Close size={3} />
+      type="button">
+      <Icon.Close size={3} aria-label="Close" />
     </button>
   )
 }


### PR DESCRIPTION
# Summary

`<svg>` elements with an `img` role must have an alternative text: https://dequeuniversity.com/rules/axe/4.6/svg-img-alt?application=msftAI

## Related Issues or PRs

This issue was introduced in https://github.com/trussworks/react-uswds/pull/2411, and began failing a11y tests in our project when 5.0.0 was released.

## How To Test

1. Open the `NavCloseButton` Storybook page
2. Change your viewport size so the button shows
3. Run an accessibility scanner like https://accessibilityinsights.io/

### Screenshots

Before:

<img width="1032" alt="CleanShot 2023-07-17 at 10 32 46@2x" src="https://github.com/trussworks/react-uswds/assets/371943/3a8dae8d-7521-4f80-aa71-92e2f46d9b03">

After:

<img width="1030" alt="CleanShot 2023-07-17 at 10 34 25@2x" src="https://github.com/trussworks/react-uswds/assets/371943/fb15a874-26f5-4f66-abb2-4837948e3e60">
