### PR TITLE
chore: Rotate maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In the process, we expect to gain learnings around how to best abstract out UI c
 
 ## Active Maintainers
 
-- [Brandon Lenz](https://github.com/brandonlenz)
+- [Andrew Nelson](https://github.com/werdnanoslen)
 
 We are starting to rotate Trussel maintainer responsibilities. Check out the [maintainers README](./docs/for_maintainers.md).
 

--- a/docs/for_maintainers.md
+++ b/docs/for_maintainers.md
@@ -60,7 +60,3 @@ Feel free to contribute to library with your time!
 ### Addressing Security Alerts
 
 Typically any security alerts we receive will be related to third-party dependencies. This repo is currently configured so that Dependabot will automatically open PRs that fix dependency vulnerabilities, so ideally most of the time manual intervention is not needed. There may also be periods of time during which an alert is issued, but the related dependencies have not yet updated -- in this case, we usually choose to accept the risk of waiting until the updates have been released. However, if an exceptional case comes up -- such as a high severity vulnerability or even a vulnerability within this library -- and you aren't sure how to handle it, you can ask for help in one of the following Truss Slack channels (in order of relevance): #react-uswds, #g-frontend, #infrasec, #engineering
-
-### Merging External PRs
-
-Currently our CI cannot run on external PRs (work from outside the Truss organization) and this prevents merge. Instead, we pull PRs into a separate branch that a CODEOWNER can create [using this script](https://github.com/jklukas/git-push-fork-to-upstream-branch). We then close the external contribution PR [with a comment](https://github.com/trussworks/react-uswds/pull/375#issuecomment-668116811) explaining what's going. This allows automation to run properly.


### PR DESCRIPTION
# Summary

- Rotates the maintainer for the new term!
- Also removes a statement in the maintainer docs that is no longer correct. Fortunately, our CI can now run successfully on 3rd party PRs