### PR TITLE
fix: Duplicate classes and invalid aria props on LanguageSelector

### DIFF
--- a/src/components/LanguageSelector/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.test.tsx
@@ -53,11 +53,24 @@ describe('LanguageSelector component', () => {
     expect(getByTestId('languageSelector')).toBeInTheDocument()
   })
 
-  it('renders custom styles', () => {
+  it('renders custom styles on the button', () => {
     const { getByTestId } = render(
       <LanguageSelector langs={languages} className="custom-class" />
     )
-    expect(getByTestId('languageSelector')).toHaveClass('custom-class')
+    expect(getByTestId('languageSelector')).not.toHaveClass('custom-class')
+    expect(getByTestId('languageSelectorButton')).toHaveClass('custom-class')
+  })
+
+  it('renders container styles on the parent', () => {
+    const { getByTestId } = render(
+      <LanguageSelector langs={languages} className="custom-class" />
+    )
+    expect(getByTestId('languageSelector')).toHaveClass(
+      'usa-language-container'
+    )
+    expect(getByTestId('languageSelectorButton')).not.toHaveClass(
+      'usa-language-container'
+    )
   })
 
   it('renders small', () => {

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -14,6 +14,9 @@ export type LanguageSelectorProps = {
   label?: string
   langs: LanguageDefinition[]
   small?: boolean
+  /**
+   * Custom classes for the call-to-action
+   */
   className?: string
   displayLang?: string
 }
@@ -27,18 +30,22 @@ export const LanguageSelector = ({
   ...divProps
 }: LanguageSelectorProps &
   JSX.IntrinsicElements['div']): React.ReactElement => {
-  const classes = classnames(
-    'usa-language-container',
-    {
-      [`usa-language--small`]: small !== undefined,
-    },
-    className
-  )
+  const containerClasses = classnames('usa-language-container', {
+    [`usa-language--small`]: small !== undefined,
+  })
 
   const [langIndex, setLangIndex] = useState(false)
+
   if (langs.length > 2) {
     const dropdownProps = { label, langs, small, displayLang }
-    return <LanguageSelectorDropdown {...dropdownProps} className={className} />
+    return (
+      <div
+        className={containerClasses}
+        data-testid="languageSelector"
+        {...divProps}>
+        <LanguageSelectorDropdown {...dropdownProps} className={className} />
+      </div>
+    )
   } else {
     if (label) {
       console.warn(
@@ -57,9 +64,12 @@ export const LanguageSelector = ({
           }
         : curLang.on_click
     return (
-      <div className={classes} data-testid="languageSelector" {...divProps}>
+      <div
+        className={containerClasses}
+        data-testid="languageSelector"
+        {...divProps}>
         <LanguageSelectorButton
-          className={classes}
+          className={className}
           label={curLang.label}
           labelAttr={curLang.attr}
           onToggle={() => {

--- a/src/components/LanguageSelector/LanguageSelectorButton.tsx
+++ b/src/components/LanguageSelector/LanguageSelectorButton.tsx
@@ -4,14 +4,12 @@ import classnames from 'classnames'
 type LanguageSelectorButtonProps = {
   label: string
   labelAttr?: string
-  isOpen?: boolean
   onToggle: () => void
 }
 
 export const LanguageSelectorButton = ({
   label,
   labelAttr,
-  isOpen,
   onToggle,
   className,
   ...buttonProps
@@ -27,8 +25,6 @@ export const LanguageSelectorButton = ({
     <button
       data-testid="languageSelectorButton"
       className={classes}
-      aria-expanded={isOpen}
-      aria-controls="language-options"
       onClick={(): void => onToggle()}
       type="button"
       {...buttonProps}>

--- a/src/components/LanguageSelector/LanguageSelectorDropdown.tsx
+++ b/src/components/LanguageSelector/LanguageSelectorDropdown.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { Menu } from '../header/Menu/Menu'
 import { LanguageSelectorButton } from './LanguageSelectorButton'
-import classnames from 'classnames'
 import { LanguageDefinition, LanguageSelectorProps } from './LanguageSelector'
 import { Button } from '../Button/Button'
 
@@ -39,41 +38,30 @@ const generateMenuItems = (langs: LanguageDefinition[]) => {
 const LanguageSelectorDropdown: React.FC<LanguageSelectorProps> = ({
   label,
   langs,
-  small,
   className,
   displayLang,
-  ...divProps
 }) => {
   const [isOpen, setIsOpen] = useState(false)
-
-  const classes = classnames(
-    'usa-language-container',
-    {
-      [`usa-language--small`]: small !== undefined,
-    },
-    className
-  )
   const displayLabel = langs.find((langDef) => langDef.attr === displayLang)
 
   return (
-    <div className={classes} data-testid="languageSelector" {...divProps}>
-      <ul className="usa-language__primary usa-accordion">
-        <li className="usa-language__primary-item">
-          <LanguageSelectorButton
-            className={classes}
-            label={displayLabel?.label || label || langs[0].label}
-            isOpen={isOpen}
-            onToggle={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
-          />
-          <Menu
-            items={generateMenuItems(langs)}
-            isOpen={isOpen}
-            id="language-options"
-            type="language"
-          />
-        </li>
-      </ul>
-    </div>
+    <ul className="usa-language__primary usa-accordion">
+      <li className="usa-language__primary-item">
+        <LanguageSelectorButton
+          aria-expanded={isOpen}
+          aria-controls="language-options"
+          className={className}
+          label={displayLabel?.label || label || langs[0].label}
+          onToggle={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
+        />
+        <Menu
+          items={generateMenuItems(langs)}
+          isOpen={isOpen}
+          id="language-options"
+          type="language"
+        />
+      </li>
+    </ul>
   )
 }
 


### PR DESCRIPTION
# Summary

This fixes a few issues with the `LanguageSelector` implementation:

1. The `usa-language-container` class was being applied to both the parent `div` and the inner `button`, which causes layout issues due to the button receiving unexpected margins and relative positioning
2. #2809

An assumption I am making in this PR is that the intent of the `className` prop is to apply custom styling to the button, which is how it's demonstrated in Storybook.

## How To Test

Storybook

### Screenshots (optional)

![CleanShot 2024-04-18 at 15 08 34@2x](https://github.com/trussworks/react-uswds/assets/371943/3b217b1a-185b-43db-8aab-05e476822542)
