### PR TITLE
fix(storybook): sufficient color contrast set in custom class button

### DIFF
--- a/.storybook/custom-styles.scss
+++ b/.storybook/custom-styles.scss
@@ -3,7 +3,7 @@
 
 // Add custom styles for storybook implementation
 .custom-class {
-  background: #fa9441;
+  background: #bf5906;
 }
 
 .usa-color-text-visited {


### PR DESCRIPTION
# Summary

Sufficient color contrast has been set for the custom class button example. ANDI color contrast test passes.

## Related Issues or PRs

Closes #2607 

## How To Test

- Open the custom class button
- Open the canvas in a new page
- run an accessibility checker (preferably ANDI)
- if using ANDI, select `color contrast`, inspect the button and check the passing of the contrast test

### Screenshots (optional)

![react-uswds-2607](https://github.com/trussworks/react-uswds/assets/75930195/95afbe3f-e7e4-4151-bbcc-85e865de140b)
