### PR TITLE
fix: useId instead of random number for tooltip ID

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -40,7 +40,7 @@ const DEFAULT_POSITION = 'top'
 // useId was introduced in React 18 - polyfill for older versions
 const genId = (): string => {
   if (React.useId) {
-    return React.useId();
+    return React.useId()
   } else {
     return `${Math.floor(Math.random() * 900000) + 100000}`
   }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -37,6 +37,15 @@ export function isCustomProps<T>(
 const TRIANGLE_SIZE = 5
 const DEFAULT_POSITION = 'top'
 
+// useId was introduced in React 18 - polyfill for older versions
+const genId = (): string => {
+  if (React.useId) {
+    return React.useId();
+  } else {
+    return `${Math.floor(Math.random() * 900000) + 100000}`
+  }
+}
+
 export function Tooltip(props: DefaultTooltipProps): ReactElement
 export function Tooltip<T>(props: CustomTooltipProps<T>): ReactElement
 export function Tooltip<
@@ -49,7 +58,7 @@ export function Tooltip<
 }: DefaultTooltipProps | CustomTooltipProps<FCProps>): ReactElement {
   const triggerElementRef = useRef<HTMLElement & HTMLButtonElement>(null)
   const tooltipBodyRef = useRef<HTMLElement>(null)
-  const tooltipID = `tooltip-${useId()}`
+  const tooltipID = useRef(`tooltip-${genId()}`)
 
   const [isVisible, setVisible] = useState(false)
   const [isShown, setIsShown] = useState(false)

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -49,9 +49,7 @@ export function Tooltip<
 }: DefaultTooltipProps | CustomTooltipProps<FCProps>): ReactElement {
   const triggerElementRef = useRef<HTMLElement & HTMLButtonElement>(null)
   const tooltipBodyRef = useRef<HTMLElement>(null)
-  const tooltipID = useRef(
-    `tooltip-${Math.floor(Math.random() * 900000) + 100000}`
-  )
+  const tooltipID = `tooltip-${useId()}`
 
   const [isVisible, setVisible] = useState(false)
   const [isShown, setIsShown] = useState(false)
@@ -290,4 +288,7 @@ export function Tooltip<
       </span> // the span that wraps the element with have the tooltip class
     )
   }
+}
+function useId() {
+  throw new Error('Function not implemented.')
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -298,6 +298,3 @@ export function Tooltip<
     )
   }
 }
-function useId() {
-  throw new Error('Function not implemented.')
-}


### PR DESCRIPTION
# Summary

## Related Issues or PRs

Alternate approach to #2562, which does not change the API of the `Tooltip` component. Use React's `useId` to generate a unique identifier instead of a random number. 

This is the expected way to generate IDs, so plays nicely with server side rendering frameworks and is easy to mock for unit or snapshot tests.

Example of jest config for mocking
```
// Make sure the auto-generated IDs are stable for snapshot testing
jest.mock("react", () => ({
  ...jest.requireActual("react"),
  useId: () => "r:id",
}));
```

## How To Test

This is a pure bugfix/refactor. It makes no change to API or UI
