### PR TITLE
chore(ci): Remove Husky to unblock release in preparation for replacement

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-yarn run lint
-yarn run format:check
-yarn run test
-yarn run test:serverside --silent
-

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "lint:fix": "tsc && eslint src --fix && stylelint \"src/**/*.{css,scss}\" --fix",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
     "format:fix": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
-    "postinstall": "husky",
-    "prepack": "pinst --disable && yarn lint && yarn test && yarn build",
-    "postpack": "pinst --enable",
     "happo": "happo run --config ./.happo.js",
     "happo-ci": "HAPPO_CONFIG_FILE='./.happo.js' npx -p happo.io happo-ci-github-actions --config ./.happo.js",
     "contributors:add": "all-contributors add"
@@ -120,7 +117,6 @@
     "globals": "^16.0.0",
     "happo-plugin-storybook": "^4.4.3",
     "happo.io": "^12.1.0",
-    "husky": "^9.0.10",
     "jsdom": "^24.0.0",
     "pinst": "^3.0.0",
     "prettier": "^3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,7 +2481,6 @@ __metadata:
     globals: ^16.0.0
     happo-plugin-storybook: ^4.4.3
     happo.io: ^12.1.0
-    husky: ^9.0.10
     jsdom: ^24.0.0
     pinst: ^3.0.0
     prettier: ^3.2.5
@@ -6300,15 +6299,6 @@ __metadata:
     agent-base: ^7.1.2
     debug: 4
   checksum: b882377a120aa0544846172e5db021fa8afbf83fea2a897d397bd2ddd8095ab268c24bc462f40a15f2a8c600bf4aa05ce52927f70038d4014e68aefecfa94e8d
-  languageName: node
-  linkType: hard
-
-"husky@npm:^9.0.10":
-  version: 9.1.7
-  resolution: "husky@npm:9.1.7"
-  bin:
-    husky: bin.js
-  checksum: c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

We want to get a release out, but Husky threatens to make that release unusable by consumers using modern versions of npm (see linked issue). That is not an acceptable risk, IMO.

So, my recommendation is to remove husky for now, do a release, and replace husky with something else (as soon as possible) in preparation for code additions and future releases

## Related Issues or PRs

Relates to (but does not close): https://github.com/trussworks/react-uswds/issues/3155

## How To Test

CI runs these checks
