### PR TITLE
fix: Adds story using validation prop for Alert component

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -122,3 +122,12 @@ export const withCTA = (): React.ReactElement => (
     {testText}
   </Alert>
 )
+
+export const withValidation = (): React.ReactElement => (
+  <Alert type="info" heading="Code requirements" headingLevel="h4" validation>
+    <ul>
+      <li>Use at least one uppercase character</li>
+      <li>Use at least one number</li>
+    </ul>
+  </Alert>
+)

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -24,21 +24,6 @@ describe('Alert component', () => {
     expect(queryByTestId('alert')).toContainHTML('p')
   })
 
-  it('renders custom children with validation prop', () => {
-    const { queryByTestId } = render(
-      <Alert type="success" headingLevel="h4" validation>
-        <ul>
-          <li>test 1</li>
-          <li>test 2</li>
-        </ul>
-      </Alert>
-    )
-    expect(queryByTestId('alert')).toHaveTextContent('test 1test 2')
-    expect(queryByTestId('alert')).toContainHTML('ul')
-    expect(queryByTestId('alert')).toContainHTML('li')
-    expect(queryByTestId('alert')).not.toContainHTML('p')
-  })
-
   it('renders validation style alert', () => {
     const { queryByTestId } = render(
       <Alert type="success" validation headingLevel="h4" className="myClass">

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -24,6 +24,21 @@ describe('Alert component', () => {
     expect(queryByTestId('alert')).toContainHTML('p')
   })
 
+  it('renders custom children with validation prop', () => {
+    const { queryByTestId } = render(
+      <Alert type="success" headingLevel="h4" validation>
+        <ul>
+          <li>test 1</li>
+          <li>test 2</li>
+        </ul>
+      </Alert>
+    )
+    expect(queryByTestId('alert')).toHaveTextContent('test 1test 2')
+    expect(queryByTestId('alert')).toContainHTML('ul')
+    expect(queryByTestId('alert')).toContainHTML('li')
+    expect(queryByTestId('alert')).not.toContainHTML('p')
+  })
+
   it('renders validation style alert', () => {
     const { queryByTestId } = render(
       <Alert type="success" validation headingLevel="h4" className="myClass">


### PR DESCRIPTION
# Summary

Adds a story for the `<Alert>` component showing use of the `validation` prop.

Currently none of the stories make use of this prop and for documentation purposes, it's a good idea to demonstrate this. I've lifted the content [from the Validation component from USWDS](https://designsystem.digital.gov/components/validation/).

## Closes #2502

<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

1. `yarn run storybook`
2.  Go to: http://localhost:9009/?path=/story/components-alert--with-validation

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
![Screenshot 2023-07-20 at 11 39 34 AM](https://github.com/trussworks/react-uswds/assets/57681819/7ea14271-e785-4411-9061-271bd3d1277d)

![Screenshot 2023-07-20 at 11 40 01 AM](https://github.com/trussworks/react-uswds/assets/57681819/521590c0-e687-4ba1-bb7e-9aa2e8f8d711)
