### PR TITLE
fix: include __mocks__ directory in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
   },
   "include": [
     "src/**/*",
+    "__mocks__/**/*",
     "custom.d.ts",
   ],
 }


### PR DESCRIPTION
This PR adds __mocks__ to tsconfig.json, which should have happened by merging main into the modal test fix that recently merged.