### PR TITLE
validate DatePicker on blur

### DIFF
--- a/src/components/forms/DatePicker/DatePicker.test.tsx
+++ b/src/components/forms/DatePicker/DatePicker.test.tsx
@@ -399,12 +399,14 @@ describe('DatePicker component', () => {
       expect(getByTestId('date-picker-external-input')).toBeValid()
     })
 
-    it('validates an invalid default value', () => {
+    it('validates an invalid default value', async () => {
       const { getByTestId } = renderDatePicker({
         defaultValue: '1990-01-01',
         minDate: '2020-01-01',
       })
 
+      await userEvent.click(getByTestId('date-picker-external-input'))
+      await userEvent.tab()
       expect(getByTestId('date-picker-external-input')).toBeInvalid()
     })
   })
@@ -538,8 +540,7 @@ describe('DatePicker component', () => {
       expect(mockOnBlur).toHaveBeenCalled()
     })
 
-    // TODO - this is an outstanding difference in behavior from USWDS. Fails because validation happens onChange.
-    it.skip('typing in the external input does not validate until blurring', async () => {
+    it('typing in the external input does not validate until blurring', async () => {
       const { getByTestId } = renderDatePicker({
         minDate: '2021-01-20',
         maxDate: '2021-02-14',
@@ -553,8 +554,7 @@ describe('DatePicker component', () => {
       expect(externalInput).toBeInvalid()
     })
 
-    // TODO - this can be implemented if the above test case is implemented
-    it.skip('pressing the Enter key in the external input validates the date', async () => {
+    it('pressing the Enter key in the external input validates the date', async () => {
       const { getByTestId } = renderDatePicker({
         minDate: '2021-01-20',
         maxDate: '2021-02-14',
@@ -597,6 +597,7 @@ describe('DatePicker component', () => {
         'abcdefg... That means the convo is done'
       )
 
+      await userEvent.tab()
       expect(externalInput).toBeInvalid()
       expect(externalInput.validationMessage).toEqual(VALIDATION_MESSAGE)
     })
@@ -610,6 +611,7 @@ describe('DatePicker component', () => {
       await userEvent.type(externalInput, 'ab/cd/efg')
       expect(mockOnChange).toHaveBeenCalledWith('ab/cd/efg')
 
+      await userEvent.tab()
       expect(externalInput).toBeInvalid()
       expect(externalInput.validationMessage).toEqual(VALIDATION_MESSAGE)
     })
@@ -625,12 +627,14 @@ describe('DatePicker component', () => {
       await userEvent.type(externalInput, '2/31/2019')
       expect(mockOnChange).toHaveBeenCalledWith('2/31/2019')
 
+      await userEvent.tab()
       expect(externalInput).toBeInvalid()
       expect(externalInput.validationMessage).toEqual(VALIDATION_MESSAGE)
       await userEvent.click(getByTestId('date-picker-button'))
       expect(getByTestId('date-picker-calendar')).toBeVisible()
       await userEvent.click(getByLabelText(/^10 February 2019/))
       expect(mockOnChange).toHaveBeenCalledWith('02/10/2019')
+      await userEvent.tab()
 
       await waitFor(() => {
         expect(externalInput).toBeValid()
@@ -651,6 +655,7 @@ describe('DatePicker component', () => {
       await userEvent.type(externalInput, '05/16/1988')
       expect(mockOnChange).toHaveBeenCalledWith('05/16/1988')
 
+      await userEvent.tab()
       expect(externalInput).toBeInvalid()
       expect(externalInput.validationMessage).toEqual(VALIDATION_MESSAGE)
     })

--- a/src/components/forms/DatePicker/DatePicker.tsx
+++ b/src/components/forms/DatePicker/DatePicker.tsx
@@ -97,6 +97,7 @@ export const DatePicker = ({
 
     if (isInvalid && !externalInputEl?.current?.validationMessage) {
       externalInputEl?.current?.setCustomValidity(VALIDATION_MESSAGE)
+      externalInputEl?.current?.setAttribute('aria-invalid', 'true')
     }
 
     if (
@@ -104,7 +105,10 @@ export const DatePicker = ({
       externalInputEl?.current?.validationMessage === VALIDATION_MESSAGE
     ) {
       externalInputEl?.current?.setCustomValidity('')
+      externalInputEl?.current?.removeAttribute('aria-invalid')
     }
+
+    externalInputEl?.current?.reportValidity()
   }
 
   const handleSelectDate = (dateString: string, closeCalendar = true): void => {
@@ -169,10 +173,6 @@ export const DatePicker = ({
       }
     }
   }, [showCalendar])
-
-  useEffect(() => {
-    validateInput()
-  }, [externalValue, minDate, maxDate])
 
   const handleToggleClick = (): void => {
     if (showCalendar) {
@@ -298,8 +298,14 @@ export const DatePicker = ({
             setFocusMode(FocusMode.Input)
           }}
           onBlur={(e): void => {
+            validateInput()
             setFocusMode(FocusMode.None)
             onBlur && onBlur(e)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' ) {
+              externalInputEl.current?.blur()
+            }
           }}
         />
         <button


### PR DESCRIPTION
# Summary
this PR fixes the skipped tests in `DatePicker.test.tsx` by adjusting `DatePicker` to validate on blur rather than with a `useEffect` hook, which matches with USWDS. it also sets the `aria-invalid` attribute and uses `reportValidity` to send `VALIDATION_MESSAGE` to the user. this PR also changes some of the tests that were dependent on the `useEffect` behavior

## Related Issues or PRs

none

## How To Test

`yarn test`
