### PR TITLE
feat: parametrized StepIndicator strings

### DIFF
--- a/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
@@ -18,10 +18,27 @@ Updates users on their progress through a multi-step process.
       },
     },
   },
+  argTypes: {
+    stepText: {
+      control: 'text',
+    },
+    ofText: {
+      control: 'text',
+    },
+  },
+  args: {
+    stepText: 'Step',
+    ofText: 'of',
+  }
 }
 
-export const defaultStepIndicator = (): React.ReactElement => (
-  <StepIndicator headingLevel="h4">
+type StorybookArguments = {
+  stepText: string
+  ofText: string
+}
+
+export const defaultStepIndicator = (args: StorybookArguments): React.ReactElement => (
+  <StepIndicator headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -30,8 +47,8 @@ export const defaultStepIndicator = (): React.ReactElement => (
   </StepIndicator>
 )
 
-export const noLabels = (): React.ReactElement => (
-  <StepIndicator showLabels={false} headingLevel="h4">
+export const noLabels = (args: StorybookArguments): React.ReactElement => (
+  <StepIndicator showLabels={false} headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -40,8 +57,8 @@ export const noLabels = (): React.ReactElement => (
   </StepIndicator>
 )
 
-export const centered = (): React.ReactElement => (
-  <StepIndicator centered headingLevel="h4">
+export const centered = (args: StorybookArguments): React.ReactElement => (
+  <StepIndicator centered headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -50,8 +67,8 @@ export const centered = (): React.ReactElement => (
   </StepIndicator>
 )
 
-export const counters = (): React.ReactElement => (
-  <StepIndicator counters="default" headingLevel="h4">
+export const counters = (args: StorybookArguments): React.ReactElement => (
+  <StepIndicator counters="default" headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -60,8 +77,8 @@ export const counters = (): React.ReactElement => (
   </StepIndicator>
 )
 
-export const smallCounters = (): React.ReactElement => (
-  <StepIndicator counters="small" headingLevel="h4">
+export const smallCounters = (args: StorybookArguments): React.ReactElement => (
+  <StepIndicator counters="small" headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -70,8 +87,8 @@ export const smallCounters = (): React.ReactElement => (
   </StepIndicator>
 )
 
-export const differentHeadingLevel = (): React.ReactElement => (
-  <StepIndicator headingLevel="h2">
+export const differentHeadingLevel = (args: StorybookArguments): React.ReactElement => (
+  <StepIndicator headingLevel="h2" ofText={args.ofText} stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />

--- a/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.stories.tsx
@@ -29,7 +29,7 @@ Updates users on their progress through a multi-step process.
   args: {
     stepText: 'Step',
     ofText: 'of',
-  }
+  },
 }
 
 type StorybookArguments = {
@@ -37,8 +37,13 @@ type StorybookArguments = {
   ofText: string
 }
 
-export const defaultStepIndicator = (args: StorybookArguments): React.ReactElement => (
-  <StepIndicator headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
+export const defaultStepIndicator = (
+  args: StorybookArguments
+): React.ReactElement => (
+  <StepIndicator
+    headingLevel="h4"
+    ofText={args.ofText}
+    stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -48,7 +53,11 @@ export const defaultStepIndicator = (args: StorybookArguments): React.ReactEleme
 )
 
 export const noLabels = (args: StorybookArguments): React.ReactElement => (
-  <StepIndicator showLabels={false} headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
+  <StepIndicator
+    showLabels={false}
+    headingLevel="h4"
+    ofText={args.ofText}
+    stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -58,7 +67,11 @@ export const noLabels = (args: StorybookArguments): React.ReactElement => (
 )
 
 export const centered = (args: StorybookArguments): React.ReactElement => (
-  <StepIndicator centered headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
+  <StepIndicator
+    centered
+    headingLevel="h4"
+    ofText={args.ofText}
+    stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -68,7 +81,11 @@ export const centered = (args: StorybookArguments): React.ReactElement => (
 )
 
 export const counters = (args: StorybookArguments): React.ReactElement => (
-  <StepIndicator counters="default" headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
+  <StepIndicator
+    counters="default"
+    headingLevel="h4"
+    ofText={args.ofText}
+    stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -78,7 +95,11 @@ export const counters = (args: StorybookArguments): React.ReactElement => (
 )
 
 export const smallCounters = (args: StorybookArguments): React.ReactElement => (
-  <StepIndicator counters="small" headingLevel="h4" ofText={args.ofText} stepText={args.stepText}>
+  <StepIndicator
+    counters="small"
+    headingLevel="h4"
+    ofText={args.ofText}
+    stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />
@@ -87,8 +108,13 @@ export const smallCounters = (args: StorybookArguments): React.ReactElement => (
   </StepIndicator>
 )
 
-export const differentHeadingLevel = (args: StorybookArguments): React.ReactElement => (
-  <StepIndicator headingLevel="h2" ofText={args.ofText} stepText={args.stepText}>
+export const differentHeadingLevel = (
+  args: StorybookArguments
+): React.ReactElement => (
+  <StepIndicator
+    headingLevel="h2"
+    ofText={args.ofText}
+    stepText={args.stepText}>
     <StepIndicatorStep label="Personal information" status="complete" />
     <StepIndicatorStep label="Household status" status="complete" />
     <StepIndicatorStep label="Supporting documents" status="current" />

--- a/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, within } from '@testing-library/react'
 import { StepIndicatorStep } from '../StepIndicatorStep/StepIndicatorStep'
 import { StepIndicator } from '../StepIndicator/StepIndicator'
 import { HeadingLevel } from '../../../types/headingLevel'
@@ -162,5 +162,33 @@ describe('StepIndicator component', () => {
     expect(heading).toHaveClass(
       'usa-step-indicator__heading my-custom-className'
     )
+  })
+
+  it('renders properly with translatable \'of\' string', () => {
+    const ofText = 'de'
+    const { queryByText } = render(
+      <StepIndicator headingLevel="h4" ofText={ofText}>
+        <StepIndicatorStep label={step1} status="complete" />
+        <StepIndicatorStep label={step2} status="current" />
+        <StepIndicatorStep label={step3} status="incomplete" />
+      </StepIndicator>
+    )
+    const totalSteps = queryByText(`${ofText} 3`)
+    expect(totalSteps).toBeInTheDocument()
+    expect(totalSteps).toHaveClass('usa-step-indicator__total-steps')
+  })
+
+  it('renders properly with translatable \'step\' string', () => {
+    const stepText = 'Paso'
+    const { getByTestId } = render(
+      <StepIndicator headingLevel="h4" stepText={stepText}>
+        <StepIndicatorStep label={step1} status="complete" />
+        <StepIndicatorStep label={step2} status="current" />
+        <StepIndicatorStep label={step3} status="incomplete" />
+      </StepIndicator>
+    )
+    const stepIndicator = getByTestId('step-indicator')
+    const stepSrOnly = within(stepIndicator).queryByText(stepText)
+    expect(stepSrOnly).toHaveClass('usa-sr-only')
   })
 })

--- a/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
@@ -14,7 +14,7 @@ describe('StepIndicator component', () => {
   })
 
   it('renders without errors', () => {
-    const { getByRole, queryByText, queryAllByText, queryByTestId } = render(
+    const { getByRole, queryByText, queryAllByText, getByTestId } = render(
       <StepIndicator headingLevel="h4">
         <StepIndicatorStep label={step1} status="complete" />
         <StepIndicatorStep label={step2} status="current" />
@@ -22,7 +22,7 @@ describe('StepIndicator component', () => {
       </StepIndicator>
     )
 
-    const stepIndicator = queryByTestId('step-indicator')
+    const stepIndicator = getByTestId('step-indicator')
 
     expect(stepIndicator).toBeInTheDocument()
     expect(stepIndicator).toHaveClass('usa-step-indicator')
@@ -30,6 +30,11 @@ describe('StepIndicator component', () => {
     expect(queryAllByText(step2)).toHaveLength(2)
     expect(queryByText(step3)).toBeInTheDocument()
     expect(getByRole('list')).toHaveClass('usa-step-indicator__segments')
+    const stepSrOnly = within(stepIndicator).queryByText('Step')
+    expect(stepSrOnly).toHaveClass('usa-sr-only')
+    const totalSteps = queryByText(`of 3`)
+    expect(totalSteps).toBeInTheDocument()
+    expect(totalSteps).toHaveClass('usa-step-indicator__total-steps')
   })
 
   it('renders properly with no labels', () => {

--- a/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.test.tsx
@@ -164,7 +164,7 @@ describe('StepIndicator component', () => {
     )
   })
 
-  it('renders properly with translatable \'of\' string', () => {
+  it("renders properly with translatable 'of' string", () => {
     const ofText = 'de'
     const { queryByText } = render(
       <StepIndicator headingLevel="h4" ofText={ofText}>
@@ -178,7 +178,7 @@ describe('StepIndicator component', () => {
     expect(totalSteps).toHaveClass('usa-step-indicator__total-steps')
   })
 
-  it('renders properly with translatable \'step\' string', () => {
+  it("renders properly with translatable 'step' string", () => {
     const stepText = 'Paso'
     const { getByTestId } = render(
       <StepIndicator headingLevel="h4" stepText={stepText}>

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -88,7 +88,9 @@ export const StepIndicator = (
       <div className="usa-step-indicator__header">
         <Heading className={headingClasses} {...remainingHeadingProps}>
           <span className="usa-step-indicator__heading-counter">
-            <span className="usa-sr-only" data-testid="step-text">{stepText}</span>
+            <span className="usa-sr-only" data-testid="step-text">
+              {stepText}
+            </span>
             <span className="usa-step-indicator__current-step">
               {currentStepNumber}
             </span>

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -16,6 +16,8 @@ type StepIndicatorProps = {
     HTMLHeadingElement
   >
   headingLevel: HeadingLevel
+  stepText?: string
+  ofText?: string
 }
 export const StepIndicator = (
   props: StepIndicatorProps
@@ -30,6 +32,8 @@ export const StepIndicator = (
     listProps,
     headingProps,
     headingLevel,
+    stepText = 'Step',
+    ofText = 'of',
   } = props
 
   const Heading = headingLevel
@@ -84,12 +88,12 @@ export const StepIndicator = (
       <div className="usa-step-indicator__header">
         <Heading className={headingClasses} {...remainingHeadingProps}>
           <span className="usa-step-indicator__heading-counter">
-            <span className="usa-sr-only">Step</span>
+            <span className="usa-sr-only" data-testid="step-text">{stepText}</span>
             <span className="usa-step-indicator__current-step">
               {currentStepNumber}
             </span>
             &nbsp;
-            <span className="usa-step-indicator__total-steps">{`of ${totalNumberOfSteps}`}</span>
+            <span className="usa-step-indicator__total-steps">{`${ofText} ${totalNumberOfSteps}`}</span>
             &nbsp;
           </span>
           <span className="usa-step-indicator__heading-text">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6508,18 +6508,18 @@ css-loader@^5.0.1:
     semver "^7.3.5"
 
 css-loader@^6.7.3:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.8.1.tgz#0f8f52699f60f5e679eab4ec0fcd68b8e8a50a88"
-  integrity sha512-xDAXtEVGlD0gJ07iclwWVkLoZOpEvAWaSyf6W18S2pOC//K8+qUDIx8IIT3D+HjnmkJPQeesOPv5aiUaJsCM2g==
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.9.0.tgz#0cc2f14df94ed97c526c5ae42b6b13916d1d8d0e"
+  integrity sha512-3I5Nu4ytWlHvOP6zItjiHlefBNtrH+oehq8tnQa2kO305qpVyx9XNIT1CXIj5bgCJs7qICBCkgCYxQLKPANoLA==
   dependencies:
     icss-utils "^5.1.0"
-    postcss "^8.4.21"
+    postcss "^8.4.31"
     postcss-modules-extract-imports "^3.0.0"
     postcss-modules-local-by-default "^4.0.3"
-    postcss-modules-scope "^3.0.0"
+    postcss-modules-scope "^3.1.0"
     postcss-modules-values "^4.0.0"
     postcss-value-parser "^4.2.0"
-    semver "^7.3.8"
+    semver "^7.5.4"
 
 css-select@^4.1.3:
   version "4.1.3"
@@ -11618,10 +11618,10 @@ nanoid@^3.3.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
   integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
-nanoid@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
-  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+nanoid@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -12629,10 +12629,10 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
-postcss-modules-scope@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
-  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+postcss-modules-scope@^3.0.0, postcss-modules-scope@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz#fbfddfda93a31f310f1d152c2bb4d3f3c5592ee0"
+  integrity sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==
   dependencies:
     postcss-selector-parser "^6.0.4"
 
@@ -12720,12 +12720,12 @@ postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.2.15, postcss@^8.4.21:
-  version "8.4.24"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
-  integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
+postcss@^8.2.15, postcss@^8.4.31:
+  version "8.4.33"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.33.tgz#1378e859c9f69bf6f638b990a0212f43e2aaa742"
+  integrity sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==
   dependencies:
-    nanoid "^3.3.6"
+    nanoid "^3.3.7"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -13921,10 +13921,10 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
# Summary

Parametrized strings in StepIndicator component to allow translation of "Step" and "of" strings. 

There are still more English strings hard coded in the StepIndicatorStep subcomponent, as well as other components, but this narrow improvement is to allow for a client project to proceed. I will continue pushing for resources to prioritize an i18n strategy (see https://github.com/trussworks/react-uswds/issues/1742)

## Related Issues or PRs

Resolves #2705 

## How To Test

- Run new tests
- Use storybook controls and inspect 👇 

### Screenshots (optional)
<img width="416" alt="image" src="https://github.com/trussworks/react-uswds/assets/764090/feb113a3-21f1-4375-a649-65a9c4699259">