### PR TITLE
fix: ‘use client’ directive syntax

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,7 +76,7 @@ export default defineConfig(({ mode: _mode }) => {
           banner: (assetInfo) =>
             assetInfo.fileName.endsWith('.js') ||
             assetInfo.fileName.endsWith('.mjs')
-              ? '"use client;"'
+              ? '"use client";'
               : '',
           globals: {
             react: 'React',


### PR DESCRIPTION
# Summary

This fixes usage of the package in a React Server Components environment (Next.js app router). This regression was introduced during the [Webpack -> Vite migration](https://github.com/trussworks/react-uswds/commit/17dde0a03c6c23b2e145b78ee8ef3faf86867431).

## How To Test

1. `npx create-next-app@latest` - select Yes for App Router when you get there
2. Add a React USWDS component to a page

### Screenshots

#### Before

![CleanShot 2024-04-17 at 18 09 53@2x](https://github.com/trussworks/react-uswds/assets/371943/2ab6126d-5d5f-41c3-9aff-fceed97550e1)


#### After

![CleanShot 2024-04-17 at 18 08 31@2x](https://github.com/trussworks/react-uswds/assets/371943/d6e846a1-7afb-44c7-8f75-6ae4eb4a308f)

