### PR TITLE
fix: use aria-controls only when appropriate on LanguageSelector

### DIFF
--- a/src/components/LanguageSelector/LanguageSelectorButton.tsx
+++ b/src/components/LanguageSelector/LanguageSelectorButton.tsx
@@ -6,6 +6,7 @@ type LanguageSelectorButtonProps = {
   labelAttr?: string
   isOpen?: boolean
   onToggle: () => void
+  controls?: string
 }
 
 export const LanguageSelectorButton = ({
@@ -14,6 +15,7 @@ export const LanguageSelectorButton = ({
   isOpen,
   onToggle,
   className,
+  controls,
   ...buttonProps
 }: LanguageSelectorButtonProps &
   JSX.IntrinsicElements['button']): React.ReactElement => {
@@ -28,7 +30,7 @@ export const LanguageSelectorButton = ({
       data-testid="languageSelectorButton"
       className={classes}
       aria-expanded={isOpen}
-      aria-controls="language-options"
+      aria-controls={controls}
       onClick={(): void => onToggle()}
       type="button"
       {...buttonProps}>

--- a/src/components/LanguageSelector/LanguageSelectorDropdown.tsx
+++ b/src/components/LanguageSelector/LanguageSelectorDropdown.tsx
@@ -54,6 +54,7 @@ const LanguageSelectorDropdown: React.FC<LanguageSelectorProps> = ({
     className
   )
   const displayLabel = langs.find((langDef) => langDef.attr === displayLang)
+  const menuID = 'language-options'
 
   return (
     <div className={classes} data-testid="languageSelector" {...divProps}>
@@ -63,12 +64,13 @@ const LanguageSelectorDropdown: React.FC<LanguageSelectorProps> = ({
             className={classes}
             label={displayLabel?.label || label || langs[0].label}
             isOpen={isOpen}
+            controls={menuID}
             onToggle={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
           />
           <Menu
             items={generateMenuItems(langs)}
             isOpen={isOpen}
-            id="language-options"
+            id={menuID}
             type="language"
           />
         </li>


### PR DESCRIPTION
# Summary

Uses aria-controls on LanguageSelector only if specified, and for this component only uses it when appropriate

## Related Issues or PRs

#2809 

## How To Test

Check Storybook's accessibility tab for LanguageSelector for errors
