### PR TITLE
fix: Adds yarn as a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6",
     "webpack": "^5.52.1",
-    "webpack-cli": "^5.0.1"
+    "webpack-cli": "^5.0.1",
+    "yarn": "^1.22.21"
   },
   "resolutions": {
     "loader-utils": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13956,6 +13956,11 @@ yargs@^17.3.1:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
+yarn@^1.22.21:
+  version "1.22.21"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.21.tgz#1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
+  integrity sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg==
+
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
# Summary

This PR adds yarn as a dev dependency. If you install a version of this package from git, (ex. github:lpsinger/react-uswds#dateFormat) the `prepare` script will run on `npm install`. This causes npm install to fail if yarn is not present on the user's machine. 

From the npm docs:

NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

