### PR TITLE
fix: don't require id or name on Textarea

### DIFF
--- a/src/components/forms/Textarea/Textarea.tsx
+++ b/src/components/forms/Textarea/Textarea.tsx
@@ -10,8 +10,6 @@ type TextareaRef =
   | undefined
 
 export interface TextareaProps {
-  id: string
-  name: string
   className?: string
   error?: boolean
   success?: boolean
@@ -20,8 +18,6 @@ export interface TextareaProps {
 }
 
 export const Textarea = ({
-  id,
-  name,
   className,
   error,
   success,
@@ -42,8 +38,6 @@ export const Textarea = ({
     <textarea
       data-testid="textarea"
       className={classes}
-      id={id}
-      name={name}
       ref={inputRef}
       {...inputProps}>
       {children}


### PR DESCRIPTION
These are optional properties for input elements. Just pass them through in inputProps.

# Summary

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
