### PR TITLE
chore: set CI fail-fast to false

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node: [ '20', '22' ]
 

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -14,7 +14,8 @@ permissions:
 jobs:
   deploy-storybook:
     runs-on: ubuntu-latest
-    strategy: fail-fast: false
+    strategy:
+      fail-fast: false
     name: Deploy Storybook
     environment:
       name: github-pages

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   deploy-storybook:
     runs-on: ubuntu-latest
+    strategy: fail-fast: false
     name: Deploy Storybook
     environment:
       name: github-pages

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -13,7 +13,10 @@ jobs:
     if: |
       startsWith(github.head_ref, 'release-')
       && github.event.pull_request.merged
-      
+
+    strategy:
+      fail-fast: false
+
     steps: 
       - name: Checkout out repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish-next:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     name: Publish next to Github Packages
     steps:
       - name: Check out repository

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:


### PR DESCRIPTION
# Summary

We've been seeing `Error: The operation was canceled.` on CI tests, with no clear indication of why. On investigation, it appears there are several possible causes (including configurations on GitHub's side), but one is the GH CI [`fail-fast` strategy](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast).

> GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails. This property defaults to true.

Setting `false` may solve this problem, but it will also surface all failing tests at once instead of making us fix them one at a time.


## How To Test

I think we just have to merge this one and let it run. Check out [the documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to see if you agree that this is low-risk.
