### PR TITLE
refactor: Introduce 'id' prop on <Tooltip>

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -33,13 +33,13 @@ Source: https://designsystem.digital.gov/components/tooltip/
 
 export const tooltipDefault = (): React.ReactElement => (
   <div className="margin-4">
-    <Tooltip label="Default">Default</Tooltip>
+    <Tooltip id="tooltip-default" label="Default">Default</Tooltip>
   </div>
 )
 
 export const tooltipTop = (): React.ReactElement => (
   <div className="margin-4">
-    <Tooltip position="top" label="Top">
+    <Tooltip id="tooltip-top" position="top" label="Top">
       Show on top
     </Tooltip>
   </div>
@@ -47,7 +47,7 @@ export const tooltipTop = (): React.ReactElement => (
 
 export const tooltipBottom = (): React.ReactElement => (
   <div className="margin-4">
-    <Tooltip position="bottom" label="Bottom">
+    <Tooltip id="tooltip-bottom" position="bottom" label="Bottom">
       Show on bottom
     </Tooltip>
   </div>
@@ -55,7 +55,7 @@ export const tooltipBottom = (): React.ReactElement => (
 
 export const tooltipRight = (): React.ReactElement => (
   <div className="margin-4">
-    <Tooltip position="right" label="Right">
+    <Tooltip id="tooltip-right" position="right" label="Right">
       Show on right
     </Tooltip>
   </div>
@@ -63,7 +63,7 @@ export const tooltipRight = (): React.ReactElement => (
 
 export const tooltipLeft = (): React.ReactElement => (
   <div className="margin-4">
-    <Tooltip position="left" label="Left">
+    <Tooltip id="tooltip-left" position="left" label="Left">
       Show on left
     </Tooltip>
   </div>
@@ -72,6 +72,7 @@ export const tooltipLeft = (): React.ReactElement => (
 export const tooltipWithUtilityClass = (): React.ReactElement => (
   <div className="margin-4">
     <Tooltip
+      id="tooltip-with-utility-class"
       wrapperclasses="width-full tablet:width-auto"
       position="right"
       label="Right">
@@ -101,6 +102,7 @@ export const CustomComponent = (): React.ReactElement => {
     <div className="margin-4">
       <p>
         <Tooltip<CustomLinkProps>
+          id="tooltip-custom-component"
           label="Follow Link"
           asCustom={CustomLink}
           to="http://www.truss.works">
@@ -114,7 +116,7 @@ export const CustomComponent = (): React.ReactElement => {
 
 export const tooltipTopLeftWrap = (): React.ReactElement => (
   <div style={{ marginTop: '32px' }}>
-    <Tooltip label="You can only add 10 links to a collection. To add more links, please create a new collection.">
+    <Tooltip id="tooltip-tl-wrap" label="You can only add 10 links to a collection. To add more links, please create a new collection.">
       Default
     </Tooltip>
   </div>
@@ -122,7 +124,7 @@ export const tooltipTopLeftWrap = (): React.ReactElement => (
 
 export const tooltipBottomLeftWrap = (): React.ReactElement => (
   <div style={{ position: 'absolute', bottom: '32px' }}>
-    <Tooltip label="You can only add 10 links to a collection. To add more links, please create a new collection.">
+    <Tooltip id="tooltip-bl-wrap" label="You can only add 10 links to a collection. To add more links, please create a new collection.">
       Default
     </Tooltip>
   </div>
@@ -130,7 +132,7 @@ export const tooltipBottomLeftWrap = (): React.ReactElement => (
 
 export const tooltipTopRightWrap = (): React.ReactElement => (
   <div style={{ marginTop: '32px', textAlign: 'right' }}>
-    <Tooltip label="You can only add 10 links to a collection. To add more links, please create a new collection.">
+    <Tooltip id="tooltip-tr-wrap" label="You can only add 10 links to a collection. To add more links, please create a new collection.">
       Default
     </Tooltip>
   </div>
@@ -146,7 +148,7 @@ export const tooltipBottomRightWrap = (): React.ReactElement => (
       paddingRight: '32px',
       textAlign: 'right',
     }}>
-    <Tooltip label="You can only add 10 links to a collection. To add more links, please create a new collection.">
+    <Tooltip id="tooltip-br-wrap" label="You can only add 10 links to a collection. To add more links, please create a new collection.">
       Default
     </Tooltip>
   </div>

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -19,7 +19,7 @@ describe('Tooltip component', () => {
   beforeEach(jest.clearAllMocks)
 
   it('renders without errors', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
 
     const wrapperEl = screen.queryByTestId('tooltipWrapper')
     expect(wrapperEl).toBeInTheDocument()
@@ -27,14 +27,13 @@ describe('Tooltip component', () => {
 
     const bodyEl = screen.queryByRole('tooltip', { hidden: true })
     expect(bodyEl).toBeInTheDocument()
-    const tooltipId = bodyEl?.getAttribute('id')
     expect(bodyEl).toHaveAttribute('role', 'tooltip')
     expect(bodyEl).toHaveAttribute('aria-hidden', 'true')
     expect(bodyEl).toHaveTextContent('Click me')
 
     const triggerEl = screen.queryByTestId('triggerElement')
     expect(triggerEl).toBeInTheDocument()
-    expect(triggerEl).toHaveAttribute('aria-describedby', tooltipId)
+    expect(triggerEl).toHaveAttribute('aria-describedby', "test-id")
     expect(triggerEl).toHaveAttribute('tabindex', '0')
     expect(triggerEl).toHaveAttribute('title', '')
     expect(triggerEl).not.toHaveClass('usa-tooltip')
@@ -42,7 +41,7 @@ describe('Tooltip component', () => {
   })
 
   it('defaults the position to top if no position prop is given', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
 
     fireEvent.mouseEnter(screen.getByTestId('triggerElement'))
     expect(screen.getByTestId('tooltipBody')).toHaveClass(
@@ -51,7 +50,7 @@ describe('Tooltip component', () => {
   })
 
   it('hides tooltip body by default', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
 
     const bodyEl = screen.queryByRole('tooltip', { hidden: true })
     expect(bodyEl).not.toHaveClass('is-visible')
@@ -65,7 +64,7 @@ describe('Tooltip component', () => {
   })
 
   it('shows tooltip body on mouse enter', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
     fireEvent.mouseEnter(screen.getByTestId('triggerElement'))
 
     const bodyEl = screen.queryByRole('tooltip')
@@ -75,7 +74,7 @@ describe('Tooltip component', () => {
   })
 
   it('hides tooltip on mouse leave', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
     const bodyEl = screen.queryByRole('tooltip', { hidden: true })
 
     fireEvent.mouseEnter(screen.getByTestId('triggerElement'))
@@ -88,7 +87,7 @@ describe('Tooltip component', () => {
   })
 
   it('shows tooltip on focus', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
     fireEvent.focus(screen.getByTestId('triggerElement'))
 
     const bodyEl = screen.queryByRole('tooltip')
@@ -98,7 +97,7 @@ describe('Tooltip component', () => {
   })
 
   it('hides tooltip on blur', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
     const bodyEl = screen.queryByRole('tooltip', { hidden: true })
 
     fireEvent.focus(screen.getByTestId('triggerElement'))
@@ -112,7 +111,7 @@ describe('Tooltip component', () => {
   })
 
   it('hides tooltip on keydown after focus', () => {
-    render(<Tooltip label="Click me">My Tooltip</Tooltip>)
+    render(<Tooltip id="test-id" label="Click me">My Tooltip</Tooltip>)
     const bodyEl = screen.queryByRole('tooltip', { hidden: true })
 
     fireEvent.focus(screen.getByTestId('triggerElement'))
@@ -127,7 +126,7 @@ describe('Tooltip component', () => {
 
   it('applies custom classes to the wrapper element', () => {
     render(
-      <Tooltip label="Click me" wrapperclasses="customWrapperClass">
+      <Tooltip id="test-id" label="Click me" wrapperclasses="customWrapperClass">
         My Tooltip
       </Tooltip>
     )
@@ -140,7 +139,7 @@ describe('Tooltip component', () => {
   describe('with a position prop', () => {
     it('applies the correct tooltip position when position prop is defined', () => {
       const { getByTestId } = render(
-        <Tooltip position="bottom" label="Click me">
+        <Tooltip id="test-id" position="bottom" label="Click me">
           My Tooltip
         </Tooltip>
       )
@@ -156,7 +155,7 @@ describe('Tooltip component', () => {
     it('applies the className to the trigger element', () => {
       const customClass = 'custom-class'
       const { getByTestId } = render(
-        <Tooltip className={customClass} position="left" label="Click me">
+        <Tooltip id="test-id" className={customClass} position="left" label="Click me">
           My Tooltip
         </Tooltip>
       )
@@ -185,6 +184,7 @@ describe('Tooltip component', () => {
     it('renders the custom component as the trigger element', () => {
       render(
         <Tooltip<CustomLinkProps>
+          id="test-id"
           label="Click me"
           asCustom={CustomLink}
           to="http://www.truss.works"
@@ -193,12 +193,9 @@ describe('Tooltip component', () => {
         </Tooltip>
       )
 
-      const bodyEl = screen.queryByRole('tooltip', { hidden: true })
-      const tooltipId = bodyEl?.getAttribute('id')
-
       const triggerEl = screen.queryByTestId('triggerElement')
       expect(triggerEl).toBeInTheDocument()
-      expect(triggerEl).toHaveAttribute('aria-describedby', tooltipId)
+      expect(triggerEl).toHaveAttribute('aria-describedby', "test-id")
       expect(triggerEl).toHaveAttribute('tabindex', '0')
       expect(triggerEl).toHaveAttribute('title', '')
       expect(triggerEl).not.toHaveClass('usa-tooltip')
@@ -216,7 +213,7 @@ describe('Tooltip component', () => {
         jest.clearAllMocks()
 
         render(
-          <Tooltip label="Click me" position="top">
+          <Tooltip id="test-id" label="Click me" position="top">
             My Tooltip
           </Tooltip>
         )
@@ -250,7 +247,7 @@ describe('Tooltip component', () => {
         jest.clearAllMocks()
 
         render(
-          <Tooltip label="Click me" position="bottom">
+          <Tooltip id="test-id" label="Click me" position="bottom">
             My Tooltip
           </Tooltip>
         )
@@ -283,7 +280,7 @@ describe('Tooltip component', () => {
         jest.clearAllMocks()
 
         render(
-          <Tooltip label="Click me" position="right">
+          <Tooltip id="test-id" label="Click me" position="right">
             My Tooltip
           </Tooltip>
         )
@@ -317,7 +314,7 @@ describe('Tooltip component', () => {
         jest.clearAllMocks()
 
         render(
-          <Tooltip label="Click me" position="left">
+          <Tooltip id="test-id" label="Click me" position="left">
             My Tooltip
           </Tooltip>
         )
@@ -352,7 +349,7 @@ describe('Tooltip component', () => {
       jest.clearAllMocks()
 
       render(
-        <Tooltip label="Click me" position="left">
+        <Tooltip id="test-id" label="Click me" position="left">
           My Tooltip
         </Tooltip>
       )

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -12,6 +12,7 @@ import classnames from 'classnames'
 import { isElementInViewport, calculateMarginOffset } from './utils'
 
 type TooltipProps<T> = {
+  id: string
   label: string
   position?: 'top' | 'bottom' | 'left' | 'right' | undefined
   wrapperclasses?: string
@@ -42,9 +43,6 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
 ): ReactElement {
   const triggerElementRef = useRef<HTMLElement & HTMLButtonElement>(null)
   const tooltipBodyRef = useRef<HTMLElement>(null)
-  const tooltipID = useRef(
-    `tooltip-${Math.floor(Math.random() * 900000) + 100000}`
-  )
 
   const [isVisible, setVisible] = useState(false)
   const [isShown, setIsShown] = useState(false)
@@ -55,7 +53,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
   const [wrapTooltip, setWrapTooltip] = useState(false)
   const [positionStyles, setPositionStyles] = useState({})
 
-  const { position, wrapperclasses, className } = props
+  const { id, position, wrapperclasses, className } = props
 
   const positionTop = (e: HTMLElement, triggerEl: HTMLElement): void => {
     const topMargin = calculateMarginOffset('top', e.offsetHeight, triggerEl)
@@ -213,7 +211,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
         ...customProps,
         ref: triggerElementRef,
         'data-testid': 'triggerElement',
-        'aria-describedby': tooltipID.current,
+        'aria-describedby': id,
         tabIndex: 0,
         title: '',
         onMouseEnter: showTooltip,
@@ -233,7 +231,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
         <span
           data-testid="tooltipBody"
           title={label}
-          id={tooltipID.current}
+          id={id}
           ref={tooltipBodyRef}
           className={tooltipBodyClasses}
           role="tooltip"
@@ -258,7 +256,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
           {...remainingProps}
           data-testid="triggerElement"
           ref={triggerElementRef}
-          aria-describedby={tooltipID.current}
+          aria-describedby={id}
           tabIndex={0}
           type="button"
           className={triggerClasses}
@@ -274,7 +272,7 @@ export function Tooltip<FCProps = DefaultTooltipProps>(
         <span
           data-testid="tooltipBody"
           title={label}
-          id={tooltipID.current}
+          id={id}
           ref={tooltipBodyRef}
           className={tooltipBodyClasses}
           role="tooltip"


### PR DESCRIPTION
# Summary

BREAKING CHANGE: This commit introduces a required 'id' property on the <Tooltip>
component which replaces the random automatically generated one used previously.

Our application creates snapshot tests using `jest-snapshot`, and the randomly-generated IDs that come from this component make the snapshots no longer deterministic (and would fail on each run).

This PR is an attempt to address that. I can't say I'm in love with this solution as it does introduce a breaking change that would require IDs to be placed on `<Tooltip>` components across the board, so I am open to other solutions as well!

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
