### PR TITLE
docs: removed circleci references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![npm version](https://img.shields.io/npm/v/@trussworks/react-uswds)](https://www.npmjs.com/package/@trussworks/react-uswds)
 [![uswds version](https://img.shields.io/github/package-json/dependency-version/trussworks/react-uswds/dev/@uswds/uswds)](https://www.npmjs.com/package/@uswds/uswds)
 
-[![CircleCI](https://img.shields.io/circleci/build/github/trussworks/react-uswds/main)](https://circleci.com/gh/trussworks/react-uswds)
 [![npm downloads](https://img.shields.io/npm/dm/@trussworks/react-uswds)](https://www.npmjs.com/package/@trussworks/react-uswds)
 
 **ReactUSWDS Component Library**
@@ -21,6 +20,8 @@ A deployed instance of the ReactUSWDS Storybook is located at: [https://trusswor
 - [@trussworks/react-uswds](#trussworksreact-uswds)
   - [Install](#install)
   - [Usage](#usage)
+    - [USWDS](#uswds)
+    - [NodeJS](#nodejs)
     - [Pre-Release](#pre-release)
   - [Background](#background)
     - [Non-Goals](#non-goals)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,16 +12,17 @@ We welcome contributions in the form of comments, issues, or pull requests with 
   - [Development](#development)
     - [Working on an issue](#working-on-an-issue)
     - [General guidelines](#general-guidelines)
-    - [Linting, formatting, & automated tests](#linting-formatting--automated-tests)
+    - [Linting, formatting, \& automated tests](#linting-formatting--automated-tests)
     - [Testing in an application](#testing-in-an-application)
       - [`yarn link`](#yarn-link)
       - [Install from a ReactUSWDS branch](#install-from-a-reactuswds-branch)
-    - [Opening & merging pull requests](#opening--merging-pull-requests)
+    - [Opening \& merging pull requests](#opening--merging-pull-requests)
+      - [Formatting your commits](#formatting-your-commits)
       - [`type`:](#type)
       - [`scope`:](#scope)
       - [`body`:](#body)
       - [`footer`:](#footer)
-  - [All-contributors](#all-contributors)
+  - [All Contributors](#all-contributors)
 
 ## Environment setup
 
@@ -257,7 +258,6 @@ Optional, can be one of the following:
 - `deps`: Updating a package listed in dependencies
 - `deps-dev`: Updating a package listed in devDependencies
 - `release`: Releasing a new version
-- `circleci`: Changes to CircleCI config and/or scripts
 - `storybook`: Changes to Storybook or stories files only
 
 #### `body`:


### PR DESCRIPTION
# Summary

This addresses one of #2265's ACs, removing two references to CircleCI, including the glaring red "failing" badge on our readme:

<img width="417" alt="Screenshot 2024-02-22 at 4 24 28 PM" src="https://github.com/trussworks/react-uswds/assets/764090/fcc72df1-26d7-47bd-80ef-6d80e775595f">


After merging this PR, update #2265 to be focused just on documenting GH Actions

## Related Issues or PRs

Addresses half of #2265
Closes #2604 

## How To Test

### Screenshots (optional)
