### PR TITLE
fix: #2620 Move form templates in Storybook

### DIFF
--- a/src/components/forms/Form/Form.stories.tsx
+++ b/src/components/forms/Form/Form.stories.tsx
@@ -4,17 +4,14 @@ import { Form } from './Form'
 
 import { Alert } from '../../Alert/Alert'
 import { Button } from '../../Button/Button'
-import { ErrorMessage } from '../ErrorMessage/ErrorMessage'
 import { Fieldset } from '../Fieldset/Fieldset'
-import { FormGroup } from '../FormGroup/FormGroup'
 import { Label } from '../Label/Label'
 import { RequiredMarker } from '../Label/RequiredMarker'
 import { TextInput } from '../TextInput/TextInput'
-import { Textarea } from '../Textarea/Textarea'
 import { Select } from '../Select/Select'
 
 export default {
-  title: 'Components/Form templates',
+  title: 'Page Templates/Forms',
   component: Form,
   parameters: {
     docs: {
@@ -32,50 +29,6 @@ Source: https://designsystem.digital.gov/components/form-templates/
 const mockSubmit = (): void => {
   /* mock submit fn */
 }
-
-export const TextInputForm = (): React.ReactElement => (
-  <div style={{ marginLeft: '4rem' }}>
-    <Form onSubmit={mockSubmit}>
-      <Label htmlFor="input-type-text">Text input label</Label>
-      <TextInput id="input-type-text" name="input-type-text" type="text" />
-
-      <Label htmlFor="input-focus">Text input focused</Label>
-      <TextInput
-        id="input-focus"
-        name="input-focus"
-        className="usa-focus"
-        type="text"
-      />
-
-      <FormGroup error>
-        <Label htmlFor="input-error" error>
-          Text input error
-        </Label>
-        <ErrorMessage id="input-error-message">
-          Helpful error message
-        </ErrorMessage>
-        <TextInput
-          id="input-error"
-          name="input-error"
-          type="text"
-          validationStatus="error"
-          aria-describedby="input-error-message"
-        />
-      </FormGroup>
-
-      <Label htmlFor="input-success">Text input success</Label>
-      <TextInput
-        id="input-success"
-        name="input-success"
-        type="text"
-        validationStatus="success"
-      />
-
-      <Label htmlFor="input-type-textarea">Text area label</Label>
-      <Textarea id="input-type-textarea" name="input-type-textarea"></Textarea>
-    </Form>
-  </div>
-)
 
 export const NameForm = (): React.ReactElement => (
   <Form onSubmit={mockSubmit}>


### PR DESCRIPTION
# Summary

Move form templates in Storybook from the `Components` section to the `Page Templates` section.  
Also move `Text input` out of `Forms` into `Components`, to match the location of other inputs.

This should only affect Storybook documentation, not any projects that use `react-uswds`.

## Related Issues or PRs

This closes #2620 

## How To Test  

You can test locally with `npm run storybook`. This should open your local build in your default browser, or you can navigate to http://localhost:9009/  
In the sidebar navigation, there is a new folder named "Forms" under the heading "Page Templates". This contains:
- Name Form
- Address Form
- Sign In Form
- Password Reset Form

Also note that "Text input" is now just inside the "Components" heading (instead of nested under "Components > Form templates").

### Screenshots (optional)
![Screenshot 2025-03-11 at 5 01 44 PM](https://github.com/user-attachments/assets/67ea1e9f-2cdc-48d7-aec0-07450fafe762)

