### PR TITLE
ci: change action used for storybook deploy

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -26,19 +26,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
+          cache: 'yarn'
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-            
       - name: Deploy 🚀
         uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
         with:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -38,14 +38,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: Install dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
-
-      - name: Build Storybook
-        run: yarn build-storybook
-
+            
       - name: Deploy 🚀
         uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
         with:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -6,6 +6,11 @@ on:
       - '[1-9].*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy-storybook:
     runs-on: ubuntu-latest
@@ -42,9 +47,9 @@ jobs:
         run: yarn build-storybook
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
         with:
-          clean: true
-          clean-exclude: |
-            CNAME
-          folder: storybook-static # The folder the action should deploy.
+          install_command: yarn install
+          build_command: yarn build-storybook
+          path: storybook-static
+          checkout: false

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -20,10 +20,10 @@ jobs:
       url: ${{ steps.build-publish.outputs.page_url }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'yarn'


### PR DESCRIPTION
# Summary
Changes the github action used for storybook deployment to one suggested by Storybook in their documentation on deployment to Github Pages (see: https://storybook.js.org/docs/sharing/publish-storybook#github-pages) in order to hopefully resolve errors in the current storybook deployment.
