### PR TITLE
fix: fixed lint warnings

### DIFF
--- a/src/components/InPageNavigation/InPageNavigation.test.tsx
+++ b/src/components/InPageNavigation/InPageNavigation.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { screen, render, getByRole } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { InPageNavigation } from './InPageNavigation'
 import { HeadingLevel } from '../../types/headingLevel'
 import { CONTENT } from './content'

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -7,7 +7,7 @@ import {
   fireEvent,
   RenderOptions,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { Modal, ModalRef } from './Modal'
 import { ModalHeading } from './ModalHeading/ModalHeading'

--- a/src/components/Modal/ModalCloseButton/ModalCloseButton.test.tsx
+++ b/src/components/Modal/ModalCloseButton/ModalCloseButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { ModalCloseButton } from './ModalCloseButton'
 

--- a/src/components/Modal/ModalOpenLink.test.tsx
+++ b/src/components/Modal/ModalOpenLink.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 
 import { ModalRef } from './Modal'
 import { ModalOpenLink } from './ModalOpenLink'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 describe('ModalOpenLink', () => {
   it('renders an anchor tag with the modal control attributes', () => {

--- a/src/components/Modal/ModalToggleButton.test.tsx
+++ b/src/components/Modal/ModalToggleButton.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 
 import { ModalRef } from './Modal'
 import { ModalToggleButton } from './ModalToggleButton'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 describe('ModalToggleButton', () => {
   it('renders a button with the modal control attributes', () => {

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { screen, render, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { ComboBox, ComboBoxRef } from './ComboBox'
 import { TextInput } from '../TextInput/TextInput'

--- a/src/components/forms/DatePicker/Calendar.test.tsx
+++ b/src/components/forms/DatePicker/Calendar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { Calendar } from './Calendar'
 import { parseDateString, today } from './utils'

--- a/src/components/forms/DatePicker/DatePicker.test.tsx
+++ b/src/components/forms/DatePicker/DatePicker.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
   screen,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { DatePicker } from './DatePicker'
 import { sampleLocalization } from './i18n'

--- a/src/components/forms/DatePicker/Day.test.tsx
+++ b/src/components/forms/DatePicker/Day.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { Day } from './Day'
 

--- a/src/components/forms/DatePicker/MonthPicker.test.tsx
+++ b/src/components/forms/DatePicker/MonthPicker.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { MonthPicker } from './MonthPicker'
 import { MONTH_LABELS } from './constants'

--- a/src/components/forms/DatePicker/YearPicker.test.tsx
+++ b/src/components/forms/DatePicker/YearPicker.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { YearPicker } from './YearPicker'
 import { parseDateString } from './utils'

--- a/src/components/forms/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import { DateRangePicker } from './DateRangePicker'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 const startDatePickerTestProps = {
   id: 'start-date',

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { FileInput, FileInputRef } from './FileInput'
 import {

--- a/src/components/forms/TextInputMask/TextInputMask.test.tsx
+++ b/src/components/forms/TextInputMask/TextInputMask.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { screen, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { TextInputMask } from './TextInputMask'
 
 describe('TextInputMask component', () => {

--- a/src/components/forms/TimePicker/TimePicker.test.tsx
+++ b/src/components/forms/TimePicker/TimePicker.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, waitFor, within } from '@testing-library/react'
 
 import { TimePicker } from './TimePicker'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 describe('TimePicker Component', () => {
   beforeEach(() => {


### PR DESCRIPTION
# Summary

Fixes a bunch of userEvents imports' lint warnings (`import/no-named-as-default`)

## Related Issues or PRs

None

## How To Test

`yarn lint` should not yield any warnings

### Screenshots (optional)
