### PR TITLE
feat: Enable custom on click handler passed via accordion item

### DIFF
--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -377,4 +377,26 @@ describe('Accordion component', () => {
       }
     )
   })
+
+  describe('with a custom click handler', () => {
+    const customToggleFunction = vi.fn()
+
+    const customTestItems: AccordionItemProps[] = [
+      {
+        title: 'First Amendment',
+        content: firstAmendment,
+        expanded: false,
+        id: '123',
+        headingLevel: 'h4',
+        handleToggle: () => {
+          customToggleFunction()
+        },
+      },
+    ]
+    it('fires the handler successfully', () => {
+      const { getByText } = render(<Accordion items={customTestItems} />)
+      fireEvent.click(getByText(testItems[0].title as string))
+      expect(customToggleFunction).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -108,7 +108,8 @@ export const Accordion = ({
           key={`accordionItem_${i}`}
           {...item}
           expanded={openItems.indexOf(item.id) > -1}
-          handleToggle={(): void => {
+          handleToggle={(e): void => {
+            if (item.handleToggle) item.handleToggle(e)
             toggleItem(item.id)
           }}
         />

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import './styles/index.scss'
 
 /** USWDS basic components */
 export { Alert } from './components/Alert/Alert'
-export { Accordion } from './components/Accordion/Accordion'
+export { Accordion, AccordionItem } from './components/Accordion/Accordion'
 export { Button } from './components/Button/Button'
 export { ButtonGroup } from './components/ButtonGroup/ButtonGroup'
 export { InPageNavigation } from './components/InPageNavigation/InPageNavigation'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import './styles/index.scss'
 
 /** USWDS basic components */
 export { Alert } from './components/Alert/Alert'
-export { Accordion, AccordionItem } from './components/Accordion/Accordion'
+export { Accordion } from './components/Accordion/Accordion'
 export { Button } from './components/Button/Button'
 export { ButtonGroup } from './components/ButtonGroup/ButtonGroup'
 export { InPageNavigation } from './components/InPageNavigation/InPageNavigation'


### PR DESCRIPTION
# Summary

Users pass in items to the Accordion component and those items could have custom onClick handlers that fire via the `handleToggle` prop. (For example, custom GA tracking events described in the below issue.) This change actually implements firing those passed-in functions.

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->

addresses #2739 

## How To Test

<!-- Describe how a reviewer could test or verify your changes. -->

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

In `Accordion.stories.tsx`, add a line to the first item in the `testItems` array:

```
    handleToggle: () => {
      console.log('hello')
    },
```
Open one of the Accordion stories in Storybook, open the developer console, click the first Accordion item and you should see "hello" appear.

### Screenshots (optional)