### PR TITLE
fix: resolve type error reported during build

### DIFF
--- a/src/deprecation.ts
+++ b/src/deprecation.ts
@@ -1,6 +1,5 @@
-export const deprecationWarning =
-  process.env.NODE_ENV !== 'production'
-    ? console.warn
-    : () => {
-        // do nothing in production
-      }
+export const deprecationWarning = import.meta.env.DEV
+  ? console.warn
+  : () => {
+      // do nothing in production
+    }


### PR DESCRIPTION
# Summary

Use [vite built-in constant](https://vite.dev/guide/env-and-mode#built-in-constants) to detect build environment rather than accessing `process` directly, since node types are (likely very intentionally) not available.

## How To Test

This should resolve the following error during `yarn build`:

```
src/deprecation.ts:2:3 - error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.

2   process.env.NODE_ENV !== 'production'
    ~~~~~~~
```