### PR TITLE
build(release): Add the prepack script back so that `yarn pack` also builds the library as it used to

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lint:fix": "tsc && eslint src --fix && stylelint \"src/**/*.{css,scss}\" --fix",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
     "format:fix": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,scss,json,md}\"",
+    "prepack": "yarn lint && yarn test && yarn build",
     "happo": "happo run --config ./.happo.js",
     "happo-ci": "HAPPO_CONFIG_FILE='./.happo.js' npx -p happo.io happo-ci-github-actions --config ./.happo.js",
     "contributors:add": "all-contributors add"


### PR DESCRIPTION
# Summary

## Related Issues or PRs

closes #3159 

## How To Test

locally, delete your `lib` folder if you have one, then run `yarn pack`. Verify the output includes the `lib` directory.

Will need to re-release and re-publish to fix for consumers