### PR TITLE
fix(a11y): Set Pagination's last page aria-label to indicate that it is the last page

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -4,16 +4,15 @@ import React from 'react'
 import { Pagination } from './Pagination'
 
 describe('Pagination component', () => {
-  const testPages = 24
-  const testThreePages = 3
-  const testSevenPages = 7
+  const totalPages = 24
   const testPathname = '/test-pathname'
 
   it('renders pagination for a list of pages', () => {
+    const currentPageNumber = 10
     render(
       <Pagination
-        totalPages={testPages}
-        currentPage={10}
+        totalPages={totalPages}
+        currentPage={currentPageNumber}
         pathname={testPathname}
       />
     )
@@ -31,21 +30,22 @@ describe('Pagination component', () => {
       'href',
       `${testPathname}?page=9`
     )
-    expect(screen.getByLabelText('Page 10')).toHaveAttribute(
+    const currentPage = screen.getByLabelText(`Page ${currentPageNumber}`)
+    expect(currentPage).toHaveAttribute(
       'href',
-      `${testPathname}?page=10`
+      `${testPathname}?page=${currentPageNumber}`
     )
-    expect(screen.getByLabelText('Page 10')).toHaveAttribute(
-      'aria-current',
-      'page'
-    )
+    expect(currentPage).toHaveAttribute('aria-current', 'page')
+
     expect(screen.getByLabelText('Page 11')).toHaveAttribute(
       'href',
       `${testPathname}?page=11`
     )
-    expect(screen.getByLabelText('Page 24')).toHaveAttribute(
+
+    const lastPage = screen.getByLabelText(`Last page, page ${totalPages}`)
+    expect(lastPage).toHaveAttribute(
       'href',
-      `${testPathname}?page=24`
+      `${testPathname}?page=${totalPages}`
     )
     expect(screen.getByLabelText('Next page')).toHaveAttribute(
       'href',
@@ -56,7 +56,7 @@ describe('Pagination component', () => {
   it('only renders the maximum number of slots', () => {
     render(
       <Pagination
-        totalPages={testPages}
+        totalPages={totalPages}
         currentPage={10}
         pathname={testPathname}
       />
@@ -67,7 +67,7 @@ describe('Pagination component', () => {
   it('renders pagination when the first page is current', () => {
     render(
       <Pagination
-        totalPages={testPages}
+        totalPages={totalPages}
         currentPage={1}
         pathname={testPathname}
       />
@@ -83,24 +83,25 @@ describe('Pagination component', () => {
   it('renders pagination when the last page is current', () => {
     render(
       <Pagination
-        totalPages={testPages}
+        totalPages={totalPages}
         currentPage={24}
         pathname={testPathname}
       />
     )
     expect(screen.queryByLabelText('Previous page')).toBeInTheDocument()
     expect(screen.queryByLabelText('Next page')).not.toBeInTheDocument()
-    expect(screen.getByLabelText('Page 24')).toHaveAttribute(
+    expect(screen.getByLabelText('Last page, page 24')).toHaveAttribute(
       'aria-current',
       'page'
     )
   })
 
   it('renders overflow at the beginning and end when current page is in the middle', () => {
+    const currentPageNumber = 10
     render(
       <Pagination
-        totalPages={testPages}
-        currentPage={10}
+        totalPages={totalPages}
+        currentPage={currentPageNumber}
         pathname={testPathname}
       />
     )
@@ -116,21 +117,20 @@ describe('Pagination component', () => {
       'href',
       `${testPathname}?page=9`
     )
-    expect(screen.getByLabelText('Page 10')).toHaveAttribute(
+    const currentPage = screen.getByLabelText(`Page ${currentPageNumber}`)
+    expect(currentPage).toHaveAttribute(
       'href',
-      `${testPathname}?page=10`
+      `${testPathname}?page=${currentPageNumber}`
     )
-    expect(screen.getByLabelText('Page 10')).toHaveAttribute(
-      'aria-current',
-      'page'
-    )
+    expect(currentPage).toHaveAttribute('aria-current', 'page')
     expect(screen.getByLabelText('Page 11')).toHaveAttribute(
       'href',
       `${testPathname}?page=11`
     )
-    expect(screen.getByLabelText('Page 24')).toHaveAttribute(
+    const lastPage = screen.getByLabelText(`Last page, page ${totalPages}`)
+    expect(lastPage).toHaveAttribute(
       'href',
-      `${testPathname}?page=24`
+      `${testPathname}?page=${totalPages}`
     )
     expect(screen.getByLabelText('Next page')).toHaveAttribute(
       'href',
@@ -142,7 +142,7 @@ describe('Pagination component', () => {
   it('renders overflow at the end when at the beginning of the pages', () => {
     render(
       <Pagination
-        totalPages={testPages}
+        totalPages={totalPages}
         currentPage={3}
         pathname={testPathname}
       />
@@ -176,9 +176,10 @@ describe('Pagination component', () => {
       'href',
       `${testPathname}?page=5`
     )
-    expect(screen.getByLabelText('Page 24')).toHaveAttribute(
+    const lastPage = screen.getByLabelText(`Last page, page ${totalPages}`)
+    expect(lastPage).toHaveAttribute(
       'href',
-      `${testPathname}?page=24`
+      `${testPathname}?page=${totalPages}`
     )
     expect(screen.getByLabelText('Next page')).toHaveAttribute(
       'href',
@@ -190,7 +191,7 @@ describe('Pagination component', () => {
   it('renders overflow at the beginning when at the end of the pages', () => {
     render(
       <Pagination
-        totalPages={testPages}
+        totalPages={totalPages}
         currentPage={21}
         pathname={testPathname}
       />
@@ -224,9 +225,10 @@ describe('Pagination component', () => {
       'href',
       `${testPathname}?page=23`
     )
-    expect(screen.getByLabelText('Page 24')).toHaveAttribute(
+    const lastPage = screen.getByLabelText(`Last page, page ${totalPages}`)
+    expect(lastPage).toHaveAttribute(
       'href',
-      `${testPathname}?page=24`
+      `${testPathname}?page=${totalPages}`
     )
     expect(screen.getByLabelText('Next page')).toHaveAttribute(
       'href',
@@ -242,6 +244,7 @@ describe('Pagination component', () => {
       'href',
       `${testPathname}?page=${randomPage + 1}`
     )
+    expect(screen.queryByLabelText(/^Last page, page/)).not.toBeInTheDocument()
   })
 
   it('can click onClickNext, onClickPrevious and onClickPagenumber', () => {
@@ -251,7 +254,7 @@ describe('Pagination component', () => {
 
     const { getByTestId, getAllByTestId } = render(
       <Pagination
-        totalPages={testPages}
+        totalPages={totalPages}
         currentPage={21}
         pathname={testPathname}
         onClickPrevious={mockOnClickPrevious}
@@ -274,11 +277,7 @@ describe('Pagination component', () => {
   describe('for fewer pages than the max slots', () => {
     it('renders pagination with no overflow 1', () => {
       render(
-        <Pagination
-          totalPages={testThreePages}
-          currentPage={2}
-          pathname={testPathname}
-        />
+        <Pagination totalPages={3} currentPage={2} pathname={testPathname} />
       )
       expect(screen.getAllByRole('listitem')).toHaveLength(5)
       expect(screen.queryAllByText('…')).toHaveLength(0)
@@ -286,11 +285,7 @@ describe('Pagination component', () => {
 
     it('renders pagination with no overflow 2', () => {
       render(
-        <Pagination
-          totalPages={testSevenPages}
-          currentPage={4}
-          pathname={testPathname}
-        />
+        <Pagination totalPages={7} currentPage={4} pathname={testPathname} />
       )
       expect(screen.getAllByRole('listitem')).toHaveLength(9)
       expect(screen.queryAllByText('…')).toHaveLength(0)
@@ -301,7 +296,7 @@ describe('Pagination component', () => {
     it('only renders the maximum number of slots', () => {
       render(
         <Pagination
-          totalPages={testPages}
+          totalPages={totalPages}
           currentPage={10}
           pathname={testPathname}
           maxSlots={10}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -20,6 +20,7 @@ type PaginationPageProps = {
   pathname: string
   page: number
   isCurrent?: boolean
+  isLastPage: boolean
   onClickPageNumber?: (
     event: React.MouseEvent<HTMLButtonElement>,
     page: number
@@ -28,6 +29,7 @@ type PaginationPageProps = {
 const PaginationPage = ({
   page,
   isCurrent,
+  isLastPage,
   pathname,
   onClickPageNumber,
 }: PaginationPageProps) => {
@@ -41,6 +43,9 @@ const PaginationPage = ({
     'text-underline'
   )
 
+  const ariaLabel = isLastPage ? `Last page, page ${page}` : `Page ${page}`
+  const ariaCurrent = isCurrent ? 'page' : undefined
+
   return (
     <li
       key={`pagination_page_${page}`}
@@ -50,8 +55,8 @@ const PaginationPage = ({
           type="button"
           data-testid="pagination-page-number"
           className={buttonClasses}
-          aria-label={`Page ${page}`}
-          aria-current={isCurrent ? 'page' : undefined}
+          aria-label={ariaLabel}
+          aria-current={ariaCurrent}
           onClick={(event) => {
             onClickPageNumber(event, page)
           }}>
@@ -61,8 +66,8 @@ const PaginationPage = ({
         <Link
           href={`${pathname}?page=${page}`}
           className={linkClasses}
-          aria-label={`Page ${page}`}
-          aria-current={isCurrent ? 'page' : undefined}>
+          aria-label={ariaLabel}
+          aria-current={ariaCurrent}>
           {page}
         </Link>
       )}
@@ -227,6 +232,7 @@ export const Pagination = ({
               page={pageNum}
               pathname={pathname}
               isCurrent={pageNum === currentPage}
+              isLastPage={totalPages !== undefined && pageNum === totalPages}
               onClickPageNumber={onClickPageNumber}
             />
           )

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -19,7 +19,7 @@ export type PaginationProps = {
 type PaginationPageProps = {
   pathname: string
   page: number
-  isCurrent?: boolean
+  isCurrent: boolean
   isLastPage: boolean
   onClickPageNumber?: (
     event: React.MouseEvent<HTMLButtonElement>,

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -16,12 +16,7 @@ export type PaginationProps = {
   ) => void
 } & JSX.IntrinsicElements['nav']
 
-const PaginationPage = ({
-  page,
-  isCurrent,
-  pathname,
-  onClickPageNumber,
-}: {
+type PaginationPageProps = {
   pathname: string
   page: number
   isCurrent?: boolean
@@ -29,7 +24,13 @@ const PaginationPage = ({
     event: React.MouseEvent<HTMLButtonElement>,
     page: number
   ) => void
-}) => {
+}
+const PaginationPage = ({
+  page,
+  isCurrent,
+  pathname,
+  onClickPageNumber,
+}: PaginationPageProps) => {
   const linkClasses = classnames('usa-pagination__button', {
     'usa-current': isCurrent,
   })


### PR DESCRIPTION
# Summary

Sets the aria-label of the last page to `Last page, page ${the_page_number}`

Side note: This component could use a lot of TLC to make it usable with a translation framework. I did not help with that in this PR, but will create an issue for the backlog.

## Related Issues or PRs

closes: https://github.com/trussworks/react-uswds/issues/3093

## How To Test

- Unit tests confirm this behavior
- Can also verify in storybook on this branch

## Screenshots (optional)

<img width="227" height="465" alt="image" src="https://github.com/user-attachments/assets/6836783e-32be-4cce-80d1-26d07bcc517d" />

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
