### PR TITLE
chore: update yarn ci

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --immutable --immutable-cache
 
       - name: Run tests with coverage
         run: yarn test:coverage
@@ -51,7 +51,7 @@ jobs:
 
       # The yarn cache is not node_modules
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --immutable --immutable-cache
 
       - name: Lint code
         run: yarn lint

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn --immutable --immutable-cache
+        run: yarn --immutable
 
       - name: Run tests with coverage
         run: yarn test:coverage
@@ -51,7 +51,7 @@ jobs:
 
       # The yarn cache is not node_modules
       - name: Install dependencies
-        run: yarn --immutable --immutable-cache
+        run: yarn --immutable
 
       - name: Lint code
         run: yarn lint

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -42,6 +42,6 @@ jobs:
           node-version-file: '.node-version'
 
       # Publish to GitHub Packages
-      - run: yarn publish --no-git-tag-version --prerelease --preid alpha-$(date +%Y%m%d%H%M%S) --tag next
+      - run: yarn npm publish --no-git-tag-version --prerelease --preid alpha-$(date +%Y%m%d%H%M%S) --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -137,8 +137,7 @@
     "vite-plugin-dts": "^4.0.3",
     "vite-plugin-svgr": "^4.2.0",
     "vitest": "^2.0.4",
-    "webpack": "^5.90.1",
-    "yarn": "^1.22.22"
+    "webpack": "^5.90.1"
   },
   "resolutions": {
     "parse-url": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2476,7 +2476,6 @@ __metadata:
     vite-plugin-svgr: ^4.2.0
     vitest: ^2.0.4
     webpack: ^5.90.1
-    yarn: ^1.22.22
   peerDependencies:
     "@types/react": ^16.x || ^17.x || ^18.x || ^19.x
     "@types/react-dom": ^16.x || ^17.x || ^18.x || ^19.x
@@ -11345,16 +11344,6 @@ __metadata:
     y18n: ^4.0.0
     yargs-parser: ^18.1.2
   checksum: 40b974f508d8aed28598087720e086ecd32a5fd3e945e95ea4457da04ee9bdb8bdd17fd91acff36dc5b7f0595a735929c514c40c402416bbb87c03f6fb782373
-  languageName: node
-  linkType: hard
-
-"yarn@npm:^1.22.22":
-  version: 1.22.22
-  resolution: "yarn@npm:1.22.22"
-  bin:
-    yarn: bin/yarn.js
-    yarnpkg: bin/yarn.js
-  checksum: 59aeef5ccfd3347287f939448e6d3594f0a42f74025b9bdc2a277641c1d4070c07a38b6e7c35e695f77410b0269a5a43c78535786564f86f39c9f781e6efa311
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

PR #3110 somehow came through with no changes. This includes the changes that should have been made with that PR:

More updates to yarn. This swaps out the --frozen-lockfile flag and removes the yarn v1 dependency.
--immutable errors when the lockfile changes.
--immutable-cache errors when the cache changes.

## Related Issues or PRs

This is a continuation of #3109 

