### PR TITLE
fix(alert): make headingLevel optional without heading

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -65,16 +65,16 @@ export const Info: Story = {
 export const Slim: Story = {
   render: () => (
     <>
-      <Alert type="success" headingLevel="h4" slim>
+      <Alert type="success" slim>
         {testText}
       </Alert>
-      <Alert type="warning" headingLevel="h4" slim>
+      <Alert type="warning" slim>
         {testText}
       </Alert>
-      <Alert type="error" headingLevel="h4" slim>
+      <Alert type="error" slim>
         {testText}
       </Alert>
-      <Alert type="info" headingLevel="h4" slim>
+      <Alert type="info" slim>
         {testText}
       </Alert>
     </>
@@ -84,16 +84,16 @@ export const Slim: Story = {
 export const NoIcon: Story = {
   render: () => (
     <>
-      <Alert type="success" headingLevel="h4" noIcon>
+      <Alert type="success" noIcon>
         {testText}
       </Alert>
-      <Alert type="warning" headingLevel="h4" noIcon>
+      <Alert type="warning" noIcon>
         {testText}
       </Alert>
-      <Alert type="error" headingLevel="h4" noIcon>
+      <Alert type="error" noIcon>
         {testText}
       </Alert>
-      <Alert type="info" headingLevel="h4" noIcon>
+      <Alert type="info" noIcon>
         {testText}
       </Alert>
     </>
@@ -103,16 +103,16 @@ export const NoIcon: Story = {
 export const SlimNoIcon: Story = {
   render: () => (
     <>
-      <Alert type="success" headingLevel="h4" slim noIcon>
+      <Alert type="success" slim noIcon>
         {testText}
       </Alert>
-      <Alert type="warning" headingLevel="h4" slim noIcon>
+      <Alert type="warning" slim noIcon>
         {testText}
       </Alert>
-      <Alert type="error" headingLevel="h4" slim noIcon>
+      <Alert type="error" slim noIcon>
         {testText}
       </Alert>
-      <Alert type="info" headingLevel="h4" slim noIcon>
+      <Alert type="info" slim noIcon>
         {testText}
       </Alert>
     </>

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -10,13 +10,13 @@ describe('Alert component', () => {
   })
 
   it('renders without errors', () => {
-    const { queryByTestId } = render(<Alert type="success" headingLevel="h4" />)
+    const { queryByTestId } = render(<Alert type="success" />)
     expect(queryByTestId('alert')).toBeInTheDocument()
   })
 
   it('renders children in <p> tag by default', () => {
     const { queryByTestId } = render(
-      <Alert type="success" headingLevel="h4" className="myClass">
+      <Alert type="success" className="myClass">
         Test children
       </Alert>
     )
@@ -26,7 +26,7 @@ describe('Alert component', () => {
 
   it('renders validation style alert', () => {
     const { queryByTestId } = render(
-      <Alert type="success" validation headingLevel="h4" className="myClass">
+      <Alert type="success" validation className="myClass">
         Test children
       </Alert>
     )
@@ -37,7 +37,7 @@ describe('Alert component', () => {
 
   it('accepts className prop', () => {
     const { queryByTestId } = render(
-      <Alert type="success" headingLevel="h4" className="myClass" />
+      <Alert type="success" className="myClass" />
     )
     expect(queryByTestId('alert')).toHaveClass('myClass')
   })
@@ -71,9 +71,7 @@ describe('Alert component', () => {
   describe('with a CTA', () => {
     it('renders the CTA', () => {
       const testCTA = <button type="button">Click Here</button>
-      const { queryByText } = render(
-        <Alert type="success" headingLevel="h4" cta={testCTA} />
-      )
+      const { queryByText } = render(<Alert type="success" cta={testCTA} />)
       expect(queryByText('Click Here')).toBeInTheDocument()
     })
   })

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -5,16 +5,28 @@ import { HeadingLevel } from '../../types/headingLevel'
 
 import styles from './Alert.module.scss'
 
-export type AlertProps = {
+type AlertBaseProps = {
   type: 'success' | 'warning' | 'error' | 'info'
-  heading?: React.ReactNode
-  headingLevel: HeadingLevel
   children?: React.ReactNode
   cta?: React.ReactNode
   slim?: boolean
   noIcon?: boolean
   validation?: boolean
-} & React.HTMLAttributes<HTMLDivElement>
+}
+
+type AlertWithHeadingProps = {
+  heading: React.ReactNode
+  headingLevel: HeadingLevel
+}
+
+type AlertWithoutHeadingProps = {
+  heading?: undefined
+  headingLevel?: HeadingLevel
+}
+
+export type AlertProps = AlertBaseProps &
+  (AlertWithHeadingProps | AlertWithoutHeadingProps) &
+  React.HTMLAttributes<HTMLDivElement>
 
 export const Alert = ({
   type,
@@ -43,7 +55,7 @@ export const Alert = ({
     className
   )
 
-  const Heading = headingLevel
+  const Heading = headingLevel ?? 'h4'
 
   return (
     <div className={classes} data-testid="alert" {...props}>


### PR DESCRIPTION
# Summary

Make `Alert` require `headingLevel` only when a `heading` is provided. Headingless alerts already render with the component's default heading level internally, so consumers should not need to pass a heading level for alerts that do not render a heading.

The stories and tests now cover headingless alerts without `headingLevel`, matching the intended public API.

## Related Issues or PRs

Closes #3244

## How To Test

- `corepack yarn vitest --run src/components/Alert/Alert.test.tsx`
- `corepack yarn tsc --noEmit`

## Screenshots (optional)

N/A

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)