### PR TITLE
feat(deps): Allow consumers to use newer uswds minor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm i @trussworks/react-uswds
 It is strongly suggested applications use the same version of USWDS that was used to build the version of ReactUSWDS they're using (see this repo's uswds `devDependency` in [package.json](./package.json)).
 A version mismatch may result in unexpected markup & CSS combinations.
 For flexibility, ReactUSWDS will not trigger warnings if consumers choose to use a higher minor version of `uswds` (hence the careted uswds `peerDependency` in [package.json](./package.json)).
-If encountering unexpected markup issues when choosing _not_ to use the matching `devDependency` version of `uswds`, consumers should always verify that aligning the versions does not resolve their issue(s).
+If encountering unexpected markup issues when choosing _not_ to use the matching `devDependency` version of `uswds`, consumers should check whether aligning the versions resolves their issue(s).
 
 You can import ReactUSWDS components using ES6 syntax:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm i @trussworks/react-uswds
 
 It is strongly suggested applications use the same version of USWDS that was used to build the version of ReactUSWDS they're using (see this repo's uswds `devDependency` in [package.json](./package.json)).
 A version mismatch may result in unexpected markup & CSS combinations.
-For flexibility, ReactUSWDS will not trigger warnings if consumers choose to use a higher minor version of `uswds` (hence the carated uswds `peerDependency` in [package.json](./package.json)).
+For flexibility, ReactUSWDS will not trigger warnings if consumers choose to use a higher minor version of `uswds` (hence the careted uswds `peerDependency` in [package.json](./package.json)).
 If encountering unexpected markup issues when choosing _not_ to use the matching `devDependency` version of `uswds`, consumers should always verify that aligning the versions does not resolve their issue(s).
 
 You can import ReactUSWDS components using ES6 syntax:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ npm i @trussworks/react-uswds
 
 ### USWDS
 
-It is strongly suggested applications use the same version of USWDS that was used to build the version of ReactUSWDS they're using. A version mismatch may result in unexpected markup & CSS combinations.
+It is strongly suggested applications use the same version of USWDS that was used to build the version of ReactUSWDS they're using (see this repo's uswds `devDependency` in [package.json](./package.json)).
+A version mismatch may result in unexpected markup & CSS combinations.
+For flexibility, ReactUSWDS will not trigger warnings if consumers choose to use a higher minor version of `uswds` (hence the carated uswds `peerDependency` in [package.json](./package.json)).
+If encountering unexpected markup issues when choosing _not_ to use the matching `devDependency` version of `uswds`, consumers should always verify that aligning the versions does not resolve their issue(s).
 
 You can import ReactUSWDS components using ES6 syntax:
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/trussworks/react-uswds#readme",
   "peerDependencies": {
-    "@uswds/uswds": "3.6.0",
+    "@uswds/uswds": "^3.6.0",
     "react": "^16.x || ^17.x || ^18.x",
     "react-dom": "^16.x || ^17.x || ^18.x"
   },


### PR DESCRIPTION
# Summary

See github issue

## Related Issues or PRs

- https://github.com/trussworks/react-uswds/pull/2572#issuecomment-1719755291
- resolves: #2598 

