### PR TITLE
chore: Remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     pull-request-branch-name:
       separator: '-'
     open-pull-requests-limit: 10
-    reviewers:
-      - "haworku"
-      - "ahobson"
     labels:
       - 'type: dependencies'
       - 'type: automerge'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,5 @@ src/stories/ @trussworks/react-uswds-design-owners
 
 # Owners for PRs that change ONLY package.json and/or yarn.lock
 
-# Note: Reviewers for dependabot PRs that change these files are configured in .github/dependabot.yml under `reviewers`
-
 package.json
 yarn.lock


### PR DESCRIPTION
# Summary

Fixes dependabot error adding reviewer who is now no longer part of Truss org (https://github.com/trussworks/react-uswds/pull/2670#issuecomment-1827155093).

We opted to not have codeowners/reviewers for dependabot PRs. Folks tend to just look at open PRs to investigate/prod dependabot along. The signal to noise ratio is too low

## How To Test

New dependabot PRs after merging this should not have the reviewer error, but no way to test before.

