### PR TITLE
build: dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,4 +28,35 @@ updates:
       - dependency-name: '@types/react-dom'
         versions:
           - '>=18.0.0'
+      - dependency-name: '@types/react-test-renderer'
+        versions:
+          - '>=18.0.0'
       - dependency-name: 'uswds'
+    groups:
+      storybook:
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+          - 'happo-plugin-storybook'
+      testing-library:
+        patterns:
+          - 'testing-library/*'
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@typescript-eslint*'
+      vite:
+        patterns:
+          - 'vite*'
+          - '@vitejs*'
+          - 'vitest'
+          - '@vitest*'
+          - '@laynezh/vite-plugin-lib-assets'
+      stylelint:
+        patterns:
+          - 'stylelint'
+          - 'stylelint-*'


### PR DESCRIPTION
# Summary

Updates the dependabot configuration to group relevant dependencies together to reduce the number of individual PRs created and to ensure dependencies that need to be updated simultaneously are done so to prevent errors.

## Related Issues or PRs

#2832 
