### PR TITLE
fix: Use default tsconfig.json for lint support of focus-trap-react.tsx

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -112,7 +112,10 @@ module.exports = defineConfig([
                 ecmaFeatures: {
                     jsx: true,
                 },
-                projectService: true,
+                projectService: {
+                    allowDefaultProject: ["__mocks__/focus-trap-react.tsx"],
+                    defaultProject: "tsconfig.json",
+                },
                 warnOnUnsupportedTypeScriptVersion: true,
             },
         },


### PR DESCRIPTION
# Summary

Resolve lint configuration error:
```
Parsing error: .../__mocks__/focus-trap-react.tsx was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject
```

Opted for `allowDefaultProject`: https://typescript-eslint.io/packages/parser/#allowdefaultproject

## Related Issues or PRs

https://github.com/trussworks/react-uswds/pull/3335#issuecomment-3564803487

## How To Test

`npx eslint --max-warnings=0 **/*.tsx`