### PR TITLE
feat: Upgrade to 3.8.1 with tooltip updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "homepage": "https://github.com/trussworks/react-uswds#readme",
   "peerDependencies": {
-    "@uswds/uswds": "^3.7.1",
+    "@uswds/uswds": "^3.8.1",
     "focus-trap-react": "^10.2.3",
     "react": "^16.x || ^17.x || ^18.x",
     "react-dom": "^16.x || ^17.x || ^18.x"
@@ -98,7 +98,7 @@
     "@types/react-test-renderer": "^18.0.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.1.1",
-    "@uswds/uswds": "3.7.1",
+    "@uswds/uswds": "3.8.1",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-istanbul": "^1.2.1",
     "all-contributors-cli": "^6.24.0",

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -110,13 +110,18 @@ describe('Tooltip component', () => {
     expect(bodyEl).toHaveAttribute('aria-hidden', 'true')
   })
 
-  it('hides tooltip on keydown after focus', () => {
+  it('hides tooltip on Escape keydown after focus', () => {
     render(<Tooltip label="Click me">My Tooltip</Tooltip>)
     const bodyEl = screen.queryByRole('tooltip', { hidden: true })
 
     fireEvent.focus(screen.getByTestId('triggerElement'))
     expect(bodyEl).toHaveClass('is-visible')
     expect(bodyEl).toHaveAttribute('aria-hidden', 'false')
+
+    fireEvent.keyDown(screen.getByTestId('triggerElement'), { key: 'a' })
+
+    expect(bodyEl).toHaveClass('is-visible')
+    expect(bodyEl).not.toHaveAttribute('aria-hidden', 'true')
 
     fireEvent.keyDown(screen.getByTestId('triggerElement'), { key: 'Escape' })
 

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -81,7 +81,7 @@ describe('Tooltip component', () => {
     expect(bodyEl).toHaveClass('is-visible')
     expect(bodyEl).toHaveAttribute('aria-hidden', 'false')
 
-    fireEvent.mouseLeave(screen.getByTestId('triggerElement'))
+    fireEvent.mouseLeave(screen.getByTestId('tooltipWrapper'))
     expect(bodyEl).not.toHaveClass('is-visible')
     expect(bodyEl).toHaveAttribute('aria-hidden', 'true')
   })

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -189,6 +189,9 @@ export function Tooltip<
   const hideTooltip = (): void => {
     setVisible(false)
   }
+  const escapeTooltip = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (e.key === 'Escape') hideTooltip()
+  }
 
   const wrapperClasses = classnames('usa-tooltip', wrapperclasses)
 
@@ -221,7 +224,7 @@ export function Tooltip<
         onMouseOver: showTooltip,
         onFocus: showTooltip,
         onBlur: hideTooltip,
-        onKeyDown: hideTooltip,
+        onKeyDown: escapeTooltip,
         className: triggerClasses,
       },
       children
@@ -273,7 +276,7 @@ export function Tooltip<
           onMouseOver={showTooltip}
           onFocus={showTooltip}
           onBlur={hideTooltip}
-          onKeyDown={hideTooltip}>
+          onKeyDown={escapeTooltip}>
           {children}
         </button>
         <span

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -220,7 +220,6 @@ export function Tooltip<
         onMouseEnter: showTooltip,
         onMouseOver: showTooltip,
         onFocus: showTooltip,
-        onMouseLeave: hideTooltip,
         onBlur: hideTooltip,
         onKeyDown: hideTooltip,
         className: triggerClasses,
@@ -229,7 +228,10 @@ export function Tooltip<
     )
 
     return (
-      <span data-testid="tooltipWrapper" className={wrapperClasses}>
+      <span
+        data-testid="tooltipWrapper"
+        className={wrapperClasses}
+        onMouseLeave={hideTooltip}>
         {triggerElement}
         <span
           data-testid="tooltipBody"
@@ -254,7 +256,10 @@ export function Tooltip<
     )
 
     return (
-      <span data-testid="tooltipWrapper" className={wrapperClasses}>
+      <span
+        data-testid="tooltipWrapper"
+        className={wrapperClasses}
+        onMouseLeave={hideTooltip}>
         <button
           {...remainingProps}
           data-testid="triggerElement"
@@ -267,7 +272,6 @@ export function Tooltip<
           onMouseEnter={showTooltip}
           onMouseOver={showTooltip}
           onFocus={showTooltip}
-          onMouseLeave={hideTooltip}
           onBlur={hideTooltip}
           onKeyDown={hideTooltip}>
           {children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,10 +3301,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@uswds/uswds@3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@uswds/uswds/-/uswds-3.7.1.tgz#455dee2d7a9c7b316192bb2e21ecd0df6fad3085"
-  integrity sha512-32u2S50bf5dwIujebqL+f1Jgx2rmRrpxcaccSZzdo3Qv9HaDUdcmeavlrxHqN30edHc7p8kRPjvjevOmOJKB7w==
+"@uswds/uswds@3.8.1":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@uswds/uswds/-/uswds-3.8.1.tgz#3d834559498ae1bb7d3a618f3f85a5f4e9818497"
+  integrity sha512-bKG/B9mJF1v0yoqth48wQDzST5Xyu3OxxpePIPDyhKWS84oDrCehnu3Z88JhSjdIAJMl8dtjtH8YvdO9kZUpAg==
   dependencies:
     classlist-polyfill "1.2.0"
     object-assign "4.1.1"


### PR DESCRIPTION
# Summary

This updates us to the latest uswds version, 3.8.1, which had two changes that required PRs here:
- [Make tooltip content hoverable](https://github.com/uswds/uswds/pull/5919)
- [Make tooltip dismissible with escape key](https://github.com/uswds/uswds/pull/5909)

## How To Test

1. Run new tests
2. Open [tooltip stories](http://localhost:9009/?path=/docs/components-tooltip--docs) and confirm (1) that you can hover on the tooltip body and (2) dismiss it by keyboard only with the Escape (and no other) key. Previously, we had set it so that any key would dismiss, which was neither helpful in general nor accessible by keyboard navigation.