### PR TITLE
fix(storybook): password label set to password input field id on sign in

### DIFF
--- a/src/stories/templates/signin.stories.tsx
+++ b/src/stories/templates/signin.stories.tsx
@@ -155,7 +155,7 @@ export const SignIn = (): React.ReactElement => {
                         required={true}
                       />
 
-                      <Label htmlFor="email">Password</Label>
+                      <Label htmlFor="password-sign-in">Password</Label>
                       <TextInput
                         id="password-sign-in"
                         name="password"


### PR DESCRIPTION
# Summary

Password field label has been correctly associated with the password input field id on the auth sign in template example.

## Related Issues or PRs

Closes #2610 

## How To Test

- Go to the page template for authentication sign in
- Use an automated accessibility checker or developer tools
- Check the correct association of the password label with its input field

### Screenshots (optional)

![react-uswds-2610](https://github.com/trussworks/react-uswds/assets/75930195/43a28421-3de7-43d5-afe1-a6116f9604fa)
