### PR TITLE
fix: moved overrides to let us use utilities

### DIFF
--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -1,0 +1,33 @@
+@use 'uswds-core' as *;
+
+// This should be set by USWDS but isn't
+// It can be removed when https://github.com/uswds/uswds/issues/4458 is fixed
+.usa-tooltip__body {
+  opacity: 0;
+}
+
+// This fixes a chromium browser bug that causes accessibility issues in the search field
+// It can be removed when https://github.com/uswds/uswds/issues/5277 is fixed
+.usa-search [type='search']::-webkit-search-cancel-button {
+  display: none;
+}
+
+// This just allows buttons as well as links in the LanguageSelector. A more ideal coding for this would just be to `@extend a` here instead of copy-pasting it, but that caused a lint error
+// It can be removed when https://github.com/uswds/uswds/issues/5409 is fixed
+
+.usa-language__submenu .usa-language__submenu-item button {
+  color: color('white');
+  display: block;
+  line-height: line-height($theme-navigation-font-family, 3);
+  padding: units(1);
+  text-decoration: none;
+  width: 100%; /* this is something that was actually missing when we were doing the extend because button widths hve different default widths than block element links */
+  &:focus {
+    outline-offset: units('neg-05');
+  }
+
+  &:hover {
+    color: color('white');
+    text-decoration: underline;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,35 +3,4 @@
 
 @forward 'backgrounds';
 @forward 'type';
-
-// This should be set by USWDS but isn't
-// It can be removed when https://github.com/uswds/uswds/issues/4458 is fixed
-.usa-tooltip__body {
-  opacity: 0;
-}
-
-// This fixes a chromium browser bug that causes accessibility issues in the search field
-// It can be removed when https://github.com/uswds/uswds/issues/5277 is fixed
-.usa-search [type='search']::-webkit-search-cancel-button {
-  display: none;
-}
-
-// This just allows buttons as well as links in the LanguageSelector. A more ideal coding for this would just be to `@extend a` here instead of copy-pasting it, but that caused a lint error
-// It can be removed when https://github.com/uswds/uswds/issues/5409 is fixed
-
-.usa-language__submenu .usa-language__submenu-item button {
-  color: #fff;
-  display: block;
-  line-height: 1.3;
-  padding: 0.5rem;
-  text-decoration: none;
-  width: 100%; /* this is something that was actually missing when we were doing the extend because button widths hve different default widths than block element links */
-  &:focus {
-    outline-offset: units('neg-05');
-  }
-
-  &:hover {
-    color: color('white');
-    text-decoration: underline;
-  }
-}
+@forward 'overrides';


### PR DESCRIPTION
# Summary

Thanks to Joe, this establishes a pattern for us to replicate in using utilities, at least in the root styles folder

## Related Issues or PRs

None

## How To Test

Add any future override styles to the new _overrides.scss file

### Screenshots (optional)
