### PR TITLE
chore: #3088 broken pre-commit tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 yarn run lint
 yarn run format:check
-yarn run test related --silent
+yarn run test
+yarn run test:serverside --silent
+

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -56,8 +56,8 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
 ): JSX.Element => {
   const { isOpen, toggleModal } = useModal(isInitiallyOpen)
   const [mounted, setMounted] = useState(false)
-  const initialPaddingRef = useRef<string>(undefined)
-  const tempPaddingRef = useRef<string>(undefined)
+  const initialPaddingRef = useRef<string|undefined>(undefined)
+  const tempPaddingRef = useRef<string|undefined>(undefined)
   const modalEl = useRef<HTMLDivElement>(null)
 
   const modalRootSelector = modalRoot || '.usa-modal-wrapper'

--- a/src/components/forms/RangeInput/RangeInput.test.tsx
+++ b/src/components/forms/RangeInput/RangeInput.test.tsx
@@ -68,7 +68,7 @@ describe('RangeInput component', () => {
   })
 
   it('renders with attached ref', () => {
-    const rangeRef: React.RefObject<HTMLInputElement | null> = React.createRef()
+    const rangeRef: React.RefObject<HTMLInputElement> = React.createRef()
 
     const { queryByTestId } = render(
       <RangeInput id="range-slider-id" name="rangeName" inputRef={rangeRef} />


### PR DESCRIPTION
# Summary
This fixes broken pre-commit tests introduced in #3088.  
I found that `yarn run test related --silent` was not finding any tests to run. When I ran `yarn run test:serverside` on my local, it showed errors.
I've updated the pre-commit commands to run the specific tests we want, and fixed the errors.

## Related Issues or PRs

#3088 feat: Upgrade to React 19

## How To Test

Create a test branch and add an empty commit to see the tests run

`git commit --allow-empty -m 'run some checks'`

