### PR TITLE
feat: Add 24h view for time picker

### DIFF
--- a/src/components/forms/TimePicker/TimePicker.stories.tsx
+++ b/src/components/forms/TimePicker/TimePicker.stories.tsx
@@ -47,6 +47,10 @@ export const WithMinAndMaxTimes: Story = {
   args: { hint: recommendedHintText, minTime: '9:00', maxTime: '17:00' },
 }
 
+export const With24HourFormat: Story = {
+  args: { hint: recommendedHintText, format: '24h' },
+}
+
 export const WithDefaultValue: Story = {
   args: { hint: recommendedHintText, defaultValue: '12:00' },
 }

--- a/src/components/forms/TimePicker/TimePicker.test.tsx
+++ b/src/components/forms/TimePicker/TimePicker.test.tsx
@@ -44,7 +44,7 @@ describe('TimePicker Component', () => {
     expect(comboBoxDropdownList.children.length).toEqual(7)
   })
 
-  it('displays military time labels without am/pm when format is 24h', () => {
+  it('displays 24 hour time labels without am/pm when format is 24h', () => {
     const { getByTestId } = render(
       <TimePicker
         {...testProps}
@@ -76,9 +76,7 @@ describe('TimePicker Component', () => {
     // A single minute digit picks the matching half hour
     await userEvent.type(comboBoxTextInput, '21:0')
     expect(ninePm).toHaveClass('usa-combo-box__list-option--focused')
-    expect(ninethirtyPm).not.toHaveClass(
-      'usa-combo-box__list-option--focused'
-    )
+    expect(ninethirtyPm).not.toHaveClass('usa-combo-box__list-option--focused')
 
     await userEvent.clear(comboBoxTextInput)
     await userEvent.type(comboBoxTextInput, '21:3')

--- a/src/components/forms/TimePicker/TimePicker.test.tsx
+++ b/src/components/forms/TimePicker/TimePicker.test.tsx
@@ -44,6 +44,67 @@ describe('TimePicker Component', () => {
     expect(comboBoxDropdownList.children.length).toEqual(7)
   })
 
+  it('displays military time labels without am/pm when format is 24h', () => {
+    const { getByTestId } = render(
+      <TimePicker
+        {...testProps}
+        format="24h"
+        minTime="12:00"
+        maxTime="14:00"
+        step={60}
+      />
+    )
+
+    const comboBoxDropdownList = getByTestId('combo-box-option-list')
+    expect(within(comboBoxDropdownList).getByText('12:00')).toBeInTheDocument()
+    expect(within(comboBoxDropdownList).getByText('13:00')).toBeInTheDocument()
+    expect(within(comboBoxDropdownList).getByText('14:00')).toBeInTheDocument()
+    expect(
+      within(comboBoxDropdownList).queryByText(/am|pm/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('filters on the minute as soon as a colon and digit are typed in 24h format', async () => {
+    const { getByTestId } = render(<TimePicker {...testProps} format="24h" />)
+
+    const comboBoxTextInput = getByTestId('combo-box-input')
+    const ninePm = getByTestId('combo-box-option-21:00')
+    const ninethirtyPm = getByTestId('combo-box-option-21:30')
+
+    await userEvent.click(comboBoxTextInput)
+
+    // A single minute digit picks the matching half hour
+    await userEvent.type(comboBoxTextInput, '21:0')
+    expect(ninePm).toHaveClass('usa-combo-box__list-option--focused')
+    expect(ninethirtyPm).not.toHaveClass(
+      'usa-combo-box__list-option--focused'
+    )
+
+    await userEvent.clear(comboBoxTextInput)
+    await userEvent.type(comboBoxTextInput, '21:3')
+    expect(ninethirtyPm).toHaveClass('usa-combo-box__list-option--focused')
+    expect(ninePm).not.toHaveClass('usa-combo-box__list-option--focused')
+  })
+
+  it('filters midnight and tolerates a leading zero in 24h format', async () => {
+    const { getByTestId } = render(<TimePicker {...testProps} format="24h" />)
+
+    const comboBoxTextInput = getByTestId('combo-box-input')
+    const midnight = getByTestId('combo-box-option-00:00')
+    const nineAm = getByTestId('combo-box-option-09:00')
+
+    await userEvent.click(comboBoxTextInput)
+
+    // A single "0" focuses midnight
+    await userEvent.type(comboBoxTextInput, '0')
+    expect(midnight).toHaveClass('usa-combo-box__list-option--focused')
+
+    // A single-digit hour still matches its zero-padded option
+    await userEvent.clear(comboBoxTextInput)
+    await userEvent.type(comboBoxTextInput, '9')
+    expect(nineAm).toHaveClass('usa-combo-box__list-option--focused')
+  })
+
   it('renders a label', () => {
     const { queryByText } = render(
       <TimePicker {...testProps} label="test label" />

--- a/src/components/forms/TimePicker/TimePicker.tsx
+++ b/src/components/forms/TimePicker/TimePicker.tsx
@@ -29,7 +29,7 @@ type BaseTimePickerProps = {
   minTime?: string
   maxTime?: string
   step?: number
-  /** Display times in 12-hour (e.g. "1:00pm") or 24-hour military format (e.g. "13:00"). Defaults to "12h". */
+  /** Display times in 12-hour (e.g. "1:00pm") or 24-hour format (e.g. "13:00"). Defaults to "12h". */
   format?: TimePickerFormat
   /** Recommended text: "Select a time from the dropdown. Type into the input to filter options." */
   hint?: string

--- a/src/components/forms/TimePicker/TimePicker.tsx
+++ b/src/components/forms/TimePicker/TimePicker.tsx
@@ -10,9 +10,14 @@ import {
   DEFAULT_MIN_TIME,
   DEFAULT_MIN_TIME_MINUTES,
   DEFAULT_STEP,
+  DEFAULT_TIME_FORMAT,
   MIN_STEP,
   TIME_PICKER_CUSTOM_FILTER,
+  TIME_PICKER_CUSTOM_FILTER_24H,
+  TimePickerFormat,
 } from './constants'
+
+export type { TimePickerFormat }
 
 type BaseTimePickerProps = {
   id: string
@@ -24,6 +29,8 @@ type BaseTimePickerProps = {
   minTime?: string
   maxTime?: string
   step?: number
+  /** Display times in 12-hour (e.g. "1:00pm") or 24-hour military format (e.g. "13:00"). Defaults to "12h". */
+  format?: TimePickerFormat
   /** Recommended text: "Select a time from the dropdown. Type into the input to filter options." */
   hint?: string
   className?: string
@@ -42,6 +49,7 @@ export const TimePicker = ({
   minTime = DEFAULT_MIN_TIME,
   maxTime = DEFAULT_MAX_TIME,
   step = DEFAULT_STEP,
+  format = DEFAULT_TIME_FORMAT,
   hint,
   className,
 }: TimePickerProps): JSX.Element => {
@@ -51,9 +59,12 @@ export const TimePicker = ({
   const parsedMaxTime = parseTimeString(maxTime) || DEFAULT_MAX_TIME_MINUTES
   const validStep = step < MIN_STEP ? MIN_STEP : step
   const timeOptions = useMemo(
-    () => getTimeOptions(parsedMinTime, parsedMaxTime, validStep),
-    [minTime, maxTime, step]
+    () => getTimeOptions(parsedMinTime, parsedMaxTime, validStep, format),
+    [minTime, maxTime, step, format]
   )
+
+  const customFilter =
+    format === '24h' ? TIME_PICKER_CUSTOM_FILTER_24H : TIME_PICKER_CUSTOM_FILTER
 
   const labelId = `${name}-label`
   const hintId = `${name}-hint`
@@ -76,7 +87,7 @@ export const TimePicker = ({
         defaultValue={defaultValue}
         options={timeOptions}
         disabled={disabled}
-        customFilter={TIME_PICKER_CUSTOM_FILTER}
+        customFilter={customFilter}
         disableFiltering
       />
     </FormGroup>

--- a/src/components/forms/TimePicker/TimePicker.tsx
+++ b/src/components/forms/TimePicker/TimePicker.tsx
@@ -14,10 +14,9 @@ import {
   MIN_STEP,
   TIME_PICKER_CUSTOM_FILTER,
   TIME_PICKER_CUSTOM_FILTER_24H,
-  TimePickerFormat,
 } from './constants'
 
-export type { TimePickerFormat }
+export type TimePickerFormat = '12h' | '24h'
 
 type BaseTimePickerProps = {
   id: string
@@ -29,7 +28,6 @@ type BaseTimePickerProps = {
   minTime?: string
   maxTime?: string
   step?: number
-  /** Display times in 12-hour (e.g. "1:00pm") or 24-hour format (e.g. "13:00"). Defaults to "12h". */
   format?: TimePickerFormat
   /** Recommended text: "Select a time from the dropdown. Type into the input to filter options." */
   hint?: string

--- a/src/components/forms/TimePicker/constants.ts
+++ b/src/components/forms/TimePicker/constants.ts
@@ -1,5 +1,8 @@
 import { CustomizableFilter } from '../ComboBox/ComboBox'
 
+export type TimePickerFormat = '12h' | '24h'
+
+export const DEFAULT_TIME_FORMAT: TimePickerFormat = '12h'
 export const DEFAULT_MAX_TIME = '23:59'
 export const DEFAULT_MAX_TIME_MINUTES = 24 * 60 - 1
 export const DEFAULT_MIN_TIME = '00:00'
@@ -13,6 +16,14 @@ export const TIME_PICKER_CUSTOM_FILTER: CustomizableFilter = {
   extras: {
     apQueryFilter: '([ap])',
     hourQueryFilter: '([1-9][0-2]?)',
+    minuteQueryFilter: '[\\d]+:([0-9]{0,2})',
+  },
+}
+
+export const TIME_PICKER_CUSTOM_FILTER_24H: CustomizableFilter = {
+  filter: '0?{{ hourQueryFilter }}:{{ minuteQueryFilter }}.*',
+  extras: {
+    hourQueryFilter: '([0-9]{1,2})',
     minuteQueryFilter: '[\\d]+:([0-9]{0,2})',
   },
 }

--- a/src/components/forms/TimePicker/constants.ts
+++ b/src/components/forms/TimePicker/constants.ts
@@ -1,6 +1,5 @@
 import { CustomizableFilter } from '../ComboBox/ComboBox'
-
-export type TimePickerFormat = '12h' | '24h'
+import type { TimePickerFormat } from './TimePicker'
 
 export const DEFAULT_TIME_FORMAT: TimePickerFormat = '12h'
 export const DEFAULT_MAX_TIME = '23:59'

--- a/src/components/forms/TimePicker/utils.test.ts
+++ b/src/components/forms/TimePicker/utils.test.ts
@@ -209,6 +209,25 @@ describe('getTimeOptions', () => {
     ])
   })
 
+  it('returns military time labels without am/pm when format is 24h', () => {
+    const nineAM = parseTimeString('09:00') as number
+    const fivePM = parseTimeString('17:00') as number
+    const oneHourInMinutes = 60
+    const timeOptions = getTimeOptions(nineAM, fivePM, oneHourInMinutes, '24h')
+
+    expect(timeOptions).toEqual([
+      { value: '09:00', label: '09:00' },
+      { value: '10:00', label: '10:00' },
+      { value: '11:00', label: '11:00' },
+      { value: '12:00', label: '12:00' },
+      { value: '13:00', label: '13:00' },
+      { value: '14:00', label: '14:00' },
+      { value: '15:00', label: '15:00' },
+      { value: '16:00', label: '16:00' },
+      { value: '17:00', label: '17:00' },
+    ])
+  })
+
   it('returns the expected list of times options with a custom step size', () => {
     const fourHoursInMinutes = 4 * 60
     const timeOptions = getTimeOptions(
@@ -242,6 +261,26 @@ describe('getTimeOptions', () => {
         value: '20:00',
         label: '8:00pm',
       },
+    ])
+  })
+
+  it('returns 24 hour formatted labels when format is 24', () => {
+    const nineAM = parseTimeString('09:00') as number
+    const sixPM = parseTimeString('18:00') as number
+    const oneHourInMinutes = 60
+    const timeOptions = getTimeOptions(nineAM, sixPM, oneHourInMinutes, '24h')
+
+    expect(timeOptions).toEqual([
+      { value: '09:00', label: '09:00' },
+      { value: '10:00', label: '10:00' },
+      { value: '11:00', label: '11:00' },
+      { value: '12:00', label: '12:00' },
+      { value: '13:00', label: '13:00' },
+      { value: '14:00', label: '14:00' },
+      { value: '15:00', label: '15:00' },
+      { value: '16:00', label: '16:00' },
+      { value: '17:00', label: '17:00' },
+      { value: '18:00', label: '18:00' },
     ])
   })
 

--- a/src/components/forms/TimePicker/utils.ts
+++ b/src/components/forms/TimePicker/utils.ts
@@ -1,4 +1,5 @@
 import { ComboBoxOption } from '../ComboBox/ComboBox'
+import type { TimePickerFormat } from './TimePicker'
 
 /**
  * Parse a string of hh:mm into minutes
@@ -53,7 +54,8 @@ const padZeros = (value: number, length: number): string => {
 export const getTimeOptions = (
   minTimeMinutes: number,
   maxTimeMinutes: number,
-  step: number
+  step: number,
+  format: TimePickerFormat = '12h'
 ): ComboBoxOption[] => {
   const timeOptions: ComboBoxOption[] = []
 
@@ -63,10 +65,12 @@ export const getTimeOptions = (
     minutes += step
   ) {
     const { minute, hour24, hour12, ampm } = getTimeContext(minutes)
+    const value = `${padZeros(hour24, 2)}:${padZeros(minute, 2)}`
 
     timeOptions.push({
-      value: `${padZeros(hour24, 2)}:${padZeros(minute, 2)}`,
-      label: `${hour12}:${padZeros(minute, 2)}${ampm}`,
+      value,
+      label:
+        format === '24h' ? value : `${hour12}:${padZeros(minute, 2)}${ampm}`,
     })
   }
 

--- a/src/components/forms/TimePicker/utils.ts
+++ b/src/components/forms/TimePicker/utils.ts
@@ -66,11 +66,12 @@ export const getTimeOptions = (
   ) {
     const { minute, hour24, hour12, ampm } = getTimeContext(minutes)
     const value = `${padZeros(hour24, 2)}:${padZeros(minute, 2)}`
+    const label =
+      format === '24h' ? value : `${hour12}:${padZeros(minute, 2)}${ampm}`
 
     timeOptions.push({
       value,
-      label:
-        format === '24h' ? value : `${hour12}:${padZeros(minute, 2)}${ampm}`,
+      label,
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,10 @@ export type { TextInputProps } from './components/forms/TextInput/TextInput'
 export { TextInputMask } from './components/forms/TextInputMask/TextInputMask'
 export type { TextInputMaskProps } from './components/forms/TextInputMask/TextInputMask'
 export { TimePicker } from './components/forms/TimePicker/TimePicker'
-export type { TimePickerProps } from './components/forms/TimePicker/TimePicker'
+export type {
+  TimePickerProps,
+  TimePickerFormat,
+} from './components/forms/TimePicker/TimePicker'
 export { ValidationChecklist } from './components/forms/Validation/ValidationChecklist'
 export type { ValidationChecklistProps } from './components/forms/Validation/ValidationChecklist'
 export { ValidationItem } from './components/forms/Validation/ValidationItem'


### PR DESCRIPTION
# Summary

<!-- (Optional) Additional details describing the proposed changes -->
Adds optional property to enable military time

## Related Issues or PRs

<!-- Link existing Github issue(s), e.g. closes #123 -->
#2947

## How To Test

Look at time picker in storybook and review the 24h option.

## Screenshots (optional)
<img width="1040" height="258" alt="image" src="https://github.com/user-attachments/assets/c02ce613-4b4f-44eb-a8c1-5142c9ea6b36" />


## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
