### PR TITLE
chore: update Yarn CI flag

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -26,7 +26,7 @@ jobs:
       
       # The yarn cache is not node_modules
       - name: Install Dependencies
-        run: yarn --prefer-offline
+        run: yarn add --cached
       
       - name: Run tests
         run: yarn test

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -32,7 +32,7 @@ jobs:
 
       # The yarn cache is not node_modules
       - name: Install dependencies
-        run: yarn --prefer-offline
+        run: yarn add --cached
 
       # Setup .npmrc file to publish to GitHub Packages
       - name: Set up node

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,3 +1,4 @@
+const { defineConfig, globalIgnores } = require('eslint/config');
 const _import = require('eslint-plugin-import');
 const typescriptEslint = require('@typescript-eslint/eslint-plugin');
 const jsxA11Y = require('eslint-plugin-jsx-a11y');
@@ -19,10 +20,11 @@ const {
 const compat = new FlatCompat({
     baseDirectory: __dirname,
     recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+    allConfig: js.configs.all,
 });
 
-module.exports = [
+module.exports = defineConfig([
+    globalIgnores(['src/serverSideTest.js']),
     ...fixupConfigRules(compat.extends(
         'eslint:recommended',
         'plugin:import/errors',
@@ -46,7 +48,7 @@ module.exports = [
         },
 
         ignores: [
-            'node_modules/*'
+            'node_modules/*',
         ],
 
         languageOptions: {
@@ -107,4 +109,4 @@ module.exports = [
             'import/no-unresolved': 'off',
         },
     }
-];
+]);

--- a/src/serverSideTest.js
+++ b/src/serverSideTest.js
@@ -5,7 +5,6 @@
  * and takes place after a webpack build.
  */
 
-// eslint-disable-next-line import/no-unresolved
 import library from '../lib/index.cjs'
 
 console.log('server-side test running')


### PR DESCRIPTION
# Summary
The `--prefer-offline` flag for installing dependencies via Yarn is deprecated in favor of `yarn add --cached`.

## Related Issues or PRs

This is related to #2878 (we forgot to update this flag).

## How To Test

This should be reflected in CI tests, though running `yarn install` on your local should produce an error on `main`, and not produce an error on this branch.

I've also made updates to the eslint config, so run `yarn lint`.


