### PR TITLE
feat: Add “use client” to fix React Server Components

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
+const { BannerPlugin } = require('webpack')
 
 const uswdsIncludePaths = [
   './node_modules/@uswds',
@@ -18,6 +20,18 @@ module.exports = {
     library: 'ReactUSWDS',
     libraryTarget: 'umd',
     globalObject: 'this',
+  },
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          compress: {
+            // Preserve directives like "use client"
+            directives: false,
+          },
+        },
+      }),
+    ],
   },
   externals: {
     react: {
@@ -39,6 +53,14 @@ module.exports = {
       chunkFilename: '[name].[id].css',
     }),
     new ForkTsCheckerWebpackPlugin(),
+    new BannerPlugin({
+      // Support React Server Components
+      // See: https://react.dev/reference/react/use-client
+      banner: '"use client";',
+      raw: true,
+      entryOnly: true,
+      test: /\.js$/,
+    }),
   ],
   resolve: {
     extensions: ['.tsx', '.ts', '.jsx', '.js'],


### PR DESCRIPTION
# Summary

This adds the [`"use client"`](https://react.dev/reference/react/use-client) directive to the transpiled JS module to support apps utilizing [React Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components):

Some context from the React docs on this directive:

> When a file marked with 'use client' is imported from a Server Component, [compatible bundlers](https://react.dev/learn/start-a-new-react-project#bleeding-edge-react-frameworks) will treat the module import as a boundary between server-run and client-run code.

> For apps that use React Server Components, the app is server-rendered by default. 'use client' introduces a server-client boundary in the [module dependency tree](https://react.dev/learn/understanding-your-ui-as-a-tree#the-module-dependency-tree), effectively creating a subtree of Client modules.

Without this directive, apps attempting to use React Server Components are greeted with an error screen. See #2540.

I think this PR would be highly impactful to Next.js applications in particular, supporting the adoption of the new [App Router](https://nextjs.org/docs) and newer React features.

## Additional context

I don't think this is the perfect solution to supporting React Server Components, but I think it's a quick fix. Longer term, #192 is likely a better approach, so that components without any React hooks or event listeners _can_ be a server component.

## Related Issues or PRs

- #2540

## How To Test

1. Clone https://github.com/sawyerh/react-uswds-server-components-bug
1. `npm install`
1. `npm run dev`
1. Open http://localhost:3000/react-uswds and observe an error
1. Stop the dev server, then run: `npm link @trussworks/react-uswds --save`
1. Open http://localhost:3000/react-uswds and observe the error is gone

## Screenshots

![CleanShot 2023-11-09 at 17 44 42@2x](https://github.com/trussworks/react-uswds/assets/371943/95fbcf7d-1f33-463f-af14-d6afc467a5f7)
