### PR TITLE
feat: Export component props

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -13,12 +13,12 @@ export interface AccordionItemProps {
   handleToggle?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-type AccordionProps = {
+export type AccordionProps = {
   bordered?: boolean
   multiselectable?: boolean
   items: AccordionItemProps[]
   className?: string
-}
+} & JSX.IntrinsicElements['div']
 
 export const AccordionItem = ({
   title,
@@ -67,7 +67,7 @@ export const Accordion = ({
   items,
   className,
   multiselectable = false,
-}: AccordionProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: AccordionProps): JSX.Element => {
   const [openItems, setOpenState] = useState(
     items.filter((i) => !!i.expanded).map((i) => i.id)
   )

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 
 import { HeadingLevel } from '../../types/headingLevel'
 
-export interface AccordionItemProps {
+export type AccordionItemProps = {
   title: React.ReactNode | string
   content: React.ReactNode
   expanded: boolean

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -5,7 +5,7 @@ import { HeadingLevel } from '../../types/headingLevel'
 
 import styles from './Alert.module.scss'
 
-type AlertProps = {
+export type AlertProps = {
   type: 'success' | 'warning' | 'error' | 'info'
   heading?: React.ReactNode
   headingLevel: HeadingLevel
@@ -14,7 +14,7 @@ type AlertProps = {
   slim?: boolean
   noIcon?: boolean
   validation?: boolean
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 export const Alert = ({
   type,
@@ -27,7 +27,7 @@ export const Alert = ({
   className,
   validation,
   ...props
-}: AlertProps & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
+}: AlertProps): JSX.Element => {
   const classes = classnames(
     'usa-alert',
     {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,7 +11,7 @@ export type ButtonProps = {
   inverse?: boolean
   size?: 'big'
   unstyled?: boolean
-}
+} & JSX.IntrinsicElements['button']
 
 export const Button = ({
   type,
@@ -26,7 +26,7 @@ export const Button = ({
   onClick,
   className,
   ...defaultProps
-}: ButtonProps & JSX.IntrinsicElements['button']): JSX.Element => {
+}: ButtonProps): JSX.Element => {
   const classes = classnames(
     'usa-button',
     {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type ButtonGroupProps = {
+export type ButtonGroupProps = {
   children: React.ReactNode
   className?: string
   type?: 'default' | 'segmented'

--- a/src/components/Collection/Collection.tsx
+++ b/src/components/Collection/Collection.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type CollectionProps = {
+export type CollectionProps = {
   condensed?: boolean
-}
+} & JSX.IntrinsicElements['ul']
 
 export const Collection = ({
   children,
   className,
   condensed,
   ...ulProps
-}: CollectionProps & JSX.IntrinsicElements['ul']): JSX.Element => {
+}: CollectionProps): JSX.Element => {
   const classes = classnames(
     'usa-collection',
     { 'usa-collection--condensed': condensed },

--- a/src/components/Collection/CollectionCalendarDate.tsx
+++ b/src/components/Collection/CollectionCalendarDate.tsx
@@ -1,8 +1,11 @@
 import React, { type JSX } from 'react'
 
-interface CollectionCalendarDateProps {
+interface CollectionCalendarDatePropsInterface {
   datetime: string
 }
+
+export type CollectionCalendarDateProps = CollectionCalendarDatePropsInterface &
+  React.HTMLProps<HTMLDivElement>
 
 const SHORT_MONTH_LABELS = [
   'Jan',

--- a/src/components/Collection/CollectionCalendarDate.tsx
+++ b/src/components/Collection/CollectionCalendarDate.tsx
@@ -1,10 +1,8 @@
 import React, { type JSX } from 'react'
 
-interface CollectionCalendarDatePropsInterface {
+export type CollectionCalendarDateProps = {
   datetime: string
 }
-
-export type CollectionCalendarDateProps = CollectionCalendarDatePropsInterface
 
 const SHORT_MONTH_LABELS = [
   'Jan',

--- a/src/components/Collection/CollectionCalendarDate.tsx
+++ b/src/components/Collection/CollectionCalendarDate.tsx
@@ -4,8 +4,7 @@ interface CollectionCalendarDatePropsInterface {
   datetime: string
 }
 
-export type CollectionCalendarDateProps = CollectionCalendarDatePropsInterface &
-  React.HTMLProps<HTMLDivElement>
+export type CollectionCalendarDateProps = CollectionCalendarDatePropsInterface
 
 const SHORT_MONTH_LABELS = [
   'Jan',

--- a/src/components/Collection/CollectionDescription.tsx
+++ b/src/components/Collection/CollectionDescription.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classname from 'classnames'
 
+export type CollectionDescriptionProps = JSX.IntrinsicElements['p']
+
 export const CollectionDescription = ({
   className,
   children,
   ...props
-}: JSX.IntrinsicElements['p']): JSX.Element => {
+}: CollectionDescriptionProps): JSX.Element => {
   const classes = classname('usa-collection__description', className)
   return (
     <p className={classes} {...props}>

--- a/src/components/Collection/CollectionHeading.tsx
+++ b/src/components/Collection/CollectionHeading.tsx
@@ -2,15 +2,12 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { HeadingLevel } from '../../types/headingLevel'
 
-interface CollectionHeadingPropsInterface {
+export type CollectionHeadingProps = {
   headingLevel: HeadingLevel
-}
-
-export type CollectionHeadingProps = CollectionHeadingPropsInterface &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLHeadingElement>,
-    HTMLHeadingElement
-  >
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLHeadingElement>,
+  HTMLHeadingElement
+>
 
 export const CollectionHeading = ({
   headingLevel,

--- a/src/components/Collection/CollectionHeading.tsx
+++ b/src/components/Collection/CollectionHeading.tsx
@@ -2,19 +2,22 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { HeadingLevel } from '../../types/headingLevel'
 
-interface CollectionHeadingProps {
+interface CollectionHeadingPropsInterface {
   headingLevel: HeadingLevel
 }
+
+export type CollectionHeadingProps = CollectionHeadingPropsInterface &
+  React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLHeadingElement>,
+    HTMLHeadingElement
+  >
+
 export const CollectionHeading = ({
   headingLevel,
   className,
   children,
   ...props
-}: CollectionHeadingProps &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLHeadingElement>,
-    HTMLHeadingElement
-  >): JSX.Element => {
+}: CollectionHeadingProps): JSX.Element => {
   const Heading = headingLevel
 
   const classes = classnames('usa-collection__heading', className)

--- a/src/components/Collection/CollectionItem.tsx
+++ b/src/components/Collection/CollectionItem.tsx
@@ -1,12 +1,9 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface CollectionItemPropsInterface {
+export type CollectionItemProps = {
   variantComponent?: React.ReactNode
-}
-
-export type CollectionItemProps = CollectionItemPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const CollectionItem = ({
   className,

--- a/src/components/Collection/CollectionItem.tsx
+++ b/src/components/Collection/CollectionItem.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface CollectionItemProps {
+interface CollectionItemPropsInterface {
   variantComponent?: React.ReactNode
 }
+
+export type CollectionItemProps = CollectionItemPropsInterface &
+  JSX.IntrinsicElements['li']
 
 export const CollectionItem = ({
   className,
   children,
   variantComponent,
   ...props
-}: CollectionItemProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: CollectionItemProps): JSX.Element => {
   const classes = classnames('usa-collection__item', className)
 
   return (

--- a/src/components/Collection/CollectionMeta.tsx
+++ b/src/components/Collection/CollectionMeta.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CollectionMetaProps = JSX.IntrinsicElements['ul']
+
 export const CollectionMeta = ({
   className,
   children,
   ...props
-}: JSX.IntrinsicElements['ul']): JSX.Element => {
+}: CollectionMetaProps): JSX.Element => {
   const classes = classnames('usa-collection__meta', className)
 
   return (

--- a/src/components/Collection/CollectionMetaItem.tsx
+++ b/src/components/Collection/CollectionMetaItem.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CollectionMetaItemProps = JSX.IntrinsicElements['li']
+
 export const CollectionMetaItem = ({
   className,
   children,
   ...props
-}: JSX.IntrinsicElements['li']): JSX.Element => {
+}: CollectionMetaItemProps): JSX.Element => {
   const classes = classnames('usa-collection__meta-item', className)
 
   return (

--- a/src/components/Collection/CollectionMetaItemTag.tsx
+++ b/src/components/Collection/CollectionMetaItemTag.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface CollectionMetaItemTagProps {
+interface CollectionMetaItemTagPropsInterface {
   tagStyle?: 'new' | 'default'
 }
+
+export type CollectionMetaItemTagProps = CollectionMetaItemTagPropsInterface &
+  JSX.IntrinsicElements['li']
 
 export const CollectionMetaItemTag = ({
   className,
   children,
   tagStyle,
   ...props
-}: CollectionMetaItemTagProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: CollectionMetaItemTagProps): JSX.Element => {
   const classes = classnames(
     'usa-collection__meta-item',
     'usa-tag',

--- a/src/components/Collection/CollectionMetaItemTag.tsx
+++ b/src/components/Collection/CollectionMetaItemTag.tsx
@@ -1,12 +1,9 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface CollectionMetaItemTagPropsInterface {
+export type CollectionMetaItemTagProps = {
   tagStyle?: 'new' | 'default'
-}
-
-export type CollectionMetaItemTagProps = CollectionMetaItemTagPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const CollectionMetaItemTag = ({
   className,

--- a/src/components/Collection/CollectionThumbnail.tsx
+++ b/src/components/Collection/CollectionThumbnail.tsx
@@ -1,12 +1,14 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CollectionThumbnailProps = JSX.IntrinsicElements['img']
+
 export const CollectionThumbnail = ({
   className,
   src,
   alt,
   ...props
-}: JSX.IntrinsicElements['img']): JSX.Element => {
+}: CollectionThumbnailProps): JSX.Element => {
   const classes = classnames('usa-collection__img', className)
 
   return <img className={classes} src={src} alt={alt} {...props} />

--- a/src/components/InPageNavigation/InPageNavigation.tsx
+++ b/src/components/InPageNavigation/InPageNavigation.tsx
@@ -4,7 +4,7 @@ import { HeadingLevel } from '../../types/headingLevel'
 import { Link } from '../Link/Link'
 import styles from './InPageNavigation.module.scss'
 
-type InPageNavigationProps = {
+export type InPageNavigationProps = {
   className?: string
   content: JSX.Element
   headingLevel?: HeadingLevel
@@ -14,7 +14,7 @@ type InPageNavigationProps = {
   scrollOffset?: string
   threshold?: number
   title?: string
-}
+} & Omit<JSX.IntrinsicElements['div'], 'content'>
 
 export const InPageNavigation = ({
   className,
@@ -27,8 +27,7 @@ export const InPageNavigation = ({
   threshold = 1,
   title = 'On this page',
   ...divProps
-}: InPageNavigationProps &
-  Omit<JSX.IntrinsicElements['div'], 'content'>): JSX.Element => {
+}: InPageNavigationProps): JSX.Element => {
   const asideClasses = classnames('usa-in-page-nav', styles.target, className)
   const { className: navClassName, ...remainingNavProps } = navProps || {}
   const navClasses = classnames('usa-in-page-nav__nav', navClassName)

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -16,7 +16,7 @@ export type LanguageSelectorProps = {
   small?: boolean
   className?: string
   displayLang?: string
-}
+} & JSX.IntrinsicElements['div']
 
 export const LanguageSelector = ({
   label,
@@ -25,7 +25,7 @@ export const LanguageSelector = ({
   className,
   displayLang,
   ...divProps
-}: LanguageSelectorProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: LanguageSelectorProps): JSX.Element => {
   const classes = classnames(
     'usa-language-container',
     {

--- a/src/components/LanguageSelector/LanguageSelectorButton.tsx
+++ b/src/components/LanguageSelector/LanguageSelectorButton.tsx
@@ -1,13 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type LanguageSelectorButtonProps = {
+export type LanguageSelectorButtonProps = {
   label: string
   labelAttr?: string
   isOpen?: boolean
   onToggle: () => void
   controls?: string
-}
+} & JSX.IntrinsicElements['button']
 
 export const LanguageSelectorButton = ({
   label,
@@ -17,8 +17,7 @@ export const LanguageSelectorButton = ({
   className,
   controls,
   ...buttonProps
-}: LanguageSelectorButtonProps &
-  JSX.IntrinsicElements['button']): JSX.Element => {
+}: LanguageSelectorButtonProps): JSX.Element => {
   const classes = classnames('usa-button', 'usa-language__link', className)
   const buttonContents = labelAttr ? (
     <span lang={labelAttr}>{label}</span>

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -10,12 +10,12 @@ type StyledLinkProps<T> = {
 } & T
 
 // These props are only required on the default Link
-interface WithDefaultLinkProps {
+type WithDefaultLinkProps = {
   href: string
 }
 
 // Add `asCustom` to the provided custom props
-interface WithCustomLinkProps<T> {
+type WithCustomLinkProps<T> = {
   asCustom: React.FunctionComponent<T>
 }
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -4,7 +4,7 @@ import { Icon } from '../Icon/Icons'
 import { Link } from '../Link/Link'
 import { Button } from '../Button/Button'
 
-type PaginationProps = {
+export type PaginationProps = {
   pathname: string // pathname of results page
   totalPages?: number // total items divided by items per page
   currentPage: number // current page number (starting at 1)
@@ -15,7 +15,7 @@ type PaginationProps = {
     event: React.MouseEvent<HTMLButtonElement>,
     page: number
   ) => void
-}
+} & JSX.IntrinsicElements['nav']
 
 const PaginationPage = ({
   page,
@@ -83,7 +83,7 @@ export const Pagination = ({
   onClickNext,
   onClickPageNumber,
   ...props
-}: PaginationProps & JSX.IntrinsicElements['nav']): JSX.Element => {
+}: PaginationProps): JSX.Element => {
   const navClasses = classnames('usa-pagination', className)
 
   const isOnFirstPage = currentPage === 1

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -1,14 +1,15 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type SideNavProps = {
+export type SideNavProps = {
   items: React.ReactNode[]
   isSubnav?: boolean
-}
+} & JSX.IntrinsicElements['ul']
 
 export const SideNav = ({
   items,
   isSubnav = false,
+  ...ulProps
 }: SideNavProps): JSX.Element => {
   const classes = classnames({
     'usa-sidenav': !isSubnav,
@@ -16,7 +17,7 @@ export const SideNav = ({
   })
 
   return (
-    <ul className={classes} data-testid="sidenav">
+    <ul className={classes} data-testid="sidenav" {...ulProps}>
       {items.map((item, i) => (
         <li key={`sidenav_item_${i}`} className="usa-sidenav__item">
           {item}

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 export type SideNavProps = {
   items: React.ReactNode[]
   isSubnav?: boolean
-} & JSX.IntrinsicElements['ul']
+}
 
 export const SideNav = ({
   items,

--- a/src/components/SiteAlert/SiteAlert.tsx
+++ b/src/components/SiteAlert/SiteAlert.tsx
@@ -1,14 +1,14 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type SiteAlertProps = {
+export type SiteAlertProps = {
   variant: 'info' | 'emergency'
   children: string | React.ReactNode | React.ReactNode[]
   heading?: string
   showIcon?: boolean
   slim?: boolean
   className?: string
-}
+} & JSX.IntrinsicElements['section']
 
 export const SiteAlert = ({
   variant,
@@ -18,7 +18,7 @@ export const SiteAlert = ({
   slim = false,
   className,
   ...sectionProps
-}: SiteAlertProps & JSX.IntrinsicElements['section']): JSX.Element => {
+}: SiteAlertProps): JSX.Element => {
   const classes = classnames(
     'usa-site-alert',
     {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -14,7 +14,7 @@ export type TableProps = {
   striped?: boolean
   compact?: boolean
   stackedStyle?: 'none' | 'default' | 'headers'
-} & JSX.IntrinsicElements['table']
+}
 
 export const Table = ({
   bordered,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 
 import styles from './Table.module.scss'
 
-type TableProps = {
+export type TableProps = {
   bordered?: boolean
   caption?: React.ReactNode
   children: React.ReactNode
@@ -14,7 +14,7 @@ type TableProps = {
   striped?: boolean
   compact?: boolean
   stackedStyle?: 'none' | 'default' | 'headers'
-}
+} & JSX.IntrinsicElements['table']
 
 export const Table = ({
   bordered,

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,17 +1,17 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type TagProps = {
+export type TagProps = {
   children: React.ReactNode
   background?: string
-}
+} & JSX.IntrinsicElements['span']
 
 export const Tag = ({
   children,
   background,
   className,
   ...spanProps
-}: TagProps & JSX.IntrinsicElements['span']): JSX.Element => {
+}: TagProps): JSX.Element => {
   const style: React.CSSProperties = {}
   if (background) {
     style.background = background

--- a/src/components/banner/Banner/Banner.tsx
+++ b/src/components/banner/Banner/Banner.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
-type BannerProps = {
+export type BannerProps = {
   divProps?: JSX.IntrinsicElements['div']
-}
+} & JSX.IntrinsicElements['section']
 
 export const Banner = ({
   children,
   divProps,
   className,
   ...sectionProps
-}: BannerProps & JSX.IntrinsicElements['section']): JSX.Element => {
+}: BannerProps): JSX.Element => {
   const classes = classNames('usa-banner', className)
 
   const { className: divClassName, ...remainingDivProps } = divProps || {}

--- a/src/components/banner/BannerButton/BannerButton.tsx
+++ b/src/components/banner/BannerButton/BannerButton.tsx
@@ -1,10 +1,10 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
-type BannerButtonProps = {
+export type BannerButtonProps = {
   isOpen: boolean
   spanProps?: JSX.IntrinsicElements['span']
-}
+} & JSX.IntrinsicElements['button']
 
 export const BannerButton = ({
   isOpen,
@@ -12,7 +12,7 @@ export const BannerButton = ({
   className,
   spanProps,
   ...buttonProps
-}: BannerButtonProps & JSX.IntrinsicElements['button']): JSX.Element => {
+}: BannerButtonProps): JSX.Element => {
   const classes = classNames(
     'usa-accordion__button usa-banner__button',
     className

--- a/src/components/banner/BannerContent/BannerContent.tsx
+++ b/src/components/banner/BannerContent/BannerContent.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
-type BannerContentProps = {
+export type BannerContentProps = {
   isOpen: boolean
-}
+} & JSX.IntrinsicElements['div']
 
 export const BannerContent = ({
   children,
   isOpen,
   className,
   ...divProps
-}: BannerContentProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: BannerContentProps): JSX.Element => {
   const classes = classNames(
     'usa-banner__content usa-accordion__content',
     className

--- a/src/components/banner/BannerFlag/BannerFlag.tsx
+++ b/src/components/banner/BannerFlag/BannerFlag.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
+export type BannerFlagProps = JSX.IntrinsicElements['img']
+
 export const BannerFlag = ({
   alt,
   className,
   ...imgProps
-}: JSX.IntrinsicElements['img']): JSX.Element => {
+}: BannerFlagProps): JSX.Element => {
   const classes = classNames('usa-banner__header-flag', className)
 
   return <img className={classes} alt={alt} {...imgProps} />

--- a/src/components/banner/BannerGuidance/BannerGuidance.tsx
+++ b/src/components/banner/BannerGuidance/BannerGuidance.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
+export type BannerGuidanceProps = JSX.IntrinsicElements['div']
+
 export const BannerGuidance = ({
   children,
   className,
   ...divProps
-}: JSX.IntrinsicElements['div']): JSX.Element => {
+}: BannerGuidanceProps): JSX.Element => {
   const divClasses = classNames('usa-banner__guidance', className)
 
   return (

--- a/src/components/banner/BannerHeader/BannerHeader.tsx
+++ b/src/components/banner/BannerHeader/BannerHeader.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, type JSX } from 'react'
 import classNames from 'classnames'
 
-type BannerHeaderProps = {
+export type BannerHeaderProps = {
   isOpen: boolean
   flagImg: ReactNode
   innerDivProps?: JSX.IntrinsicElements['div']
@@ -9,7 +9,7 @@ type BannerHeaderProps = {
   headerTextProps?: JSX.IntrinsicElements['p']
   headerActionText: ReactNode
   headerActionProps?: JSX.IntrinsicElements['p']
-}
+} & JSX.IntrinsicElements['header']
 
 export const BannerHeader = ({
   children,
@@ -22,7 +22,7 @@ export const BannerHeader = ({
   headerActionProps,
   className,
   ...headerProps
-}: BannerHeaderProps & JSX.IntrinsicElements['header']): JSX.Element => {
+}: BannerHeaderProps): JSX.Element => {
   const classes = classNames(
     'usa-banner__header',
     {

--- a/src/components/banner/BannerIcon/BannerIcon.tsx
+++ b/src/components/banner/BannerIcon/BannerIcon.tsx
@@ -1,12 +1,14 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
+export type BannerIconProps = JSX.IntrinsicElements['img']
+
 export const BannerIcon = ({
   src,
   alt,
   className,
   ...imgProps
-}: JSX.IntrinsicElements['img']): JSX.Element => {
+}: BannerIconProps): JSX.Element => {
   const classes = classNames('usa-banner__icon usa-media-block__img', className)
 
   return (

--- a/src/components/banner/GovBanner/GovBanner.tsx
+++ b/src/components/banner/GovBanner/GovBanner.tsx
@@ -107,17 +107,17 @@ const getCopy = (language: Language, tld: TLD): GovBannerCopy => {
   }
 }
 
-type GovBannerProps = {
+export type GovBannerProps = {
   tld?: TLD
   language?: Language
-}
+} & JSX.IntrinsicElements['section']
 
 export const GovBanner = ({
   tld = '.gov',
   language = 'english',
   className,
   ...sectionProps
-}: GovBannerProps & JSX.IntrinsicElements['section']): JSX.Element => {
+}: GovBannerProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false)
 
   const {

--- a/src/components/breadcrumb/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb/Breadcrumb.tsx
@@ -1,14 +1,11 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface BreadcrumbPropsInterface {
+export type BreadcrumbProps = {
   children: React.ReactNode
   className?: string
   current?: boolean
-}
-
-export type BreadcrumbProps = BreadcrumbPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const Breadcrumb = ({
   children,

--- a/src/components/breadcrumb/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb/Breadcrumb.tsx
@@ -1,18 +1,21 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface BreadcrumbProps {
+export interface BreadcrumbPropsInterface {
   children: React.ReactNode
   className?: string
   current?: boolean
 }
+
+export type BreadcrumbProps = BreadcrumbPropsInterface &
+  JSX.IntrinsicElements['li']
 
 export const Breadcrumb = ({
   children,
   current = false,
   className,
   ...listItemProps
-}: BreadcrumbProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: BreadcrumbProps): JSX.Element => {
   const classes = classnames(
     'usa-breadcrumb__list-item',
     {

--- a/src/components/breadcrumb/BreadcrumbBar/BreadcrumbBar.tsx
+++ b/src/components/breadcrumb/BreadcrumbBar/BreadcrumbBar.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, type JSX } from 'react'
 import classnames from 'classnames'
 import { BreadcrumbProps } from '../Breadcrumb/Breadcrumb'
 
-type BreadcrumbBarProps = {
+export type BreadcrumbBarProps = {
   children: ReactElement<BreadcrumbProps> | ReactElement<BreadcrumbProps>[]
   variant?: 'default' | 'wrap'
   className?: string

--- a/src/components/breadcrumb/BreadcrumbLink/BreadcrumbLink.tsx
+++ b/src/components/breadcrumb/BreadcrumbLink/BreadcrumbLink.tsx
@@ -7,6 +7,11 @@ import {
   Link,
 } from '../../Link/Link'
 
+export type {
+  DefaultLinkProps as DefaultBreadcrumbLinkProps,
+  CustomLinkProps as CustomBreadcrumbLinkProps,
+} from '../../Link/Link'
+
 export function BreadcrumbLink(props: DefaultLinkProps): JSX.Element
 export function BreadcrumbLink<T>(props: CustomLinkProps<T>): JSX.Element
 export function BreadcrumbLink<FCProps = DefaultLinkProps>({

--- a/src/components/card/Card/Card.tsx
+++ b/src/components/card/Card/Card.tsx
@@ -3,11 +3,12 @@ import classnames from 'classnames'
 
 import { GridLayoutProp, applyGridClasses } from '../../grid/Grid/Grid'
 
-type CardProps = {
+export type CardProps = {
   layout?: 'standardDefault' | 'flagDefault' | 'flagMediaRight'
   headerFirst?: boolean
   containerProps?: React.HTMLAttributes<HTMLDivElement>
-}
+} & JSX.IntrinsicElements['li'] &
+  GridLayoutProp
 
 export const Card = ({
   layout = 'standardDefault',
@@ -17,7 +18,7 @@ export const Card = ({
   gridLayout,
   containerProps,
   ...liProps
-}: CardProps & JSX.IntrinsicElements['li'] & GridLayoutProp): JSX.Element => {
+}: CardProps): JSX.Element => {
   const { className: containerClass, ...restContainerProps } =
     containerProps || {}
 

--- a/src/components/card/CardBody/CardBody.tsx
+++ b/src/components/card/CardBody/CardBody.tsx
@@ -1,16 +1,14 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export type CardBodyProps = JSX.IntrinsicElements['div']
+export type CardBodyProps = JSX.IntrinsicElements['div'] & { exdent?: boolean }
 
 export const CardBody = ({
   exdent,
   children,
   className,
   ...bodyProps
-}: {
-  exdent?: boolean
-} & CardBodyProps): JSX.Element => {
+}: CardBodyProps): JSX.Element => {
   const classes = classnames(
     'usa-card__body',
     {

--- a/src/components/card/CardBody/CardBody.tsx
+++ b/src/components/card/CardBody/CardBody.tsx
@@ -1,6 +1,8 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CardBodyProps = JSX.IntrinsicElements['div']
+
 export const CardBody = ({
   exdent,
   children,
@@ -8,7 +10,7 @@ export const CardBody = ({
   ...bodyProps
 }: {
   exdent?: boolean
-} & JSX.IntrinsicElements['div']): JSX.Element => {
+} & CardBodyProps): JSX.Element => {
   const classes = classnames(
     'usa-card__body',
     {

--- a/src/components/card/CardFooter/CardFooter.tsx
+++ b/src/components/card/CardFooter/CardFooter.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export type CardFooterProps = JSX.IntrinsicElements['div']
+export type CardFooterProps = JSX.IntrinsicElements['div'] & {
+  exdent?: boolean
+}
 
 export const CardFooter = ({
   exdent,
   children,
   className,
   ...footerProps
-}: {
-  exdent?: boolean
-} & CardFooterProps): JSX.Element => {
+}: CardFooterProps): JSX.Element => {
   const classes = classnames(
     'usa-card__footer',
     {

--- a/src/components/card/CardFooter/CardFooter.tsx
+++ b/src/components/card/CardFooter/CardFooter.tsx
@@ -1,6 +1,8 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CardFooterProps = JSX.IntrinsicElements['div']
+
 export const CardFooter = ({
   exdent,
   children,
@@ -8,7 +10,7 @@ export const CardFooter = ({
   ...footerProps
 }: {
   exdent?: boolean
-} & JSX.IntrinsicElements['div']): JSX.Element => {
+} & CardFooterProps): JSX.Element => {
   const classes = classnames(
     'usa-card__footer',
     {

--- a/src/components/card/CardGroup/CardGroup.tsx
+++ b/src/components/card/CardGroup/CardGroup.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CardGroupProps = JSX.IntrinsicElements['ul']
+
 export const CardGroup = ({
   children,
   className,
   ...ulProps
-}: JSX.IntrinsicElements['ul']): JSX.Element => {
+}: CardGroupProps): JSX.Element => {
   const classes = classnames('usa-card-group', className)
 
   return (

--- a/src/components/card/CardHeader/CardHeader.tsx
+++ b/src/components/card/CardHeader/CardHeader.tsx
@@ -1,6 +1,8 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type CardHeaderProps = JSX.IntrinsicElements['div']
+
 export const CardHeader = ({
   exdent,
   children,
@@ -8,7 +10,7 @@ export const CardHeader = ({
   ...headerProps
 }: {
   exdent?: boolean
-} & JSX.IntrinsicElements['div']): JSX.Element => {
+} & CardHeaderProps): JSX.Element => {
   const classes = classnames(
     'usa-card__header',
     {

--- a/src/components/card/CardHeader/CardHeader.tsx
+++ b/src/components/card/CardHeader/CardHeader.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export type CardHeaderProps = JSX.IntrinsicElements['div']
+export type CardHeaderProps = JSX.IntrinsicElements['div'] & {
+  exdent?: boolean
+}
 
 export const CardHeader = ({
   exdent,
   children,
   className,
   ...headerProps
-}: {
-  exdent?: boolean
-} & CardHeaderProps): JSX.Element => {
+}: CardHeaderProps): JSX.Element => {
   const classes = classnames(
     'usa-card__header',
     {

--- a/src/components/card/CardMedia/CardMedia.tsx
+++ b/src/components/card/CardMedia/CardMedia.tsx
@@ -1,15 +1,12 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface CardMediaPropsInterface {
+export type CardMediaProps = {
   exdent?: boolean
   inset?: boolean
   imageClass?: string
   children: React.ReactNode
-}
-
-export type CardMediaProps = CardMediaPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const CardMedia = ({
   exdent,

--- a/src/components/card/CardMedia/CardMedia.tsx
+++ b/src/components/card/CardMedia/CardMedia.tsx
@@ -1,12 +1,15 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface CardMediaProps {
+interface CardMediaPropsInterface {
   exdent?: boolean
   inset?: boolean
   imageClass?: string
   children: React.ReactNode
 }
+
+export type CardMediaProps = CardMediaPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const CardMedia = ({
   exdent,
@@ -15,7 +18,7 @@ export const CardMedia = ({
   children,
   className,
   ...mediaProps
-}: CardMediaProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: CardMediaProps): JSX.Element => {
   const classes = classnames(
     'usa-card__media',
     {

--- a/src/components/footer/Address/Address.tsx
+++ b/src/components/footer/Address/Address.tsx
@@ -1,19 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type AddressProps = {
+export type AddressProps = {
   size?: 'big' | 'medium' | 'slim'
   /*
      Contact info items - e.g. anchor tags or text for email, phone, website, etc.
    */
   items: React.ReactNode[]
-}
+} & React.HTMLAttributes<HTMLElement>
 
 export const Address = ({
   size,
   className,
   items,
-}: AddressProps & React.HTMLAttributes<HTMLElement>): JSX.Element => {
+}: AddressProps): JSX.Element => {
   const isBig = size === 'big'
   const isMedium = size === 'medium'
   const isSlim = size === 'slim'

--- a/src/components/footer/Footer/Footer.tsx
+++ b/src/components/footer/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type FooterProps = {
+export type FooterProps = {
   size?: 'big' | 'medium' | 'slim'
   /**
    * Component for "return to top" button/handling
@@ -15,7 +15,7 @@ type FooterProps = {
    * Content in lower footer section, e.g. contact information
    */
   secondary: React.ReactNode
-}
+} & React.HTMLAttributes<HTMLElement>
 
 export const Footer = ({
   size,
@@ -23,7 +23,7 @@ export const Footer = ({
   primary,
   secondary,
   ...footerAttributes
-}: FooterProps & React.HTMLAttributes<HTMLElement>): JSX.Element => {
+}: FooterProps): JSX.Element => {
   const classes = classnames(
     'usa-footer',
     {

--- a/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.tsx
+++ b/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.tsx
@@ -4,7 +4,7 @@ import { NavList } from '../../header/NavList/NavList'
 
 export type ExtendedNavLinksType = React.ReactNode[][]
 
-type FooterExtendedNavListProps = {
+export type FooterExtendedNavListProps = {
   isMobile?: boolean
   /* 
     Turn on mobile styles via prop. If undefined, a fallback is used based on the client window width.
@@ -13,14 +13,13 @@ type FooterExtendedNavListProps = {
     Multidimensional array of grouped nav links. Sub-arrays are column sections, first element is used as a heading.
   */
   nestedLinks: ExtendedNavLinksType
-}
+} & React.HTMLAttributes<HTMLElement>
 
 export const FooterExtendedNavList = ({
   className,
   isMobile,
   nestedLinks,
-}: FooterExtendedNavListProps &
-  React.HTMLAttributes<HTMLElement>): JSX.Element => {
+}: FooterExtendedNavListProps): JSX.Element => {
   const classes = classnames('grid-row grid-gap-4', className)
   const isClient = window && typeof window === 'object'
 

--- a/src/components/footer/FooterNav/FooterNav.tsx
+++ b/src/components/footer/FooterNav/FooterNav.tsx
@@ -11,7 +11,7 @@ function isExtendedNavLinks(
   return (links as ExtendedNavLinksType)[0].constructor === Array
 }
 
-type FooterNavProps = {
+export type FooterNavProps = {
   size?: 'big' | 'medium' | 'slim'
   isMobile?: boolean
   /*
@@ -19,7 +19,7 @@ type FooterNavProps = {
      FooterExtendedNavList can only be used with multidimensional array (ExtendedNavLinksType) and size="big" prop.
    */
   links: React.ReactNode[] | ExtendedNavLinksType
-}
+} & React.HTMLAttributes<HTMLElement>
 
 export const FooterNav = ({
   className,
@@ -27,7 +27,7 @@ export const FooterNav = ({
   isMobile,
   links,
   ...elementAttributes
-}: FooterNavProps & React.HTMLAttributes<HTMLElement>): JSX.Element => {
+}: FooterNavProps): JSX.Element => {
   const isBig = size === 'big'
   const isMedium = size === 'medium'
   const isSlim = size === 'slim'

--- a/src/components/footer/Logo/Logo.tsx
+++ b/src/components/footer/Logo/Logo.tsx
@@ -5,13 +5,13 @@ export type LogoProps = {
   size?: 'big' | 'medium' | 'slim'
   heading?: React.ReactNode
   image: React.ReactNode
-} & React.HtmlHTMLAttributes<HTMLElement>
-
+  className?: string
+}
 export const Logo = ({
   size,
   heading,
   image,
-  ...elementAttributes
+  className,
 }: LogoProps): JSX.Element => {
   const isBig = size === 'big'
   const isMedium = size === 'medium'
@@ -23,7 +23,7 @@ export const Logo = ({
       'mobile-lg:grid-col-6 mobile-lg:grid-gap-2': isBig || isMedium,
       'grid-gap-2': isSlim,
     },
-    elementAttributes.className
+    className
   )
 
   const columnClasses = classnames({

--- a/src/components/footer/Logo/Logo.tsx
+++ b/src/components/footer/Logo/Logo.tsx
@@ -1,18 +1,18 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type LogoProps = {
+export type LogoProps = {
   size?: 'big' | 'medium' | 'slim'
   heading?: React.ReactNode
   image: React.ReactNode
-}
+} & React.HtmlHTMLAttributes<HTMLElement>
 
 export const Logo = ({
   size,
   heading,
   image,
   ...elementAttributes
-}: LogoProps & React.HtmlHTMLAttributes<HTMLElement>): JSX.Element => {
+}: LogoProps): JSX.Element => {
   const isBig = size === 'big'
   const isMedium = size === 'medium'
   const isSlim = size === 'slim'

--- a/src/components/footer/SocialLinks/SocialLinks.tsx
+++ b/src/components/footer/SocialLinks/SocialLinks.tsx
@@ -3,18 +3,18 @@ import classnames from 'classnames'
 import { Icon } from '../../Icon/Icons'
 import { IconProps } from '../../Icon/Icon'
 
-type SocialLinksProps = {
+export type SocialLinksProps = {
   links: React.ReactNode[]
-}
+} & JSX.IntrinsicElements['div']
 
-type SocialLinkProps = {
+export type SocialLinkProps = {
   name: 'Facebook' | 'Twitter' | 'YouTube' | 'Instagram' | 'RSS'
-}
+} & JSX.IntrinsicElements['a']
 
 export const SocialLinks = ({
   className,
   links,
-}: SocialLinksProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: SocialLinksProps): JSX.Element => {
   const classes = classnames(
     'usa-footer__social-links grid-row grid-gap-1',
     className
@@ -33,7 +33,7 @@ export const SocialLinks = ({
 export const SocialLink = ({
   name,
   ...props
-}: SocialLinkProps & JSX.IntrinsicElements['a']): JSX.Element => {
+}: SocialLinkProps): JSX.Element => {
   let IconComponent: React.ComponentType<IconProps>
   switch (name) {
     case 'Facebook':

--- a/src/components/forms/Checkbox/Checkbox.tsx
+++ b/src/components/forms/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { LegacyInputRef } from '../../../types/legacyInputRef'
 
-type CheckboxProps = {
+export type CheckboxProps = {
   id: string
   name: string
   className?: string
@@ -10,7 +10,7 @@ type CheckboxProps = {
   inputRef?: LegacyInputRef
   tile?: boolean
   labelDescription?: React.ReactNode
-}
+} & JSX.IntrinsicElements['input']
 
 export const Checkbox = ({
   id,
@@ -21,7 +21,7 @@ export const Checkbox = ({
   tile,
   labelDescription,
   ...inputProps
-}: CheckboxProps & JSX.IntrinsicElements['input']): JSX.Element => {
+}: CheckboxProps): JSX.Element => {
   const classes = classnames('usa-checkbox', className)
   const checkboxClasses = classnames('usa-checkbox__input', {
     'usa-checkbox__input--tile': tile,

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -41,7 +41,7 @@ export interface CustomizableFilter {
   extras?: Record<string, string>
 }
 
-type ComboBoxProps = {
+export type ComboBoxProps = {
   id: string
   name: string
   className?: string

--- a/src/components/forms/DateInput/DateInput.tsx
+++ b/src/components/forms/DateInput/DateInput.tsx
@@ -5,14 +5,14 @@ import { TextInput, OptionalTextInputProps } from '../TextInput/TextInput'
 import { Label } from '../Label/Label'
 import { FormGroup } from '../FormGroup/FormGroup'
 
-type DateInputElementProps = {
+export type DateInputProps = {
   id: string
   name: string
   label: string
   unit: 'month' | 'day' | 'year'
   maxLength: number
   minLength?: number
-}
+} & OptionalTextInputProps
 
 export const DateInput = ({
   id,
@@ -23,7 +23,7 @@ export const DateInput = ({
   minLength,
   className,
   ...inputProps
-}: DateInputElementProps & OptionalTextInputProps): JSX.Element => {
+}: DateInputProps): JSX.Element => {
   const formGroupClasses = classnames({
     'usa-form-group--month': unit == 'month',
     'usa-form-group--day': unit == 'day',

--- a/src/components/forms/DateInputGroup/DateInputGroup.tsx
+++ b/src/components/forms/DateInputGroup/DateInputGroup.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type DateInputGroupProps = JSX.IntrinsicElements['div']
+
 export const DateInputGroup = ({
   children,
   className,
   ...divAttributes
-}: JSX.IntrinsicElements['div']): JSX.Element => {
+}: DateInputGroupProps): JSX.Element => {
   const classes = classnames('usa-memorable-date', className)
 
   return (

--- a/src/components/forms/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.tsx
@@ -6,7 +6,7 @@ import { formatDate, parseDateString } from '../DatePicker/utils'
 import { FormGroup } from '../FormGroup/FormGroup'
 import { Label } from '../Label/Label'
 
-type DateRangePickerProps = {
+export type DateRangePickerProps = {
   startDateLabel?: string
   startDateHint?: string
   startDatePickerProps: Omit<DatePickerProps, 'rangeDate'>
@@ -14,11 +14,9 @@ type DateRangePickerProps = {
   endDateHint?: string
   endDatePickerProps: Omit<DatePickerProps, 'rangeDate'>
   className?: string
-}
+} & JSX.IntrinsicElements['div']
 
-export const DateRangePicker = (
-  props: DateRangePickerProps & JSX.IntrinsicElements['div']
-): JSX.Element => {
+export const DateRangePicker = (props: DateRangePickerProps): JSX.Element => {
   const {
     startDateLabel,
     startDateHint,

--- a/src/components/forms/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/forms/DateRangePicker/DateRangePicker.tsx
@@ -14,7 +14,7 @@ export type DateRangePickerProps = {
   endDateHint?: string
   endDatePickerProps: Omit<DatePickerProps, 'rangeDate'>
   className?: string
-} & JSX.IntrinsicElements['div']
+}
 
 export const DateRangePicker = (props: DateRangePickerProps): JSX.Element => {
   const {

--- a/src/components/forms/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/forms/ErrorMessage/ErrorMessage.tsx
@@ -1,11 +1,11 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type ErrorMessageProps = {
+export type ErrorMessageProps = {
   children: React.ReactNode
   id?: string
   className?: string
-}
+} & JSX.IntrinsicElements['span']
 
 export const ErrorMessage = ({
   children,

--- a/src/components/forms/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/forms/ErrorMessage/ErrorMessage.tsx
@@ -5,7 +5,7 @@ export type ErrorMessageProps = {
   children: React.ReactNode
   id?: string
   className?: string
-} & JSX.IntrinsicElements['span']
+}
 
 export const ErrorMessage = ({
   children,

--- a/src/components/forms/Fieldset/Fieldset.tsx
+++ b/src/components/forms/Fieldset/Fieldset.tsx
@@ -2,13 +2,13 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { RequiredMarker } from '../Label/RequiredMarker'
 
-type FieldsetProps = {
+export type FieldsetProps = {
   children: React.ReactNode
   legend?: React.ReactNode
   legendStyle?: 'default' | 'large' | 'srOnly'
   className?: string
   requiredMarker?: boolean
-}
+} & JSX.IntrinsicElements['fieldset']
 
 export const Fieldset = ({
   children,
@@ -17,7 +17,7 @@ export const Fieldset = ({
   legendStyle = 'default',
   requiredMarker,
   ...fieldsetProps
-}: FieldsetProps & JSX.IntrinsicElements['fieldset']): JSX.Element => {
+}: FieldsetProps): JSX.Element => {
   const classes = classnames('usa-fieldset', className)
 
   const legendClasses = classnames({

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -11,7 +11,7 @@ import classnames from 'classnames'
 import { FilePreview } from './FilePreview'
 import { makeSafeForID } from './utils'
 
-type FileInputProps = {
+export type FileInputProps = {
   id: string
   name: string
   dragText?: string
@@ -22,7 +22,7 @@ type FileInputProps = {
   accept?: string
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   onDrop?: (e: React.DragEvent) => void
-}
+} & JSX.IntrinsicElements['input']
 
 export type FileInputRef = {
   clearFiles: () => void
@@ -32,7 +32,7 @@ export type FileInputRef = {
 
 export const FileInputForwardRef: React.ForwardRefRenderFunction<
   FileInputRef,
-  FileInputProps & JSX.IntrinsicElements['input']
+  FileInputProps
 > = (
   {
     name,

--- a/src/components/forms/Form/Form.tsx
+++ b/src/components/forms/Form/Form.tsx
@@ -14,7 +14,7 @@ type CustomFormProps = {
 
 export type OptionalFormProps = CustomFormProps & JSX.IntrinsicElements['form']
 
-type FormProps = RequiredFormProps & OptionalFormProps
+export type FormProps = RequiredFormProps & OptionalFormProps
 
 export const Form = ({
   onSubmit,

--- a/src/components/forms/FormGroup/FormGroup.tsx
+++ b/src/components/forms/FormGroup/FormGroup.tsx
@@ -5,7 +5,7 @@ export type FormGroupProps = {
   children: React.ReactNode
   className?: string
   error?: boolean
-} & JSX.IntrinsicElements['div']
+}
 
 export const FormGroup = ({
   children,

--- a/src/components/forms/FormGroup/FormGroup.tsx
+++ b/src/components/forms/FormGroup/FormGroup.tsx
@@ -1,11 +1,11 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type FormGroupProps = {
+export type FormGroupProps = {
   children: React.ReactNode
   className?: string
   error?: boolean
-}
+} & JSX.IntrinsicElements['div']
 
 export const FormGroup = ({
   children,

--- a/src/components/forms/InputPrefix/InputPrefix.tsx
+++ b/src/components/forms/InputPrefix/InputPrefix.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type InputPrefixProps = {
+export type InputPrefixProps = {
   className?: string
   children: React.ReactNode
 } & JSX.IntrinsicElements['div']

--- a/src/components/forms/InputSuffix/InputSuffix.tsx
+++ b/src/components/forms/InputSuffix/InputSuffix.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type InputSuffixProps = {
+export type InputSuffixProps = {
   className?: string
   children: React.ReactNode
 } & JSX.IntrinsicElements['div']

--- a/src/components/forms/Label/Label.tsx
+++ b/src/components/forms/Label/Label.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { RequiredMarker } from './RequiredMarker'
 
-type LabelProps = {
+export type LabelProps = {
   children: React.ReactNode
   htmlFor: string
   className?: string
@@ -10,7 +10,7 @@ type LabelProps = {
   hint?: React.ReactNode
   srOnly?: boolean
   requiredMarker?: boolean
-}
+} & JSX.IntrinsicElements['label']
 
 export const Label = ({
   children,
@@ -21,7 +21,7 @@ export const Label = ({
   srOnly,
   requiredMarker,
   ...labelProps
-}: LabelProps & JSX.IntrinsicElements['label']): JSX.Element => {
+}: LabelProps): JSX.Element => {
   const classes = classnames(
     {
       'usa-label': !srOnly,

--- a/src/components/forms/Label/RequiredMarker.tsx
+++ b/src/components/forms/Label/RequiredMarker.tsx
@@ -1,7 +1,5 @@
 import React, { type JSX } from 'react'
 
-export type RequiredMarkerProps = JSX.IntrinsicElements['abbr']
-
 export const RequiredMarker = (): JSX.Element => {
   return (
     <abbr title="required" className="usa-hint usa-hint--required">

--- a/src/components/forms/Label/RequiredMarker.tsx
+++ b/src/components/forms/Label/RequiredMarker.tsx
@@ -1,5 +1,7 @@
 import React, { type JSX } from 'react'
 
+export type RequiredMarkerProps = JSX.IntrinsicElements['abbr']
+
 export const RequiredMarker = (): JSX.Element => {
   return (
     <abbr title="required" className="usa-hint usa-hint--required">

--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { LegacyInputRef } from '../../../types/legacyInputRef'
 
-type RadioProps = {
+export type RadioProps = {
   id: string
   name: string
   className?: string
@@ -10,7 +10,7 @@ type RadioProps = {
   inputRef?: LegacyInputRef
   tile?: boolean
   labelDescription?: React.ReactNode
-}
+} & JSX.IntrinsicElements['input']
 
 export const Radio = ({
   id,
@@ -21,7 +21,7 @@ export const Radio = ({
   tile,
   labelDescription,
   ...inputProps
-}: RadioProps & JSX.IntrinsicElements['input']): JSX.Element => {
+}: RadioProps): JSX.Element => {
   const classes = classnames('usa-radio', className)
   const radioClasses = classnames('usa-radio__input', {
     'usa-radio__input--tile': tile,

--- a/src/components/forms/RangeInput/RangeInput.tsx
+++ b/src/components/forms/RangeInput/RangeInput.tsx
@@ -2,7 +2,7 @@ import React, { useState, type JSX } from 'react'
 import classnames from 'classnames'
 import { LegacyInputRef } from '../../../types/legacyInputRef'
 
-type RangeInputProps = {
+export type RangeInputProps = {
   id: string
   name: string
   min?: number
@@ -10,7 +10,7 @@ type RangeInputProps = {
   textPreposition?: string
   textUnit?: string
   inputRef?: LegacyInputRef
-}
+} & JSX.IntrinsicElements['input']
 
 export const RangeInput = ({
   className,
@@ -18,7 +18,7 @@ export const RangeInput = ({
   textPreposition,
   textUnit,
   ...inputProps
-}: RangeInputProps & JSX.IntrinsicElements['input']): JSX.Element => {
+}: RangeInputProps): JSX.Element => {
   const classes = classnames('usa-range', className)
   // input range defaults to min = 0, max = 100, step = 1, and value = (max/2) if not specified.
   const defaultMin = 0

--- a/src/components/forms/Select/Select.tsx
+++ b/src/components/forms/Select/Select.tsx
@@ -3,14 +3,14 @@ import classnames from 'classnames'
 import { ValidationStatus } from '../../../types/validationStatus'
 import { LegacyInputRef } from '../../../types/legacyInputRef'
 
-type SelectProps = {
+export type SelectProps = {
   id: string
   name: string
   className?: string
   children: React.ReactNode
   validationStatus?: ValidationStatus
   inputRef?: LegacyInputRef<HTMLSelectElement>
-}
+} & JSX.IntrinsicElements['select']
 
 export const Select = ({
   id,
@@ -20,7 +20,7 @@ export const Select = ({
   children,
   validationStatus,
   ...inputProps
-}: SelectProps & JSX.IntrinsicElements['select']): JSX.Element => {
+}: SelectProps): JSX.Element => {
   const isError = validationStatus === 'error'
   const isSuccess = validationStatus === 'success'
   const classes = classnames(

--- a/src/components/forms/TextInputMask/TextInputMask.tsx
+++ b/src/components/forms/TextInputMask/TextInputMask.tsx
@@ -3,7 +3,7 @@ import React, { type JSX, useEffect, useState } from 'react'
 import classnames from 'classnames'
 import { TextInput, TextInputProps } from '../TextInput/TextInput'
 
-export type AllProps = TextInputProps & {
+export type TextInputMaskProps = TextInputProps & {
   mask: string
   charset?: string
 }
@@ -49,7 +49,7 @@ export const TextInputMask = ({
   charset,
   onChange,
   ...inputProps
-}: AllProps): JSX.Element => {
+}: TextInputMaskProps): JSX.Element => {
   const classes = classnames(
     {
       'usa-masked': mask,

--- a/src/components/forms/TextInputMask/TextInputMask.tsx
+++ b/src/components/forms/TextInputMask/TextInputMask.tsx
@@ -6,7 +6,7 @@ import { TextInput, TextInputProps } from '../TextInput/TextInput'
 export type TextInputMaskProps = TextInputProps & {
   mask: string
   charset?: string
-}
+} & JSX.IntrinsicElements['input']
 
 function maskString(value: string, mask: string, charset?: string) {
   const maskData = charset || mask

--- a/src/components/forms/Textarea/Textarea.tsx
+++ b/src/components/forms/Textarea/Textarea.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { LegacyInputRef } from '../../../types/legacyInputRef'
 
-export interface TextareaPropsInterface {
+export type TextareaProps = {
   id: string
   name: string
   className?: string
@@ -10,10 +10,7 @@ export interface TextareaPropsInterface {
   success?: boolean
   children?: React.ReactNode
   inputRef?: LegacyInputRef<HTMLTextAreaElement>
-}
-
-export type TextareaProps = TextareaPropsInterface &
-  JSX.IntrinsicElements['textarea']
+} & JSX.IntrinsicElements['textarea']
 
 export const Textarea = ({
   id,

--- a/src/components/forms/Textarea/Textarea.tsx
+++ b/src/components/forms/Textarea/Textarea.tsx
@@ -2,7 +2,7 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { LegacyInputRef } from '../../../types/legacyInputRef'
 
-export interface TextareaProps {
+export interface TextareaPropsInterface {
   id: string
   name: string
   className?: string
@@ -11,6 +11,9 @@ export interface TextareaProps {
   children?: React.ReactNode
   inputRef?: LegacyInputRef<HTMLTextAreaElement>
 }
+
+export type TextareaProps = TextareaPropsInterface &
+  JSX.IntrinsicElements['textarea']
 
 export const Textarea = ({
   id,
@@ -21,7 +24,7 @@ export const Textarea = ({
   children,
   inputRef,
   ...inputProps
-}: TextareaProps & JSX.IntrinsicElements['textarea']): JSX.Element => {
+}: TextareaProps): JSX.Element => {
   const classes = classnames(
     'usa-textarea',
     {

--- a/src/components/forms/TimePicker/TimePicker.tsx
+++ b/src/components/forms/TimePicker/TimePicker.tsx
@@ -28,7 +28,7 @@ type BaseTimePickerProps = {
   className?: string
 }
 
-type TimePickerProps = BaseTimePickerProps &
+export type TimePickerProps = BaseTimePickerProps &
   Omit<JSX.IntrinsicElements['input'], 'onChange'>
 
 export const TimePicker = ({

--- a/src/components/forms/Validation/ValidationChecklist.tsx
+++ b/src/components/forms/Validation/ValidationChecklist.tsx
@@ -1,10 +1,7 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export type ValidationChecklistProps = {
-  id: string
-  children: React.ReactNode
-} & JSX.IntrinsicElements['ul']
+export type ValidationChecklistProps = JSX.IntrinsicElements['ul']
 
 export const ValidationChecklist = ({
   children,

--- a/src/components/forms/Validation/ValidationChecklist.tsx
+++ b/src/components/forms/Validation/ValidationChecklist.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type ValidationChecklistProps = {
+export type ValidationChecklistProps = {
   id: string
   children: React.ReactNode
-}
+} & JSX.IntrinsicElements['ul']
 
 export const ValidationChecklist = ({
   children,
   className,
   ...ulProps
-}: ValidationChecklistProps & JSX.IntrinsicElements['ul']): JSX.Element => {
+}: ValidationChecklistProps): JSX.Element => {
   const classes = classnames(className, 'usa-checklist')
   return (
     <ul className={classes} data-testid="validationChecklist" {...ulProps}>

--- a/src/components/forms/Validation/ValidationItem.tsx
+++ b/src/components/forms/Validation/ValidationItem.tsx
@@ -1,18 +1,18 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type ValidationItemProps = {
+export type ValidationItemProps = {
   children: React.ReactNode
   id: string
   isValid: boolean
-}
+} & JSX.IntrinsicElements['li']
 
 export const ValidationItem = ({
   children,
   className,
   isValid,
   ...liProps
-}: ValidationItemProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: ValidationItemProps): JSX.Element => {
   const classes = classnames(
     'usa-checklist__item',
     { 'usa-checklist__item--checked': isValid },

--- a/src/components/grid/GridContainer/GridContainer.tsx
+++ b/src/components/grid/GridContainer/GridContainer.tsx
@@ -3,19 +3,21 @@ import classnames from 'classnames'
 
 import { ContainerSizes } from '../types'
 
-type GridContainerProps = {
+type GridContainerProps<T> = {
   containerSize?: ContainerSizes
   className?: string
   children: React.ReactNode
-}
+} & T
 
 interface WithCustomGridContainerProps<T> {
   asCustom: React.FunctionComponent<T>
 }
 
-export type DefaultGridContainerProps = GridContainerProps
+export type DefaultGridContainerProps = GridContainerProps<
+  JSX.IntrinsicElements['div']
+>
 
-export type CustomGridContainerProps<T> = GridContainerProps &
+export type CustomGridContainerProps<T> = GridContainerProps<T> &
   WithCustomGridContainerProps<T>
 
 export function isCustomProps<T>(
@@ -25,8 +27,8 @@ export function isCustomProps<T>(
 }
 
 function gridContainerClasses(
-  className: GridContainerProps['className'],
-  containerSize: GridContainerProps['containerSize']
+  className: DefaultGridContainerProps['className'],
+  containerSize: DefaultGridContainerProps['containerSize']
 ): string | undefined {
   const classes = classnames(
     {

--- a/src/components/header/ExtendedNav/ExtendedNav.tsx
+++ b/src/components/header/ExtendedNav/ExtendedNav.tsx
@@ -4,14 +4,14 @@ import classnames from 'classnames'
 import { NavCloseButton } from '../NavCloseButton/NavCloseButton'
 import { NavList } from '../NavList/NavList'
 
-type ExtendedNavProps = {
+export type ExtendedNavProps = {
   primaryItems: React.ReactNode[]
   secondaryItems: React.ReactNode[]
   onToggleMobileNav?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => void
   mobileExpanded?: boolean
-}
+} & JSX.IntrinsicElements['nav']
 
 export const ExtendedNav = ({
   primaryItems,
@@ -21,7 +21,7 @@ export const ExtendedNav = ({
   className,
   onToggleMobileNav,
   ...navProps
-}: ExtendedNavProps & JSX.IntrinsicElements['nav']): JSX.Element => {
+}: ExtendedNavProps): JSX.Element => {
   const classes = classnames(
     'usa-nav',
     {

--- a/src/components/header/Header/Header.tsx
+++ b/src/components/header/Header/Header.tsx
@@ -1,13 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type HeaderProps = {
+export type HeaderProps = {
   basic?: boolean
   extended?: boolean
   basicWithMegaMenu?: boolean
   children: React.ReactNode
   showMobileOverlay?: boolean
-}
+} & JSX.IntrinsicElements['header']
 
 export const Header = ({
   basic,
@@ -17,7 +17,7 @@ export const Header = ({
   showMobileOverlay,
   className,
   ...headerProps
-}: HeaderProps & JSX.IntrinsicElements['header']): JSX.Element => {
+}: HeaderProps): JSX.Element => {
   const classes = classnames(
     'usa-header',
     {

--- a/src/components/header/MegaMenu/MegaMenu.tsx
+++ b/src/components/header/MegaMenu/MegaMenu.tsx
@@ -3,17 +3,17 @@ import classnames from 'classnames'
 
 import { NavList, NavListProps } from '../NavList/NavList'
 
-type MegaMenuProps = {
+export type MegaMenuProps = {
   items: React.ReactNode[][]
   isOpen: boolean
-}
+} & NavListProps
 
 export const MegaMenu = ({
   items,
   isOpen,
   className,
   ...navListProps
-}: MegaMenuProps & NavListProps): JSX.Element => {
+}: MegaMenuProps): JSX.Element => {
   const classes = classnames('usa-nav__submenu usa-megamenu', className)
 
   return (

--- a/src/components/header/Menu/Menu.tsx
+++ b/src/components/header/Menu/Menu.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX } from 'react'
 import { NavList, NavListProps } from '../NavList/NavList'
 
-type MenuProps = {
+export type MenuProps = {
   items: React.ReactNode[]
   isOpen: boolean
   type?:
@@ -11,7 +11,7 @@ type MenuProps = {
     | 'megamenu'
     | 'footerSecondary'
     | 'language'
-}
+} & NavListProps
 
 export const Menu = ({
   className,
@@ -19,7 +19,7 @@ export const Menu = ({
   isOpen,
   type,
   ...navListProps
-}: MenuProps & NavListProps): JSX.Element => {
+}: MenuProps): JSX.Element => {
   return (
     <NavList
       className={className}

--- a/src/components/header/NavCloseButton/NavCloseButton.tsx
+++ b/src/components/header/NavCloseButton/NavCloseButton.tsx
@@ -3,11 +3,13 @@ import classnames from 'classnames'
 // assets
 import { Icon } from '../../Icon/Icons'
 
+export type NavCloseButtonProps = JSX.IntrinsicElements['button']
+
 export const NavCloseButton = ({
   onClick,
   className,
   ...buttonProps
-}: JSX.IntrinsicElements['button']): JSX.Element => {
+}: NavCloseButtonProps): JSX.Element => {
   const classes = classnames('usa-nav__close', className)
 
   return (

--- a/src/components/header/NavDropDownButton/NavDropDownButton.tsx
+++ b/src/components/header/NavDropDownButton/NavDropDownButton.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type NavDropDownButtonProps = {
+export type NavDropDownButtonProps = {
   label: string
   /*
     Element (i.e. menu) id already present in DOM that will be controlled by this button
@@ -10,7 +10,7 @@ type NavDropDownButtonProps = {
   isOpen: boolean
   onToggle: () => void
   isCurrent?: boolean
-}
+} & JSX.IntrinsicElements['button']
 
 export const NavDropDownButton = ({
   label,
@@ -20,7 +20,7 @@ export const NavDropDownButton = ({
   isCurrent,
   className,
   ...buttonProps
-}: NavDropDownButtonProps & JSX.IntrinsicElements['button']): JSX.Element => {
+}: NavDropDownButtonProps): JSX.Element => {
   const classes = classnames(
     'usa-accordion__button',
     'usa-nav__link',

--- a/src/components/header/NavMenuButton/NavMenuButton.tsx
+++ b/src/components/header/NavMenuButton/NavMenuButton.tsx
@@ -1,14 +1,14 @@
 import React, { type JSX } from 'react'
 
-type NavMenuButtonProps = {
+export type NavMenuButtonProps = {
   label: React.ReactNode
-}
+} & JSX.IntrinsicElements['button']
 
 export const NavMenuButton = ({
   label,
   onClick,
   ...buttonProps
-}: NavMenuButtonProps & JSX.IntrinsicElements['button']): JSX.Element => {
+}: NavMenuButtonProps): JSX.Element => {
   return (
     <button
       className="usa-menu-btn"

--- a/src/components/header/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.tsx
@@ -4,13 +4,13 @@ import classnames from 'classnames'
 import { NavCloseButton } from '../NavCloseButton/NavCloseButton'
 import { NavList } from '../NavList/NavList'
 
-type PrimaryNavProps = {
+export type PrimaryNavProps = {
   items: React.ReactNode[]
   onToggleMobileNav?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => void
   mobileExpanded?: boolean
-}
+} & JSX.IntrinsicElements['nav']
 
 export const PrimaryNav = ({
   items,
@@ -19,7 +19,7 @@ export const PrimaryNav = ({
   children,
   className,
   ...navProps
-}: PrimaryNavProps & JSX.IntrinsicElements['nav']): JSX.Element => {
+}: PrimaryNavProps): JSX.Element => {
   const classes = classnames(
     'usa-nav',
     {

--- a/src/components/header/Title/Title.tsx
+++ b/src/components/header/Title/Title.tsx
@@ -9,7 +9,7 @@ export const Title = ({
   className,
   children,
   ...divProps
-}: TitleProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: TitleProps): JSX.Element => {
   const classes = classnames('usa-logo', className)
 
   return (

--- a/src/components/header/Title/Title.tsx
+++ b/src/components/header/Title/Title.tsx
@@ -1,9 +1,9 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type TitleProps = {
+export type TitleProps = {
   children: React.ReactNode
-}
+} & JSX.IntrinsicElements['div']
 
 export const Title = ({
   className,

--- a/src/components/iconlist/IconList.tsx
+++ b/src/components/iconlist/IconList.tsx
@@ -1,12 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IconListPropsInterface {
+export type IconListProps = {
   children: React.ReactNode
   className?: string
-}
-
-export type IconListProps = IconListPropsInterface & JSX.IntrinsicElements['ul']
+} & JSX.IntrinsicElements['ul']
 
 export const IconList = ({
   children,

--- a/src/components/iconlist/IconList.tsx
+++ b/src/components/iconlist/IconList.tsx
@@ -1,15 +1,17 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IconListProps {
+interface IconListPropsInterface {
   children: React.ReactNode
   className?: string
 }
 
+export type IconListProps = IconListPropsInterface & JSX.IntrinsicElements['ul']
+
 export const IconList = ({
   children,
   className,
-}: IconListProps & JSX.IntrinsicElements['ul']): JSX.Element => {
+}: IconListProps): JSX.Element => {
   const classes = classnames(className, 'usa-icon-list')
 
   return (

--- a/src/components/iconlist/IconListContent/IconListContent.tsx
+++ b/src/components/iconlist/IconListContent/IconListContent.tsx
@@ -1,16 +1,19 @@
 import classnames from 'classnames'
 import React, { ReactNode, type JSX } from 'react'
 
-interface IconListContentProps {
+interface IconListContentPropsInterface {
   className?: string
   children?: ReactNode
 }
+
+export type IconListContentProps = IconListContentPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const IconListContent = ({
   className,
   children,
   ...divProps
-}: IconListContentProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: IconListContentProps): JSX.Element => {
   const classes = classnames(className, 'usa-icon-list__content')
 
   return (

--- a/src/components/iconlist/IconListContent/IconListContent.tsx
+++ b/src/components/iconlist/IconListContent/IconListContent.tsx
@@ -1,13 +1,10 @@
 import classnames from 'classnames'
 import React, { ReactNode, type JSX } from 'react'
 
-interface IconListContentPropsInterface {
+export type IconListContentProps = {
   className?: string
   children?: ReactNode
-}
-
-export type IconListContentProps = IconListContentPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const IconListContent = ({
   className,

--- a/src/components/iconlist/IconListIcon/IconListIcon.tsx
+++ b/src/components/iconlist/IconListIcon/IconListIcon.tsx
@@ -1,16 +1,19 @@
 import classnames from 'classnames'
 import React, { ReactNode, type JSX } from 'react'
 
-interface IconListIconProps {
+interface IconListIconPropsInterface {
   className?: string
   children: ReactNode
 }
+
+export type IconListIconProps = IconListIconPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const IconListIcon = ({
   className,
   children,
   ...divProps
-}: IconListIconProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: IconListIconProps): JSX.Element => {
   const classes = classnames(className, 'usa-icon-list__icon')
 
   return (

--- a/src/components/iconlist/IconListIcon/IconListIcon.tsx
+++ b/src/components/iconlist/IconListIcon/IconListIcon.tsx
@@ -1,13 +1,10 @@
 import classnames from 'classnames'
 import React, { ReactNode, type JSX } from 'react'
 
-interface IconListIconPropsInterface {
+export type IconListIconProps = {
   className?: string
   children: ReactNode
-}
-
-export type IconListIconProps = IconListIconPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const IconListIcon = ({
   className,

--- a/src/components/iconlist/IconListItem/IconListItem.tsx
+++ b/src/components/iconlist/IconListItem/IconListItem.tsx
@@ -1,13 +1,10 @@
 import React, { ReactNode, type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IconListItemPropsInterface {
+export type IconListItemProps = {
   className?: string
   children: ReactNode
-}
-
-export type IconListItemProps = IconListItemPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const IconListItem = ({
   className,

--- a/src/components/iconlist/IconListItem/IconListItem.tsx
+++ b/src/components/iconlist/IconListItem/IconListItem.tsx
@@ -1,16 +1,19 @@
 import React, { ReactNode, type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IconListItemProps {
+interface IconListItemPropsInterface {
   className?: string
   children: ReactNode
 }
+
+export type IconListItemProps = IconListItemPropsInterface &
+  JSX.IntrinsicElements['li']
 
 export const IconListItem = ({
   className,
   children,
   ...liProps
-}: IconListItemProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: IconListItemProps): JSX.Element => {
   const classes = classnames(className, 'usa-icon-list__item')
 
   return (

--- a/src/components/iconlist/IconListTitle/IconListTitle.tsx
+++ b/src/components/iconlist/IconListTitle/IconListTitle.tsx
@@ -16,13 +16,13 @@ interface ParagraphIconListTitleProps extends BaseIconListTitleProps {
   type: 'p'
 }
 
-type IconListHeadingTitleProps = HeadingIconListTitleProps &
+export type IconListHeadingTitleProps = HeadingIconListTitleProps &
   React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLHeadingElement>,
     HTMLHeadingElement
   >
 
-type IconListParagraphTitleProps = ParagraphIconListTitleProps &
+export type IconListParagraphTitleProps = ParagraphIconListTitleProps &
   JSX.IntrinsicElements['p']
 
 export const IconListTitle = ({

--- a/src/components/identifier/Identifier/Identifier.tsx
+++ b/src/components/identifier/Identifier/Identifier.tsx
@@ -1,16 +1,16 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-type IdentifierProps = {
+export type IdentifierProps = {
   className?: string
   children: React.ReactNode
-}
+} & JSX.IntrinsicElements['div']
 
 export const Identifier = ({
   className,
   children,
   ...divProps
-}: IdentifierProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: IdentifierProps): JSX.Element => {
   const classes = classnames('usa-identifier', className)
   return (
     <div data-testid="identifier" className={classes} {...divProps}>

--- a/src/components/identifier/IdentifierGov/IdentifierGov.tsx
+++ b/src/components/identifier/IdentifierGov/IdentifierGov.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierGovProps {
+interface IdentifierGovPropsInterface {
   children?: React.ReactNode
   className?: string
 }
+
+export type IdentifierGovProps = IdentifierGovPropsInterface &
+  JSX.IntrinsicElements['section']
 
 export const IdentifierGov = ({
   children,
   className,
   ...sectionProps
-}: IdentifierGovProps & JSX.IntrinsicElements['section']): JSX.Element => {
+}: IdentifierGovProps): JSX.Element => {
   const classes = classnames(
     'usa-identifier__section usa-identifier__section--usagov',
     className

--- a/src/components/identifier/IdentifierGov/IdentifierGov.tsx
+++ b/src/components/identifier/IdentifierGov/IdentifierGov.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierGovPropsInterface {
+export type IdentifierGovProps = {
   children?: React.ReactNode
   className?: string
-}
-
-export type IdentifierGovProps = IdentifierGovPropsInterface &
-  JSX.IntrinsicElements['section']
+} & JSX.IntrinsicElements['section']
 
 export const IdentifierGov = ({
   children,

--- a/src/components/identifier/IdentifierIdentity/IdentifierIdentity.tsx
+++ b/src/components/identifier/IdentifierIdentity/IdentifierIdentity.tsx
@@ -1,18 +1,21 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierIdentityProps {
+interface IdentifierIdentityPropsInterface {
   children: React.ReactNode
   domain: string
   className?: string
 }
+
+export type IdentifierIdentityProps = IdentifierIdentityPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const IdentifierIdentity = ({
   children,
   domain,
   className,
   ...divProps
-}: IdentifierIdentityProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: IdentifierIdentityProps): JSX.Element => {
   const classes = classnames('usa-identifier__identity', className)
   return (
     <div data-testid="identifierIdentity" className={classes} {...divProps}>

--- a/src/components/identifier/IdentifierIdentity/IdentifierIdentity.tsx
+++ b/src/components/identifier/IdentifierIdentity/IdentifierIdentity.tsx
@@ -1,14 +1,11 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierIdentityPropsInterface {
+export type IdentifierIdentityProps = {
   children: React.ReactNode
   domain: string
   className?: string
-}
-
-export type IdentifierIdentityProps = IdentifierIdentityPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const IdentifierIdentity = ({
   children,

--- a/src/components/identifier/IdentifierLink/IdentifierLink.tsx
+++ b/src/components/identifier/IdentifierLink/IdentifierLink.tsx
@@ -8,6 +8,11 @@ import {
   Link,
 } from '../../Link/Link'
 
+export type {
+  DefaultLinkProps as DefaultIdentifierLinkProps,
+  CustomLinkProps as CustomIdentifierLinkProps,
+} from '../../Link/Link'
+
 export function IdentifierLink(props: DefaultLinkProps): JSX.Element
 export function IdentifierLink<T>(props: CustomLinkProps<T>): JSX.Element
 export function IdentifierLink<FCProps = DefaultLinkProps>({

--- a/src/components/identifier/IdentifierLinkItem/IdentifierLinkItem.tsx
+++ b/src/components/identifier/IdentifierLinkItem/IdentifierLinkItem.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface IdentifierLinkItemPropsInterface {
+export type IdentifierLinkItemProps = {
   children: React.ReactNode
   className?: string
-}
-
-export type IdentifierLinkItemProps = IdentifierLinkItemPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const IdentifierLinkItem = ({
   children,

--- a/src/components/identifier/IdentifierLinkItem/IdentifierLinkItem.tsx
+++ b/src/components/identifier/IdentifierLinkItem/IdentifierLinkItem.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface IdentifierLinkItemProps {
+export interface IdentifierLinkItemPropsInterface {
   children: React.ReactNode
   className?: string
 }
+
+export type IdentifierLinkItemProps = IdentifierLinkItemPropsInterface &
+  JSX.IntrinsicElements['li']
 
 export const IdentifierLinkItem = ({
   children,
   className,
   ...listItemProps
-}: IdentifierLinkItemProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: IdentifierLinkItemProps): JSX.Element => {
   const classes = classnames('usa-identifier__required-links-item', className)
   return (
     <li className={classes} {...listItemProps}>

--- a/src/components/identifier/IdentifierLinks/IdentifierLinks.tsx
+++ b/src/components/identifier/IdentifierLinks/IdentifierLinks.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, type JSX } from 'react'
 import classnames from 'classnames'
 import { IdentifierLinkItemProps } from '../IdentifierLinkItem/IdentifierLinkItem'
 
-interface IdentifierLinksProps {
+export interface IdentifierLinksProps {
   children:
     | ReactElement<IdentifierLinkItemProps>
     | ReactElement<IdentifierLinkItemProps>[]

--- a/src/components/identifier/IdentifierLinks/IdentifierLinks.tsx
+++ b/src/components/identifier/IdentifierLinks/IdentifierLinks.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, type JSX } from 'react'
 import classnames from 'classnames'
 import { IdentifierLinkItemProps } from '../IdentifierLinkItem/IdentifierLinkItem'
 
-export interface IdentifierLinksProps {
+export type IdentifierLinksProps = {
   children:
     | ReactElement<IdentifierLinkItemProps>
     | ReactElement<IdentifierLinkItemProps>[]

--- a/src/components/identifier/IdentifierLogo/IdentifierLogo.tsx
+++ b/src/components/identifier/IdentifierLogo/IdentifierLogo.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface IdentifierLogoProps {
+export interface IdentifierLogoPropsInterface {
   children: React.ReactNode
   className?: string
 }
+
+export type IdentifierLogoProps = IdentifierLogoPropsInterface &
+  JSX.IntrinsicElements['a']
 
 export const IdentifierLogo = ({
   children,
   className,
   ...anchorProps
-}: IdentifierLogoProps & JSX.IntrinsicElements['a']): JSX.Element => {
+}: IdentifierLogoProps): JSX.Element => {
   const classes = classnames('usa-identifier__logo', className)
   return (
     <a className={classes} {...anchorProps}>

--- a/src/components/identifier/IdentifierLogo/IdentifierLogo.tsx
+++ b/src/components/identifier/IdentifierLogo/IdentifierLogo.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface IdentifierLogoPropsInterface {
+export type IdentifierLogoProps = {
   children: React.ReactNode
   className?: string
-}
-
-export type IdentifierLogoProps = IdentifierLogoPropsInterface &
-  JSX.IntrinsicElements['a']
+} & JSX.IntrinsicElements['a']
 
 export const IdentifierLogo = ({
   children,

--- a/src/components/identifier/IdentifierLogos/IdentifierLogos.tsx
+++ b/src/components/identifier/IdentifierLogos/IdentifierLogos.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierLogosProps {
+interface IdentifierLogosPropsInterface {
   children: React.ReactNode
   className?: string
 }
+
+export type IdentifierLogosProps = IdentifierLogosPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const IdentifierLogos = ({
   children,
   className,
   ...divProps
-}: IdentifierLogosProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: IdentifierLogosProps): JSX.Element => {
   const classes = classnames('usa-identifier__logos', className)
   return (
     <div data-testid="identifierLogos" className={classes} {...divProps}>

--- a/src/components/identifier/IdentifierLogos/IdentifierLogos.tsx
+++ b/src/components/identifier/IdentifierLogos/IdentifierLogos.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierLogosPropsInterface {
+export type IdentifierLogosProps = {
   children: React.ReactNode
   className?: string
-}
-
-export type IdentifierLogosProps = IdentifierLogosPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const IdentifierLogos = ({
   children,

--- a/src/components/identifier/IdentifierMasthead/IdentifierMasthead.tsx
+++ b/src/components/identifier/IdentifierMasthead/IdentifierMasthead.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierMastheadProps {
+interface IdentifierMastheadPropsInterface {
   className?: string
   children?: React.ReactNode
 }
+
+export type IdentifierMastheadProps = IdentifierMastheadPropsInterface &
+  JSX.IntrinsicElements['section']
 
 export const IdentifierMasthead = ({
   className,
   children,
   ...sectionProps
-}: IdentifierMastheadProps & JSX.IntrinsicElements['section']): JSX.Element => {
+}: IdentifierMastheadProps): JSX.Element => {
   const classes = classnames(
     'usa-identifier__section usa-identifier__section--masthead',
     className

--- a/src/components/identifier/IdentifierMasthead/IdentifierMasthead.tsx
+++ b/src/components/identifier/IdentifierMasthead/IdentifierMasthead.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface IdentifierMastheadPropsInterface {
+export type IdentifierMastheadProps = {
   className?: string
   children?: React.ReactNode
-}
-
-export type IdentifierMastheadProps = IdentifierMastheadPropsInterface &
-  JSX.IntrinsicElements['section']
+} & JSX.IntrinsicElements['section']
 
 export const IdentifierMasthead = ({
   className,

--- a/src/components/mediablock/MediaBlockBody/MediaBlockBody.tsx
+++ b/src/components/mediablock/MediaBlockBody/MediaBlockBody.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classNames from 'classnames'
 
+export type MediaBlockBodyProps = JSX.IntrinsicElements['div']
+
 export const MediaBlockBody = ({
   children,
   className,
   ...divProps
-}: JSX.IntrinsicElements['div']): JSX.Element => {
+}: MediaBlockBodyProps): JSX.Element => {
   const classes = classNames('usa-media-block__body', className)
 
   return (

--- a/src/components/modal/ModalFooter/ModalFooter.tsx
+++ b/src/components/modal/ModalFooter/ModalFooter.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface ModalFooterProps {
+interface ModalFooterPropsInterface {
   children: React.ReactNode
   className?: string
 }
+
+export type ModalFooterProps = ModalFooterPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const ModalFooter = ({
   children,
   className,
   ...divProps
-}: ModalFooterProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: ModalFooterProps): JSX.Element => {
   const classes = classnames('usa-modal__footer', className)
 
   return (

--- a/src/components/modal/ModalFooter/ModalFooter.tsx
+++ b/src/components/modal/ModalFooter/ModalFooter.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface ModalFooterPropsInterface {
+export type ModalFooterProps = {
   children: React.ReactNode
   className?: string
-}
-
-export type ModalFooterProps = ModalFooterPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const ModalFooter = ({
   children,

--- a/src/components/modal/ModalHeading/ModalHeading.tsx
+++ b/src/components/modal/ModalHeading/ModalHeading.tsx
@@ -1,11 +1,13 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
+export type ModalHeadingProps = React.HTMLProps<HTMLHeadingElement>
+
 export const ModalHeading = ({
   className,
   children,
   ...headingProps
-}: React.HTMLProps<HTMLHeadingElement>): JSX.Element => {
+}: ModalHeadingProps): JSX.Element => {
   const classes = classnames('usa-modal__heading', className)
 
   return (

--- a/src/components/modal/ModalOpenLink.tsx
+++ b/src/components/modal/ModalOpenLink.tsx
@@ -8,7 +8,7 @@ import {
   Link,
 } from '../Link/Link'
 
-type ModalOpenLinkProps = {
+export type ModalOpenLinkProps = {
   modalRef: React.RefObject<ModalRef | null>
 }
 

--- a/src/components/processlist/ProcessList/ProcessList.tsx
+++ b/src/components/processlist/ProcessList/ProcessList.tsx
@@ -2,16 +2,16 @@ import React, { type JSX } from 'react'
 import classnames from 'classnames'
 import { ProcessListItemProps } from '../ProcessListItem/ProcessListItem'
 
-type ProcessListProps = {
+export type ProcessListProps = {
   className?: string
   children: React.ReactElement<ProcessListItemProps>[]
-}
+} & JSX.IntrinsicElements['ol']
 
 export const ProcessList = ({
   className,
   children,
   ...listProps
-}: ProcessListProps & JSX.IntrinsicElements['ol']): JSX.Element => {
+}: ProcessListProps): JSX.Element => {
   const classes = classnames('usa-process-list', className)
   return (
     <ol className={classes} {...listProps}>

--- a/src/components/processlist/ProcessListHeading/ProcessListHeading.tsx
+++ b/src/components/processlist/ProcessListHeading/ProcessListHeading.tsx
@@ -16,14 +16,14 @@ interface ParagraphProcessListHeadingProps extends BaseProcessListHeadingProps {
   type: 'p'
 }
 
-type ProcessListHeadingProps = HeadingProcessListHeadingProps &
+export type ProcessListHeadingProps = HeadingProcessListHeadingProps &
   React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLHeadingElement>,
     HTMLHeadingElement
   >
 
-type ProcessListParagraphHeadingProps = ParagraphProcessListHeadingProps &
-  JSX.IntrinsicElements['p']
+export type ProcessListParagraphHeadingProps =
+  ParagraphProcessListHeadingProps & JSX.IntrinsicElements['p']
 
 export const ProcessListHeading = ({
   type,

--- a/src/components/processlist/ProcessListItem/ProcessListItem.tsx
+++ b/src/components/processlist/ProcessListItem/ProcessListItem.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface ProcessListItemProps {
+export interface ProcessListItemPropsInterface {
   className?: string
   children?: React.ReactNode
 }
+
+export type ProcessListItemProps = ProcessListItemPropsInterface &
+  JSX.IntrinsicElements['li']
 
 export const ProcessListItem = ({
   className,
   children,
   ...liProps
-}: ProcessListItemProps & JSX.IntrinsicElements['li']): JSX.Element => {
+}: ProcessListItemProps): JSX.Element => {
   const liClasses = classnames('usa-process-list__item', className)
   return (
     <li className={liClasses} {...liProps}>

--- a/src/components/processlist/ProcessListItem/ProcessListItem.tsx
+++ b/src/components/processlist/ProcessListItem/ProcessListItem.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-export interface ProcessListItemPropsInterface {
+export type ProcessListItemProps = {
   className?: string
   children?: React.ReactNode
-}
-
-export type ProcessListItemProps = ProcessListItemPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const ProcessListItem = ({
   className,

--- a/src/components/search/Search/Search.tsx
+++ b/src/components/search/Search/Search.tsx
@@ -10,7 +10,7 @@ type SearchLocalization = {
   buttonText: string
 }
 
-type SearchInputProps = {
+export type SearchProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   size?: 'big' | 'small'
   className?: string
@@ -21,7 +21,7 @@ type SearchInputProps = {
   i18n?: SearchLocalization
   buttonAriaLabel?: string
   inputProps?: OptionalTextInputProps
-}
+} & OptionalFormProps
 
 export const Search = ({
   onSubmit,
@@ -35,7 +35,7 @@ export const Search = ({
   buttonAriaLabel,
   inputProps,
   ...formProps
-}: SearchInputProps & OptionalFormProps): JSX.Element => {
+}: SearchProps): JSX.Element => {
   const classes = classnames('usa-search', className)
 
   return (

--- a/src/components/stepindicator/StepIndicator/StepIndicator.tsx
+++ b/src/components/stepindicator/StepIndicator/StepIndicator.tsx
@@ -8,7 +8,7 @@ export type StepStatusText = {
   incomplete: string
 }
 
-type StepIndicatorProps = {
+export type StepIndicatorProps = {
   showLabels?: boolean
   counters?: 'none' | 'default' | 'small'
   centered?: boolean
@@ -25,6 +25,7 @@ type StepIndicatorProps = {
   ofText?: string
   statusText?: StepStatusText
 }
+
 export const StepIndicator = (props: StepIndicatorProps): JSX.Element => {
   const {
     showLabels = true,

--- a/src/components/stepindicator/StepIndicatorStep/StepIndicatorStep.tsx
+++ b/src/components/stepindicator/StepIndicatorStep/StepIndicatorStep.tsx
@@ -3,15 +3,12 @@ import React, { type JSX } from 'react'
 
 import { StepStatusText } from '../StepIndicator/StepIndicator'
 
-export interface StepIndicatorStepPropsInterface {
+export type StepIndicatorStepProps = {
   label: string
   status?: 'complete' | 'current' | 'incomplete'
   statusText?: StepStatusText
   className?: string
-}
-
-export type StepIndicatorStepProps = StepIndicatorStepPropsInterface &
-  JSX.IntrinsicElements['li']
+} & JSX.IntrinsicElements['li']
 
 export const StepIndicatorStep = (
   props: StepIndicatorStepProps

--- a/src/components/stepindicator/StepIndicatorStep/StepIndicatorStep.tsx
+++ b/src/components/stepindicator/StepIndicatorStep/StepIndicatorStep.tsx
@@ -3,15 +3,18 @@ import React, { type JSX } from 'react'
 
 import { StepStatusText } from '../StepIndicator/StepIndicator'
 
-export interface StepIndicatorStepProps {
+export interface StepIndicatorStepPropsInterface {
   label: string
   status?: 'complete' | 'current' | 'incomplete'
   statusText?: StepStatusText
   className?: string
 }
 
+export type StepIndicatorStepProps = StepIndicatorStepPropsInterface &
+  JSX.IntrinsicElements['li']
+
 export const StepIndicatorStep = (
-  props: StepIndicatorStepProps & JSX.IntrinsicElements['li']
+  props: StepIndicatorStepProps
 ): JSX.Element => {
   const {
     label,

--- a/src/components/summarybox/SummaryBox/SummaryBox.tsx
+++ b/src/components/summarybox/SummaryBox/SummaryBox.tsx
@@ -2,16 +2,16 @@ import React, { type JSX } from 'react'
 
 import classnames from 'classnames'
 
-type SummaryBoxProps = {
+export type SummaryBoxProps = {
   children?: React.ReactNode
   className?: string
-}
+} & JSX.IntrinsicElements['div']
 
 export const SummaryBox = ({
   children,
   className,
   ...divProps
-}: SummaryBoxProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: SummaryBoxProps): JSX.Element => {
   const classes = classnames('usa-summary-box', className)
   return (
     <div className={classes} data-testid="summary-box" {...divProps}>

--- a/src/components/summarybox/SummaryBoxContent/SummaryBoxContent.tsx
+++ b/src/components/summarybox/SummaryBoxContent/SummaryBoxContent.tsx
@@ -1,13 +1,10 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface SummaryBoxTextPropsInterface {
+export type SummaryBoxContentProps = {
   children?: React.ReactNode
   className?: string
-}
-
-export type SummaryBoxContentProps = SummaryBoxTextPropsInterface &
-  JSX.IntrinsicElements['div']
+} & JSX.IntrinsicElements['div']
 
 export const SummaryBoxContent = ({
   children,

--- a/src/components/summarybox/SummaryBoxContent/SummaryBoxContent.tsx
+++ b/src/components/summarybox/SummaryBoxContent/SummaryBoxContent.tsx
@@ -1,16 +1,19 @@
 import React, { type JSX } from 'react'
 import classnames from 'classnames'
 
-interface SummaryBoxTextProps {
+interface SummaryBoxTextPropsInterface {
   children?: React.ReactNode
   className?: string
 }
+
+export type SummaryBoxContentProps = SummaryBoxTextPropsInterface &
+  JSX.IntrinsicElements['div']
 
 export const SummaryBoxContent = ({
   children,
   className,
   ...divProps
-}: SummaryBoxTextProps & JSX.IntrinsicElements['div']): JSX.Element => {
+}: SummaryBoxContentProps): JSX.Element => {
   const classes = classnames('usa-summary-box__text', className)
   return (
     <div className={classes} {...divProps}>

--- a/src/components/summarybox/SummaryBoxHeading/SummaryBoxHeading.tsx
+++ b/src/components/summarybox/SummaryBoxHeading/SummaryBoxHeading.tsx
@@ -2,17 +2,14 @@ import React, { type JSX, ReactNode } from 'react'
 import classnames from 'classnames'
 import { HeadingLevel } from '../../../types/headingLevel'
 
-interface SummaryBoxHeadingPropsInterface {
+export type SummaryBoxHeadingProps = {
   children: ReactNode
   className?: string
   headingLevel: HeadingLevel
-}
-
-export type SummaryBoxHeadingProps = SummaryBoxHeadingPropsInterface &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLHeadingElement>,
-    HTMLHeadingElement
-  >
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLHeadingElement>,
+  HTMLHeadingElement
+>
 
 export const SummaryBoxHeading = ({
   children,

--- a/src/components/summarybox/SummaryBoxHeading/SummaryBoxHeading.tsx
+++ b/src/components/summarybox/SummaryBoxHeading/SummaryBoxHeading.tsx
@@ -2,22 +2,24 @@ import React, { type JSX, ReactNode } from 'react'
 import classnames from 'classnames'
 import { HeadingLevel } from '../../../types/headingLevel'
 
-interface SummaryBoxHeadingProps {
+interface SummaryBoxHeadingPropsInterface {
   children: ReactNode
   className?: string
   headingLevel: HeadingLevel
 }
+
+export type SummaryBoxHeadingProps = SummaryBoxHeadingPropsInterface &
+  React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLHeadingElement>,
+    HTMLHeadingElement
+  >
 
 export const SummaryBoxHeading = ({
   children,
   className,
   headingLevel,
   ...h3Props
-}: SummaryBoxHeadingProps &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLHeadingElement>,
-    HTMLHeadingElement
-  >): JSX.Element => {
+}: SummaryBoxHeadingProps): JSX.Element => {
   const classes = classnames('usa-summary-box__heading', className)
   const Heading = headingLevel
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,6 @@ export type { InputSuffixProps } from './components/forms/InputSuffix/InputSuffi
 export { Label } from './components/forms/Label/Label'
 export type { LabelProps } from './components/forms/Label/Label'
 export { RequiredMarker } from './components/forms/Label/RequiredMarker'
-export type { RequiredMarkerProps } from './components/forms/Label/RequiredMarker'
 export { LanguageSelector } from './components/LanguageSelector/LanguageSelector'
 export type {
   LanguageDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,163 +1,272 @@
 // Global CSS
 import './styles/index.scss'
 
-/** USWDS basic components */
+/** USWDS basic components/types */
 export { Alert } from './components/Alert/Alert'
+export type { AlertProps } from './components/Alert/Alert';
 export { Accordion } from './components/Accordion/Accordion'
+export type { AccordionProps } from './components/Accordion/Accordion'
 export { Button } from './components/Button/Button'
+export type { ButtonProps } from './components/Button/Button'
 export { ButtonGroup } from './components/ButtonGroup/ButtonGroup'
+export type { ButtonGroupProps } from './components/ButtonGroup/ButtonGroup'
 export { InPageNavigation } from './components/InPageNavigation/InPageNavigation'
+export type { InPageNavigationProps } from './components/InPageNavigation/InPageNavigation'
 export { Link } from './components/Link/Link'
+export type { DefaultLinkProps, CustomLinkProps } from './components/Link/Link'
 export { MediaBlockBody } from './components/mediablock/MediaBlockBody/MediaBlockBody'
+export type { MediaBlockBodyProps } from './components/mediablock/MediaBlockBody/MediaBlockBody'
 export { Table } from './components/Table/Table'
+export type { TableProps } from './components/Table/Table'
 export { Tag } from './components/Tag/Tag'
+export type { TagProps } from './components/Tag/Tag'
 export { Tooltip } from './components/Tooltip/Tooltip'
+export type { DefaultTooltipProps, CustomTooltipProps } from './components/Tooltip/Tooltip'
 export { SideNav } from './components/SideNav/SideNav'
+export type { SideNavProps } from './components/SideNav/SideNav'
 export { Pagination } from './components/Pagination/Pagination'
+export type { PaginationProps } from './components/Pagination/Pagination'
 
-/** Banner components */
+/** Banner components/types */
 export { Banner } from './components/banner/Banner/Banner'
+export type { BannerProps } from './components/banner/Banner/Banner'
 export { BannerButton } from './components/banner/BannerButton/BannerButton'
+export type { BannerButtonProps } from './components/banner/BannerButton/BannerButton'
 export { BannerContent } from './components/banner/BannerContent/BannerContent'
+export type { BannerContentProps } from './components/banner/BannerContent/BannerContent'
 export { BannerFlag } from './components/banner/BannerFlag/BannerFlag'
+export type { BannerFlagProps } from './components/banner/BannerFlag/BannerFlag'
 export { BannerGuidance } from './components/banner/BannerGuidance/BannerGuidance'
+export type { BannerGuidanceProps } from './components/banner/BannerGuidance/BannerGuidance'
 export { BannerHeader } from './components/banner/BannerHeader/BannerHeader'
+export type { BannerHeaderProps } from './components/banner/BannerHeader/BannerHeader'
 export { BannerIcon } from './components/banner/BannerIcon/BannerIcon'
+export type { BannerIconProps } from './components/banner/BannerIcon/BannerIcon'
 export { GovBanner } from './components/banner/GovBanner/GovBanner'
+export type { GovBannerProps } from './components/banner/GovBanner/GovBanner'
 
-/** Collection components */
+/** Collection components/types */
 export { Collection } from './components/Collection/Collection'
+export type { CollectionProps } from './components/Collection/Collection'
 export { CollectionItem } from './components/Collection/CollectionItem'
+export type { CollectionItemProps } from './components/Collection/CollectionItem'
 export { CollectionHeading } from './components/Collection/CollectionHeading'
+export type { CollectionHeadingProps } from './components/Collection/CollectionHeading'
 export { CollectionDescription } from './components/Collection/CollectionDescription'
+export type { CollectionDescriptionProps } from './components/Collection/CollectionDescription'
 export { CollectionMeta } from './components/Collection/CollectionMeta'
+export type { CollectionMetaProps } from './components/Collection/CollectionMeta'
 export { CollectionMetaItem } from './components/Collection/CollectionMetaItem'
+export type { CollectionMetaItemProps } from './components/Collection/CollectionMetaItem'
 export { CollectionMetaItemTag } from './components/Collection/CollectionMetaItemTag'
+export type { CollectionMetaItemTagProps } from './components/Collection/CollectionMetaItemTag'
+
 export { CollectionThumbnail } from './components/Collection/CollectionThumbnail'
+export type { CollectionThumbnailProps } from './components/Collection/CollectionThumbnail'
 export { CollectionCalendarDate } from './components/Collection/CollectionCalendarDate'
+export type { CollectionCalendarDateProps } from './components/Collection/CollectionCalendarDate'
 
-/** Grid components */
+/** Grid components/types */
 export { GridContainer } from './components/grid/GridContainer/GridContainer'
+export type { DefaultGridContainerProps, CustomGridContainerProps } from './components/grid/GridContainer/GridContainer'
 export { Grid } from './components/grid/Grid/Grid'
+export type { DefaultGridProps, CustomGridProps } from './components/grid/Grid/Grid'
 
-/** Form components */
+/** Form components/types */
 export { CharacterCount } from './components/forms/CharacterCount/CharacterCount'
+export type { TextInputCharacterCountProps, TextareaCharacterCountProps } from './components/forms/CharacterCount/CharacterCount'
 export { Checkbox } from './components/forms/Checkbox/Checkbox'
+export type { CheckboxProps } from './components/forms/Checkbox/Checkbox'
 export { ComboBox } from './components/forms/ComboBox/ComboBox'
 export type {
   ComboBoxRef,
+  ComboBoxProps,
   ComboBoxOption,
 } from './components/forms/ComboBox/ComboBox'
 export { DateInput } from './components/forms/DateInput/DateInput'
+export type { DateInputProps } from './components/forms/DateInput/DateInput'
 export { DateInputGroup } from './components/forms/DateInputGroup/DateInputGroup'
+export type { DateInputGroupProps } from './components/forms/DateInputGroup/DateInputGroup'
 export { DatePicker } from './components/forms/DatePicker/DatePicker'
+export type { DatePickerProps } from './components/forms/DatePicker/DatePicker'
 export { DateRangePicker } from './components/forms/DateRangePicker/DateRangePicker'
+export type { DateRangePickerProps } from './components/forms/DateRangePicker/DateRangePicker'
 export { ErrorMessage } from './components/forms/ErrorMessage/ErrorMessage'
+export type { ErrorMessageProps } from './components/forms/ErrorMessage/ErrorMessage'
 export { Fieldset } from './components/forms/Fieldset/Fieldset'
+export type { FieldsetProps } from './components/forms/Fieldset/Fieldset'
 export { FileInput } from './components/forms/FileInput/FileInput'
-export type { FileInputRef } from './components/forms/FileInput/FileInput'
+export type { FileInputRef, FileInputProps } from './components/forms/FileInput/FileInput'
 export { Form } from './components/forms/Form/Form'
+export type { FormProps } from './components/forms/Form/Form'
 export { FormGroup } from './components/forms/FormGroup/FormGroup'
+export type { FormGroupProps } from './components/forms/FormGroup/FormGroup'
 export { InputGroup } from './components/forms/InputGroup/InputGroup'
+export type { InputGroupProps } from './components/forms/InputGroup/InputGroup'
 export { InputPrefix } from './components/forms/InputPrefix/InputPrefix'
+export type { InputPrefixProps } from './components/forms/InputPrefix/InputPrefix'
 export { InputSuffix } from './components/forms/InputSuffix/InputSuffix'
+export type { InputSuffixProps } from './components/forms/InputSuffix/InputSuffix'
 export { Label } from './components/forms/Label/Label'
+export type { LabelProps } from './components/forms/Label/Label'
 export { RequiredMarker } from './components/forms/Label/RequiredMarker'
+export type { RequiredMarkerProps } from './components/forms/Label/RequiredMarker'
 export { LanguageSelector } from './components/LanguageSelector/LanguageSelector'
+export type { LanguageDefinition, LanguageSelectorProps } from './components/LanguageSelector/LanguageSelector'
 export { LanguageSelectorButton } from './components/LanguageSelector/LanguageSelectorButton'
-export type { LanguageDefinition } from './components/LanguageSelector/LanguageSelector'
+export type { LanguageSelectorButtonProps } from './components/LanguageSelector/LanguageSelectorButton'
 export { Radio } from './components/forms/Radio/Radio'
+export type { RadioProps } from './components/forms/Radio/Radio'
 export { RangeInput } from './components/forms/RangeInput/RangeInput'
+export type{ RangeInputProps } from './components/forms/RangeInput/RangeInput'
 export { Select } from './components/forms/Select/Select'
+export type { SelectProps } from './components/forms/Select/Select'
 export { Textarea } from './components/forms/Textarea/Textarea'
+export type { TextareaProps } from './components/forms/Textarea/Textarea'
 export { TextInput } from './components/forms/TextInput/TextInput'
+export type { TextInputProps } from './components/forms/TextInput/TextInput'
 export { TextInputMask } from './components/forms/TextInputMask/TextInputMask'
+export type { TextInputMaskProps } from './components/forms/TextInputMask/TextInputMask'
 export { TimePicker } from './components/forms/TimePicker/TimePicker'
+export type { TimePickerProps } from './components/forms/TimePicker/TimePicker'
 export { ValidationChecklist } from './components/forms/Validation/ValidationChecklist'
+export type { ValidationChecklistProps } from './components/forms/Validation/ValidationChecklist'
 export { ValidationItem } from './components/forms/Validation/ValidationItem'
+export type { ValidationItemProps } from './components/forms/Validation/ValidationItem'
 export type { ValidationStatus } from './types/validationStatus'
 
-/** Header Components */
+/** Header Components/types */
 export { ExtendedNav } from './components/header/ExtendedNav/ExtendedNav'
+export type { ExtendedNavProps } from './components/header/ExtendedNav/ExtendedNav'
 export { Header } from './components/header/Header/Header'
+export type { HeaderProps } from './components/header/Header/Header'
 export { MegaMenu } from './components/header/MegaMenu/MegaMenu'
+export type { MegaMenuProps } from './components/header/MegaMenu/MegaMenu'
 export { Menu } from './components/header/Menu/Menu'
+export type { MenuProps } from './components/header/Menu/Menu'
 export { NavCloseButton } from './components/header/NavCloseButton/NavCloseButton'
+export type { NavCloseButtonProps } from './components/header/NavCloseButton/NavCloseButton'
 export { NavList } from './components/header/NavList/NavList'
+export type { NavListProps } from './components/header/NavList/NavList'
 export { NavMenuButton } from './components/header/NavMenuButton/NavMenuButton'
+export type { NavMenuButtonProps } from './components/header/NavMenuButton/NavMenuButton'
 export { NavDropDownButton } from './components/header/NavDropDownButton/NavDropDownButton'
+export type { NavDropDownButtonProps } from './components/header/NavDropDownButton/NavDropDownButton'
 export { PrimaryNav } from './components/header/PrimaryNav/PrimaryNav'
+export type { PrimaryNavProps } from './components/header/PrimaryNav/PrimaryNav'
 export { Title } from './components/header/Title/Title'
+export type { TitleProps } from './components/header/Title/Title'
 
-/** IconList component */
+/** IconList component/types */
 export { IconList } from './components/iconlist/IconList'
+export type { IconListProps } from './components/iconlist/IconList'
 export { IconListContent } from './components/iconlist/IconListContent/IconListContent'
+export type { IconListContentProps } from './components/iconlist/IconListContent/IconListContent'
 export { IconListIcon } from './components/iconlist/IconListIcon/IconListIcon'
+export type { IconListIconProps } from './components/iconlist/IconListIcon/IconListIcon'
 export { IconListItem } from './components/iconlist/IconListItem/IconListItem'
+export type { IconListItemProps } from './components/iconlist/IconListItem/IconListItem'
 export { IconListTitle } from './components/iconlist/IconListTitle/IconListTitle'
+export type { IconListHeadingTitleProps, IconListParagraphTitleProps } from './components/iconlist/IconListTitle/IconListTitle'
 
 // Icons
 export { Icon } from './components/Icon/Icons'
 
-/** Identifier Components */
+/** Identifier Components/types */
 export { Identifier } from './components/identifier/Identifier/Identifier'
+export type { IdentifierProps } from './components/identifier/Identifier/Identifier'
 export { IdentifierGov } from './components/identifier/IdentifierGov/IdentifierGov'
+export type { IdentifierGovProps } from './components/identifier/IdentifierGov/IdentifierGov'
 export { IdentifierIdentity } from './components/identifier/IdentifierIdentity/IdentifierIdentity'
+export type { IdentifierIdentityProps } from './components/identifier/IdentifierIdentity/IdentifierIdentity'
 export { IdentifierLink } from './components/identifier/IdentifierLink/IdentifierLink'
+export type { DefaultIdentifierLinkProps, CustomIdentifierLinkProps } from './components/identifier/IdentifierLink/IdentifierLink'
 export { IdentifierLinkItem } from './components/identifier/IdentifierLinkItem/IdentifierLinkItem'
+export type { IdentifierLinkItemProps } from './components/identifier/IdentifierLinkItem/IdentifierLinkItem'
 export { IdentifierLinks } from './components/identifier/IdentifierLinks/IdentifierLinks'
+export type { IdentifierLinksProps } from './components/identifier/IdentifierLinks/IdentifierLinks'
 export { IdentifierLogo } from './components/identifier/IdentifierLogo/IdentifierLogo'
+export type { IdentifierLogoProps } from './components/identifier/IdentifierLogo/IdentifierLogo'
 export { IdentifierLogos } from './components/identifier/IdentifierLogos/IdentifierLogos'
+export type { IdentifierLogosProps } from './components/identifier/IdentifierLogos/IdentifierLogos'
 export { IdentifierMasthead } from './components/identifier/IdentifierMasthead/IdentifierMasthead'
+export type { IdentifierMastheadProps } from './components/identifier/IdentifierMasthead/IdentifierMasthead'
 
-/** Footer components */
+/** Footer components/types */
 export { Address } from './components/footer/Address/Address'
+export type { AddressProps } from './components/footer/Address/Address'
 export { Footer } from './components/footer/Footer/Footer'
+export type { FooterProps } from './components/footer/Footer/Footer'
 export { FooterExtendedNavList } from './components/footer/FooterExtendedNavList/FooterExtendedNavList'
+export type { FooterExtendedNavListProps } from './components/footer/FooterExtendedNavList/FooterExtendedNavList'
 export { FooterNav } from './components/footer/FooterNav/FooterNav'
+export type { FooterNavProps } from './components/footer/FooterNav/FooterNav'
 export { Logo } from './components/footer/Logo/Logo'
+export type { LogoProps } from './components/footer/Logo/Logo'
 export {
   SocialLinks,
   SocialLink,
 } from './components/footer/SocialLinks/SocialLinks'
+export type { SocialLinksProps, SocialLinkProps } from './components/footer/SocialLinks/SocialLinks'
 
-/** Modal components */
+/** Modal components/types */
 export { Modal } from './components/modal/Modal'
-export { ModalToggleButton } from './components/modal/ModalToggleButton'
-export { ModalOpenLink } from './components/modal/ModalOpenLink'
-export { ModalHeading } from './components/modal/ModalHeading/ModalHeading'
-export { ModalFooter } from './components/modal/ModalFooter/ModalFooter'
 export type { ModalProps, ModalRef } from './components/modal/Modal'
+export { ModalOpenLink } from './components/modal/ModalOpenLink'
+export type { ModalOpenLinkProps } from './components/modal/ModalOpenLink'
+export { ModalHeading } from './components/modal/ModalHeading/ModalHeading'
+export type { ModalHeadingProps } from './components/modal/ModalHeading/ModalHeading'
+export { ModalFooter } from './components/modal/ModalFooter/ModalFooter'
+export type { ModalFooterProps } from './components/modal/ModalFooter/ModalFooter'
 
-/** Card components */
+/** Card components/types */
 export { CardGroup } from './components/card/CardGroup/CardGroup'
+export type { CardGroupProps } from './components/card/CardGroup/CardGroup'
 export { Card } from './components/card/Card/Card'
+export type { CardProps } from './components/card/Card/Card'
 export { CardHeader } from './components/card/CardHeader/CardHeader'
+export type { CardHeaderProps } from './components/card/CardHeader/CardHeader'
 export { CardMedia } from './components/card/CardMedia/CardMedia'
+export type { CardMediaProps } from './components/card/CardMedia/CardMedia'
 export { CardBody } from './components/card/CardBody/CardBody'
+export type { CardBodyProps } from './components/card/CardBody/CardBody'
 export { CardFooter } from './components/card/CardFooter/CardFooter'
+export type { CardFooterProps } from './components/card/CardFooter/CardFooter'
 
-/** Breadcrumb components */
+/** Breadcrumb components/types */
 export { BreadcrumbBar } from './components/breadcrumb/BreadcrumbBar/BreadcrumbBar'
+export type { BreadcrumbBarProps } from './components/breadcrumb/BreadcrumbBar/BreadcrumbBar'
 export { Breadcrumb } from './components/breadcrumb/Breadcrumb/Breadcrumb'
+export type { BreadcrumbProps } from './components/breadcrumb/Breadcrumb/Breadcrumb'
 export { BreadcrumbLink } from './components/breadcrumb/BreadcrumbLink/BreadcrumbLink'
+export type { DefaultBreadcrumbLinkProps, CustomBreadcrumbLinkProps } from './components/breadcrumb/BreadcrumbLink/BreadcrumbLink'
 
-/** StepIndicator components */
+/** StepIndicator components/types */
 export { StepIndicator } from './components/stepindicator/StepIndicator/StepIndicator'
+export type { StepIndicatorProps } from './components/stepindicator/StepIndicator/StepIndicator'
 export { StepIndicatorStep } from './components/stepindicator/StepIndicatorStep/StepIndicatorStep'
+export type { StepIndicatorStepProps } from './components/stepindicator/StepIndicatorStep/StepIndicatorStep'
 
 export { Search } from './components/search/Search/Search'
+export type { SearchProps } from './components/search/Search/Search'
 
 export { SummaryBox } from './components/summarybox/SummaryBox/SummaryBox'
+export type { SummaryBoxProps } from './components/summarybox/SummaryBox/SummaryBox'
 export { SummaryBoxHeading } from './components/summarybox/SummaryBoxHeading/SummaryBoxHeading'
+export type { SummaryBoxHeadingProps } from './components/summarybox/SummaryBoxHeading/SummaryBoxHeading'
 export { SummaryBoxContent } from './components/summarybox/SummaryBoxContent/SummaryBoxContent'
+export type { SummaryBoxContentProps } from './components/summarybox/SummaryBoxContent/SummaryBoxContent'
 
-/** ProcessList components */
+/** ProcessList components/types */
 export { ProcessList } from './components/processlist/ProcessList/ProcessList'
+export type { ProcessListProps } from './components/processlist/ProcessList/ProcessList'
 export { ProcessListItem } from './components/processlist/ProcessListItem/ProcessListItem'
+export type { ProcessListItemProps } from './components/processlist/ProcessListItem/ProcessListItem'
 export { ProcessListHeading } from './components/processlist/ProcessListHeading/ProcessListHeading'
+export type { ProcessListHeadingProps, ProcessListParagraphHeadingProps } from './components/processlist/ProcessListHeading/ProcessListHeading'
 
 export { SiteAlert } from './components/SiteAlert/SiteAlert'
+export type { SiteAlertProps } from './components/SiteAlert/SiteAlert'
 
-/** Types */
+/** Other Types */
 export type { HeadingLevel } from './types/headingLevel'

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import './styles/index.scss'
 
 /** USWDS basic components/types */
 export { Alert } from './components/Alert/Alert'
-export type { AlertProps } from './components/Alert/Alert';
+export type { AlertProps } from './components/Alert/Alert'
 export { Accordion } from './components/Accordion/Accordion'
 export type { AccordionProps } from './components/Accordion/Accordion'
 export { Button } from './components/Button/Button'
@@ -21,7 +21,10 @@ export type { TableProps } from './components/Table/Table'
 export { Tag } from './components/Tag/Tag'
 export type { TagProps } from './components/Tag/Tag'
 export { Tooltip } from './components/Tooltip/Tooltip'
-export type { DefaultTooltipProps, CustomTooltipProps } from './components/Tooltip/Tooltip'
+export type {
+  DefaultTooltipProps,
+  CustomTooltipProps,
+} from './components/Tooltip/Tooltip'
 export { SideNav } from './components/SideNav/SideNav'
 export type { SideNavProps } from './components/SideNav/SideNav'
 export { Pagination } from './components/Pagination/Pagination'
@@ -68,13 +71,22 @@ export type { CollectionCalendarDateProps } from './components/Collection/Collec
 
 /** Grid components/types */
 export { GridContainer } from './components/grid/GridContainer/GridContainer'
-export type { DefaultGridContainerProps, CustomGridContainerProps } from './components/grid/GridContainer/GridContainer'
+export type {
+  DefaultGridContainerProps,
+  CustomGridContainerProps,
+} from './components/grid/GridContainer/GridContainer'
 export { Grid } from './components/grid/Grid/Grid'
-export type { DefaultGridProps, CustomGridProps } from './components/grid/Grid/Grid'
+export type {
+  DefaultGridProps,
+  CustomGridProps,
+} from './components/grid/Grid/Grid'
 
 /** Form components/types */
 export { CharacterCount } from './components/forms/CharacterCount/CharacterCount'
-export type { TextInputCharacterCountProps, TextareaCharacterCountProps } from './components/forms/CharacterCount/CharacterCount'
+export type {
+  TextInputCharacterCountProps,
+  TextareaCharacterCountProps,
+} from './components/forms/CharacterCount/CharacterCount'
 export { Checkbox } from './components/forms/Checkbox/Checkbox'
 export type { CheckboxProps } from './components/forms/Checkbox/Checkbox'
 export { ComboBox } from './components/forms/ComboBox/ComboBox'
@@ -96,7 +108,10 @@ export type { ErrorMessageProps } from './components/forms/ErrorMessage/ErrorMes
 export { Fieldset } from './components/forms/Fieldset/Fieldset'
 export type { FieldsetProps } from './components/forms/Fieldset/Fieldset'
 export { FileInput } from './components/forms/FileInput/FileInput'
-export type { FileInputRef, FileInputProps } from './components/forms/FileInput/FileInput'
+export type {
+  FileInputRef,
+  FileInputProps,
+} from './components/forms/FileInput/FileInput'
 export { Form } from './components/forms/Form/Form'
 export type { FormProps } from './components/forms/Form/Form'
 export { FormGroup } from './components/forms/FormGroup/FormGroup'
@@ -112,13 +127,16 @@ export type { LabelProps } from './components/forms/Label/Label'
 export { RequiredMarker } from './components/forms/Label/RequiredMarker'
 export type { RequiredMarkerProps } from './components/forms/Label/RequiredMarker'
 export { LanguageSelector } from './components/LanguageSelector/LanguageSelector'
-export type { LanguageDefinition, LanguageSelectorProps } from './components/LanguageSelector/LanguageSelector'
+export type {
+  LanguageDefinition,
+  LanguageSelectorProps,
+} from './components/LanguageSelector/LanguageSelector'
 export { LanguageSelectorButton } from './components/LanguageSelector/LanguageSelectorButton'
 export type { LanguageSelectorButtonProps } from './components/LanguageSelector/LanguageSelectorButton'
 export { Radio } from './components/forms/Radio/Radio'
 export type { RadioProps } from './components/forms/Radio/Radio'
 export { RangeInput } from './components/forms/RangeInput/RangeInput'
-export type{ RangeInputProps } from './components/forms/RangeInput/RangeInput'
+export type { RangeInputProps } from './components/forms/RangeInput/RangeInput'
 export { Select } from './components/forms/Select/Select'
 export type { SelectProps } from './components/forms/Select/Select'
 export { Textarea } from './components/forms/Textarea/Textarea'
@@ -167,10 +185,14 @@ export type { IconListIconProps } from './components/iconlist/IconListIcon/IconL
 export { IconListItem } from './components/iconlist/IconListItem/IconListItem'
 export type { IconListItemProps } from './components/iconlist/IconListItem/IconListItem'
 export { IconListTitle } from './components/iconlist/IconListTitle/IconListTitle'
-export type { IconListHeadingTitleProps, IconListParagraphTitleProps } from './components/iconlist/IconListTitle/IconListTitle'
+export type {
+  IconListHeadingTitleProps,
+  IconListParagraphTitleProps,
+} from './components/iconlist/IconListTitle/IconListTitle'
 
 // Icons
 export { Icon } from './components/Icon/Icons'
+export type { IconProps } from './components/Icon/Icon'
 
 /** Identifier Components/types */
 export { Identifier } from './components/identifier/Identifier/Identifier'
@@ -180,7 +202,10 @@ export type { IdentifierGovProps } from './components/identifier/IdentifierGov/I
 export { IdentifierIdentity } from './components/identifier/IdentifierIdentity/IdentifierIdentity'
 export type { IdentifierIdentityProps } from './components/identifier/IdentifierIdentity/IdentifierIdentity'
 export { IdentifierLink } from './components/identifier/IdentifierLink/IdentifierLink'
-export type { DefaultIdentifierLinkProps, CustomIdentifierLinkProps } from './components/identifier/IdentifierLink/IdentifierLink'
+export type {
+  DefaultIdentifierLinkProps,
+  CustomIdentifierLinkProps,
+} from './components/identifier/IdentifierLink/IdentifierLink'
 export { IdentifierLinkItem } from './components/identifier/IdentifierLinkItem/IdentifierLinkItem'
 export type { IdentifierLinkItemProps } from './components/identifier/IdentifierLinkItem/IdentifierLinkItem'
 export { IdentifierLinks } from './components/identifier/IdentifierLinks/IdentifierLinks'
@@ -207,7 +232,10 @@ export {
   SocialLinks,
   SocialLink,
 } from './components/footer/SocialLinks/SocialLinks'
-export type { SocialLinksProps, SocialLinkProps } from './components/footer/SocialLinks/SocialLinks'
+export type {
+  SocialLinksProps,
+  SocialLinkProps,
+} from './components/footer/SocialLinks/SocialLinks'
 
 /** Modal components/types */
 export { Modal } from './components/modal/Modal'
@@ -239,7 +267,10 @@ export type { BreadcrumbBarProps } from './components/breadcrumb/BreadcrumbBar/B
 export { Breadcrumb } from './components/breadcrumb/Breadcrumb/Breadcrumb'
 export type { BreadcrumbProps } from './components/breadcrumb/Breadcrumb/Breadcrumb'
 export { BreadcrumbLink } from './components/breadcrumb/BreadcrumbLink/BreadcrumbLink'
-export type { DefaultBreadcrumbLinkProps, CustomBreadcrumbLinkProps } from './components/breadcrumb/BreadcrumbLink/BreadcrumbLink'
+export type {
+  DefaultBreadcrumbLinkProps,
+  CustomBreadcrumbLinkProps,
+} from './components/breadcrumb/BreadcrumbLink/BreadcrumbLink'
 
 /** StepIndicator components/types */
 export { StepIndicator } from './components/stepindicator/StepIndicator/StepIndicator'
@@ -263,7 +294,10 @@ export type { ProcessListProps } from './components/processlist/ProcessList/Proc
 export { ProcessListItem } from './components/processlist/ProcessListItem/ProcessListItem'
 export type { ProcessListItemProps } from './components/processlist/ProcessListItem/ProcessListItem'
 export { ProcessListHeading } from './components/processlist/ProcessListHeading/ProcessListHeading'
-export type { ProcessListHeadingProps, ProcessListParagraphHeadingProps } from './components/processlist/ProcessListHeading/ProcessListHeading'
+export type {
+  ProcessListHeadingProps,
+  ProcessListParagraphHeadingProps,
+} from './components/processlist/ProcessListHeading/ProcessListHeading'
 
 export { SiteAlert } from './components/SiteAlert/SiteAlert'
 export type { SiteAlertProps } from './components/SiteAlert/SiteAlert'


### PR DESCRIPTION
# Summary

Exports props for all components in index.ts for easy/intuitive access when consumers want to get TS access to the props our components accept.

## Related Issues or PRs

Closes #2587 

## How To Test

Verify correct component prop exporting, could try to access component props elsewhere
