### PR TITLE
fix: moved smooth-scroll application to useEffect

### DIFF
--- a/src/components/InPageNavigation/InPageNavigation.module.scss
+++ b/src/components/InPageNavigation/InPageNavigation.module.scss
@@ -1,5 +1,5 @@
 @media not (prefers-reduced-motion) {
-  html {
+  .smooth-scroll {
     scroll-behavior: smooth;
   }
 }

--- a/src/components/InPageNavigation/InPageNavigation.test.tsx
+++ b/src/components/InPageNavigation/InPageNavigation.test.tsx
@@ -4,6 +4,7 @@ import { userEvent } from '@testing-library/user-event'
 import { InPageNavigation } from './InPageNavigation'
 import { HeadingLevel } from '../../types/headingLevel'
 import { CONTENT } from './content'
+import styles from './InPageNavigation.module.scss'
 
 describe('InPageNavigation component', () => {
   const props = {
@@ -50,6 +51,7 @@ describe('InPageNavigation component', () => {
       name: 'On this page',
     })
     expect(heading).toBeInTheDocument()
+    expect(document.querySelector('html')).toHaveClass(styles['smooth-scroll'])
   })
 
   it('sets the heading and title', () => {

--- a/src/components/InPageNavigation/InPageNavigation.tsx
+++ b/src/components/InPageNavigation/InPageNavigation.tsx
@@ -29,7 +29,7 @@ export const InPageNavigation = ({
   ...divProps
 }: InPageNavigationProps &
   Omit<JSX.IntrinsicElements['div'], 'content'>): React.ReactElement => {
-  const classes = classnames('usa-in-page-nav', styles.target, className)
+  const asideClasses = classnames('usa-in-page-nav', styles.target, className)
   const { className: navClassName, ...remainingNavProps } = navProps || {}
   const navClasses = classnames('usa-in-page-nav__nav', navClassName)
   const { className: mainClassName, ...remainingMainProps } = mainProps || {}
@@ -57,12 +57,16 @@ export const InPageNavigation = ({
   const observer = new IntersectionObserver(handleIntersection, observerOptions)
   useEffect(() => {
     document.querySelectorAll('h2,h3').forEach((h) => observer.observe(h))
+    document.querySelector('html')?.classList.add(styles['smooth-scroll'])
+    return () => {
+      document.querySelector('html')?.classList.remove(styles['smooth-scroll'])
+    }
   })
 
   return (
     <div className="usa-in-page-nav-container" {...divProps}>
       <aside
-        className={classes}
+        className={asideClasses}
         aria-label={title}
         data-testid="InPageNavigation">
         <nav className={navClasses} {...remainingNavProps}>


### PR DESCRIPTION
# Summary

Fixes leak of smooth-scroll, limits it just to pages where component is being used

Also changed a variable to be more descriptive

## Related Issues or PRs

Resolves #2867

## How To Test

Use storybook as an example, comparing the [live version](https://trussworks.github.io/react-uswds/?path=/docs/components-in-page-navigation--docs) (where smooth-scroll is applied on all pages after loading the component) vs what you can build locally, shown below:

![Apr-04-2024 14-31-50](https://github.com/trussworks/react-uswds/assets/764090/1dccfd26-ddd1-481e-958f-ee6073c09af8)


### Screenshots (optional)
