### PR TITLE
feat: add optional change/selected text to FileInput

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -65,6 +65,9 @@ export const AcceptImages = (): JSX.Element => (
       name="file-input-wildcard"
       accept="image/*"
       aria-describedby="file-input-wildcard-hint"
+      previewSingleSelectedFileText="Selected photo"
+      previewMultipleSelectedFileText="Photos selected"
+      changeSelectedFileText="Change photo"
       multiple
     />
   </FormGroup>

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -171,6 +171,23 @@ describe('FileInput component', () => {
       expect(previewHeading).toHaveTextContent('Selected file Change file')
     })
 
+    it('renders a custom header text when a single file is chosen', async () => {
+      const { getByTestId } = render(
+        <FileInput
+          {...testProps}
+          previewSingleSelectedFileText="Selected photo"
+          previewMultipleSelectedFileText="Photos selected"
+          changeSelectedFileText="Change photo"
+        />
+      )
+      const inputEl = getByTestId('file-input-input')
+      await userEvent.upload(inputEl, TEST_PNG_FILE)
+      expect(getByTestId('file-input-preview')).toBeInTheDocument()
+      expect(getByTestId('file-input-instructions')).toHaveClass('display-none')
+      const previewHeading = getByTestId('file-input-preview-heading')
+      expect(previewHeading).toHaveTextContent('Selected photo Change photo')
+    })
+
     it('renders a preview for each file and header text when multiple files are chosen', async () => {
       const { getByTestId, getAllByTestId } = render(
         <FileInput {...testProps} multiple={true} />

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -17,6 +17,9 @@ type FileInputProps = {
   dragText?: string
   chooseText?: string
   errorText?: string
+  previewSingleSelectedFileText?: string
+  previewMultipleSelectedFileText?: string
+  changeSelectedFileText?: string
   disabled?: boolean
   multiple?: boolean
   accept?: string
@@ -40,6 +43,9 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     dragText,
     chooseText,
     errorText,
+    previewSingleSelectedFileText,
+    previewMultipleSelectedFileText,
+    changeSelectedFileText,
     disabled,
     multiple,
     className,
@@ -94,6 +100,9 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
     : 'Drag file here or '
   const defaultChooseText = 'choose from folder'
   const defaultErrorText = 'This is not a valid file type.'
+  const defaultSingleSelectedFileText = 'Selected file'
+  const defaultMultipleSelectedFileText = ' files selected'
+  const defaultChangeSelectedFileText = 'Change file'
 
   const filePreviews = []
   if (files) {
@@ -116,8 +125,10 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
 
   const previewHeaderText =
     filePreviews.length > 1
-      ? `${filePreviews.length} files selected`
-      : 'Selected file'
+      ? previewMultipleSelectedFileText
+        ? `${filePreviews.length} ${previewMultipleSelectedFileText}`
+        : `${filePreviews.length} ${defaultMultipleSelectedFileText}`
+      : previewSingleSelectedFileText || defaultSingleSelectedFileText
 
   const preventInvalidFiles = (e: React.DragEvent): void => {
     setShowError(false)
@@ -191,7 +202,9 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
             className="usa-file-input__preview-heading">
             {previewHeaderText}{' '}
             <span className="usa-file-input__choose">
-              Change file{filePreviews.length > 1 && 's'}
+              {changeSelectedFileText
+                ? `${changeSelectedFileText}${filePreviews.length > 1 && 's'}`
+                : `${defaultChangeSelectedFileText}${filePreviews.length > 1 && 's'}`}
             </span>
           </div>
         )}


### PR DESCRIPTION
# Summary

This PR adds new optional properties to FileInput so that the preview header can be customized.

## Related Issues or PRs

Closes [3115](https://github.com/trussworks/react-uswds/issues/3115)

## How To Test

The [accept images](http://localhost:9009/?path=/story/components-file-input--accept-images) story was updated to show the new feature.  Additionally a new test was added as well.

<!-- Does this change fix an issue or bug in an application you work on? Make sure you've tested this branch in your application to verify it works before merging & releasing. -->

### Screenshots (optional)
<img width="527" alt="Screenshot 2025-03-24 at 10 12 10 AM" src="https://github.com/user-attachments/assets/517d1663-0fa1-4bd3-a5ab-402a26e00e9d" />
