### PR TITLE
fix: Allows semibold to accomodate our typogrpahy story

### DIFF
--- a/src/styles/_uswds-theme.scss
+++ b/src/styles/_uswds-theme.scss
@@ -2,5 +2,6 @@
 @use 'uswds-core' with (
   $theme-image-path: '@uswds/uswds/img',
   $theme-font-path: '@uswds/uswds/fonts',
-  $theme-show-notifications: false
+  $theme-show-notifications: false,
+  $theme-font-weight-semibold: 600
 );

--- a/src/styles/_uswds-theme.scss
+++ b/src/styles/_uswds-theme.scss
@@ -2,6 +2,6 @@
 @use 'uswds-core' with (
   $theme-image-path: '@uswds/uswds/img',
   $theme-font-path: '@uswds/uswds/fonts',
-  $theme-show-notifications: false,
-  $theme-font-weight-semibold: 600
+  $theme-font-weight-semibold: 600,
+  $theme-show-notifications: false
 );


### PR DESCRIPTION
# Summary

Our typography story mentions 'semibold', but uswds [marked that weight as "unneeded"](https://github.com/uswds/uswds/blob/develop/packages/uswds-core/src/styles/settings/_settings-typography.scss#L333) so it appeared as normal text:
<img width="223" alt="image" src="https://github.com/trussworks/react-uswds/assets/764090/aabbcd0c-9774-4c76-b7b1-37ce83f3e5a5">


This PR overrides that to allow our story to look like it's intended:
<img width="220" alt="image" src="https://github.com/trussworks/react-uswds/assets/764090/a7ef2ee2-7e22-4028-8fb9-54c4b6f812de">

Alternatively, we can undo this change and instead replace the "semibold" example with a "light" font example, which _is_ allowed by the base uswds package.

## Related Issues or PRs

None, just a little bug noticed by a client

## How To Test

Open [typography story](http://localhost:9009/?path=/story/components-typography-type-styles--type-styles), see that "text semibold" is now actually semibold

### Screenshots (optional)
see above