### PR TITLE
fix: readme quick links

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This repository is governed by the [Contributor Covenant](./CODE_OF_CONDUCT.md)
 
 ### Quick links:
 
-- [Yarn scripts](./docs/contributing#available-commands)
+- [Yarn scripts](./docs/contributing.md#available-commands)
 - [PR commit guidelines](./docs/contributing.md#opening--merging-pull-requests)
 - [Adding new components](./docs/adding_new_components.md)
 - [Testing in an application](./docs/contributing.md#testing-in-an-application)


### PR DESCRIPTION
# Summary
Yarn scripts links(under the Quick links in the Contributing section) were not properly configured due to which clicking on the link would take us to a page that was not present in the repository. 
This fix solves the issue

## Related Issues or PRs
Closes #2645

<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test
1. Go to the Readme file
2. Scroll down to Contributing -> Quick Links
3. Click on Yarn scripts
4. See contributing.md document is opening

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots
![Screenshot from 2023-10-29 18-48-10](https://github.com/trussworks/react-uswds/assets/87698014/b40530d1-2a36-45dd-a66e-de98f734796c)
![Screenshot from 2023-10-29 19-04-34](https://github.com/trussworks/react-uswds/assets/87698014/e00c67ac-6e4f-4f54-ba08-24c85d018a77)

