### PR TITLE
fix: Updates file input stories to set appropriate html for value of label

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -88,7 +88,7 @@ export const multipleFilesInput = (): React.ReactElement => (
 export const withError = (): React.ReactElement => (
   <div style={{ marginLeft: '1.25em' }}>
     <FormGroup error>
-      <Label htmlFor="file-input-multiple" error>
+      <Label htmlFor="file-input-error" error>
         Input has an error
       </Label>
       <span className="usa-hint" id="file-input-error-hint">


### PR DESCRIPTION

# Summary
Associates label with the right input using `htmlFor` in `withError` story of file input. 

## Related Issues or PRs
closes #2609 
<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test
1. Launch storybook and navigate to with error story of file input
![image](https://github.com/trussworks/react-uswds/assets/44632502/7e2ea9f4-0e70-4d5e-8748-14cd2a1f4eaf)
2. Click open canvas in new tab button to open this story in a new tab
![image](https://github.com/trussworks/react-uswds/assets/44632502/dd6252cd-2b19-49f7-bec4-e0df6a0ed319)
3. Run automated accessibility checker of choice on the page that opens to check for `Form elements should have labels` issue
4. Should not see any `Form elements should have labels` 

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
![image](https://github.com/trussworks/react-uswds/assets/44632502/ea543376-9ed8-4e3c-8b2d-cab49bd74699)

