### PR TITLE
fix: Minor cleanup in Pagination stories

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Pagination } from './Pagination'
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const pathname = '/test-pathname'
 
@@ -9,25 +9,36 @@ const meta: Meta<typeof Pagination> = {
   component: Pagination,
   args: {
     pathname,
+    currentPage: 1,
   },
   argTypes: {
-    currentPage: { control: 'number' },
-    maxSlots: { control: 'number' },
-    totalPages: { control: 'number' },
+    currentPage: {
+      control: { type: 'number', min: 1 },
+    },
+    maxSlots: {
+      control: { type: 'number', min: 1 },
+    },
+    totalPages: {
+      control: { type: 'number', min: 1 },
+    },
   },
 }
 export default meta
 type Story = StoryObj<typeof Pagination>
 
-const Template = ({ ...args }) => {
-  const [current, setCurrentPage] = useState<number>(args.currentPage)
+const Template: StoryFn<typeof Pagination> = (args) => {
+  const argPage =
+    args.totalPages !== undefined
+      ? Math.min(args.currentPage, args.totalPages)
+      : args.currentPage
 
-  useEffect(() => {
-    if (args.totalPages && args.currentPage >= args.totalPages) {
-      return
-    }
-    setCurrentPage(args.currentPage)
-  }, [args.currentPage])
+  const [current, setCurrentPage] = useState<number>(argPage)
+
+  const [prevArgPage, setPrevArgPage] = useState(argPage)
+  if (argPage !== prevArgPage) {
+    setPrevArgPage(argPage)
+    setCurrentPage(argPage)
+  }
 
   const handleNext = () => {
     const nextPage = current + 1
@@ -51,7 +62,7 @@ const Template = ({ ...args }) => {
       totalPages={args.totalPages}
       currentPage={current}
       maxSlots={args.maxSlots}
-      pathname={pathname}
+      pathname={args.pathname}
       onClickNext={handleNext}
       onClickPrevious={handlePrevious}
       onClickPageNumber={handlePageNumber}


### PR DESCRIPTION
# Summary
- Fix eslint react-hooks violation "Calling setState synchronously within an effect can trigger cascading renders" by replacing `useEffect` with state updates during render, as described in [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
- Add type to template arguments.
- Set a default `currentPage` arg so that it is never undefined in the template function.
- Set bounds on page arguments to avoid going into negative numbers or exceeding the total number of pages.
- Respect `pathname` arg.

## How To Test

1. The storybook controls for current and total pages should be better bounded now.
1. The hook lint error can be seen by temporarily enabling react-hooks linting:
   ```diff
   diff --git a/eslint.config.cjs b/eslint.config.cjs
   index fa6b8bc..a13ab1c 100644
   --- a/eslint.config.cjs
   +++ b/eslint.config.cjs
   @@ -31,6 +31,7 @@ module.exports = defineConfig([
            'plugin:import/warnings',
            'plugin:import/typescript',
            'plugin:react/recommended',
   +        'plugin:react-hooks/recommended',
            'plugin:jsx-a11y/recommended',
            'plugin:security/recommended-legacy',
            'plugin:storybook/recommended',
   ```


