### PR TITLE
fix: Exclude placeholder prop from Modal props

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -23,7 +23,8 @@ interface ModalComponentProps {
   isInitiallyOpen?: boolean
 }
 
-export type ModalProps = ModalComponentProps & Omit<JSX.IntrinsicElements['div'], 'placeholder'>
+export type ModalProps = ModalComponentProps &
+  Omit<JSX.IntrinsicElements['div'], 'placeholder'>
 
 export type ModalRef = {
   modalId: string

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -23,7 +23,7 @@ interface ModalComponentProps {
   isInitiallyOpen?: boolean
 }
 
-export type ModalProps = ModalComponentProps & JSX.IntrinsicElements['div']
+export type ModalProps = ModalComponentProps & Omit<JSX.IntrinsicElements['div'], 'placeholder'>
 
 export type ModalRef = {
   modalId: string

--- a/src/components/Modal/ModalWindow/ModalWindow.tsx
+++ b/src/components/Modal/ModalWindow/ModalWindow.tsx
@@ -14,7 +14,7 @@ interface ModalWindowProps {
 
 export const ModalWindowForwardRef: React.ForwardRefRenderFunction<
   HTMLDivElement,
-  ModalWindowProps & JSX.IntrinsicElements['div']
+  ModalWindowProps & Omit<JSX.IntrinsicElements['div'], 'placeholder'>
 > = (
   {
     modalId,

--- a/src/components/Modal/ModalWrapper/ModalWrapper.tsx
+++ b/src/components/Modal/ModalWrapper/ModalWrapper.tsx
@@ -12,7 +12,7 @@ interface ModalWrapperProps {
 
 export const ModalWrapperForwardRef: React.ForwardRefRenderFunction<
   HTMLDivElement,
-  ModalWrapperProps & JSX.IntrinsicElements['div']
+  ModalWrapperProps & Omit<JSX.IntrinsicElements['div'], 'placeholder'>
 > = (
   { id, children, isVisible, forceAction, className, handleClose, ...divProps },
   ref


### PR DESCRIPTION
# Summary

The types generated for Modal props indicate that `placeholder` is available because `@types/react` prior to v18.2.43 has `placeholder` as an attribute in `HTMLAttributes`. Beginning with `@types/react` v18.2.43, the `placeholder` attribute has been removed from `HTMLAttributes`. As a result, projects that consume this package but are themselves on `@types/react` v18.2.43 or newer no longer recognize `placeholder` as an optional property; they see it as stemming from these Modal props rather than `JSX.IntrinsicElements['div']`, and that it is required, not optional.

Patch Modal to manually omit placeholder from available properties without updating packages, which would require a more significant lift.

Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67170

## How To Test

1. Add react-uswds to a TypeScript project that has a dependency on `@types/react` v18.2.48.
2. Use the `<Modal>` component without defining the `placeholder` attribute.
3. Attempt to build the project -- the TypeScript compiler will report an error that `placeholder` is required but not defined:
   ```
   [tsl] ERROR in /path/sanitized/MyComponent.tsx(95,10) 
      TS2741: Property 'placeholder' is missing in type '{ children: Element[]; ref: RefObject<ModalRef>; "aria-describedby": string; id: string; className: string; }' but required in type 'Pick<ModalProps, "children" | "id" | "onError" | "key" | "aria-label" | "className" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | ... 249 more ... | "isInitiallyOpen">'.
   ```

## Additional Notes

1. This PR would be obsoleted by #2714 since that PR also updates `@types/react` to v18.2.48. That PR requires a major version update though, whereas this fix is safe to apply as a patch update.
1. Modal was verified to be the only component affected by this issue by grepping built `lib/components` for string `"placeholder"`. The only other component where the `placeholder` attribute appears explicitly is `FileInput` and there it is supported (`HTMLInputElement` instead of `HTMLDivElement`).