### PR TITLE
chore: Fix reported unused imports

### DIFF
--- a/src/components/InPageNavigation/InPageNavigation.stories.tsx
+++ b/src/components/InPageNavigation/InPageNavigation.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { InPageNavigation } from './InPageNavigation'
 import { CONTENT } from './content'
 import { HeadingLevel } from '../../types/headingLevel'
-import classNames from 'classnames'
 
 export default {
   title: 'Components/In-Page Navigation',

--- a/src/components/forms/Label/Label.stories.tsx
+++ b/src/components/forms/Label/Label.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Label } from './Label'
-import { RequiredMarker } from './RequiredMarker'
 
 export default {
   title: 'Components/Form elements/Label',


### PR DESCRIPTION
# Summary

Github PRs were displaying some linting warnings about these files, this PR resolves them.

e.g:
<img width="626" alt="image" src="https://github.com/trussworks/react-uswds/assets/15805554/da3effe1-e733-4518-912f-3f4348c9bc9e">

## How To Test

- [x] This PR doesn't show the warnings on it
