### PR TITLE
chore: add ronaktruss as a contributor for maintenance

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,9 +3,7 @@
   "projectOwner": "trussworks",
   "repoType": "github",
   "repoHost": "https://github.com",
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 100,
   "commit": true,
   "contributors": [
@@ -14,453 +12,326 @@
       "name": "Suzanne Rozier",
       "avatar_url": "https://avatars.githubusercontent.com/u/2723066?v=4",
       "profile": "https://github.com/suzubara",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "haworku",
       "name": "haworku",
       "avatar_url": "https://avatars.githubusercontent.com/u/10750442?v=4",
       "profile": "https://github.com/haworku",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "ahobson",
       "name": "Andrew Hobson",
       "avatar_url": "https://avatars.githubusercontent.com/u/21983?v=4",
       "profile": "https://github.com/ahobson",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "gidjin",
       "name": "John Gedeon",
       "avatar_url": "https://avatars.githubusercontent.com/u/940173?v=4",
       "profile": "https://github.com/gidjin",
-      "contributions": [
-        "code",
-        "maintenance"
-      ]
+      "contributions": ["code", "maintenance"]
     },
     {
       "login": "eamahanna",
       "name": "Emily Mahanna",
       "avatar_url": "https://avatars.githubusercontent.com/u/56279459?v=4",
       "profile": "https://github.com/eamahanna",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "brandonlenz",
       "name": "Brandon Lenz",
       "avatar_url": "https://avatars.githubusercontent.com/u/15805554?v=4",
       "profile": "https://github.com/brandonlenz",
-      "contributions": [
-        "code",
-        "doc",
-        "maintenance",
-        "bug"
-      ]
+      "contributions": ["code", "doc", "maintenance", "bug"]
     },
     {
       "login": "sojeri",
       "name": "Jeri Sommers",
       "avatar_url": "https://avatars.githubusercontent.com/u/10818509?v=4",
       "profile": "https://github.com/sojeri",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "tinyels",
       "name": "Erin Stanfill",
       "avatar_url": "https://avatars.githubusercontent.com/u/3142631?v=4",
       "profile": "https://github.com/tinyels",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "esacteksab",
       "name": "Barry Morrison",
       "avatar_url": "https://avatars.githubusercontent.com/u/689591?v=4",
       "profile": "http://www.barrymorrison.com/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "duncan-truss",
       "name": "Duncan",
       "avatar_url": "https://avatars.githubusercontent.com/u/52669884?v=4",
       "profile": "https://github.com/duncan-truss",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "SirenaBorracha",
       "name": "Arianna Kellogg",
       "avatar_url": "https://avatars.githubusercontent.com/u/16230705?v=4",
       "profile": "https://github.com/SirenaBorracha",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "christopherhuii",
       "name": "Christopher Hui",
       "avatar_url": "https://avatars.githubusercontent.com/u/8367504?v=4",
       "profile": "https://github.com/christopherhuii",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "jim",
       "name": "Jim Benton",
       "avatar_url": "https://avatars.githubusercontent.com/u/3331?v=4",
       "profile": "http://pandasguide.com/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "jenbutongit",
       "name": "Jen Duong",
       "avatar_url": "https://avatars.githubusercontent.com/u/22080510?v=4",
       "profile": "https://github.com/jenbutongit",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "kimallen",
       "name": "Kim Allen",
       "avatar_url": "https://avatars.githubusercontent.com/u/13249580?v=4",
       "profile": "https://github.com/kimallen",
-      "contributions": [
-        "code",
-        "a11y"
-      ]
+      "contributions": ["code", "a11y"]
     },
     {
       "login": "kylehilltruss",
       "name": "Kyle Hill",
       "avatar_url": "https://avatars.githubusercontent.com/u/83614364?v=4",
       "profile": "https://github.com/kylehilltruss",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "rswerve",
       "name": "Mazdak Atighi",
       "avatar_url": "https://avatars.githubusercontent.com/u/8964335?v=4",
       "profile": "https://github.com/rswerve",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "hgarfinkle",
       "name": "Helen Garfinkle",
       "avatar_url": "https://avatars.githubusercontent.com/u/7664177?v=4",
       "profile": "https://github.com/hgarfinkle",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "rogeruiz",
       "name": "Roger Steve Ruiz",
       "avatar_url": "https://avatars.githubusercontent.com/u/706004?v=4",
       "profile": "https://github.com/rogeruiz",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "lpsinger",
       "name": "Leo Singer",
       "avatar_url": "https://avatars.githubusercontent.com/u/728407?v=4",
       "profile": "https://github.com/lpsinger",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "Shkeating",
       "name": "Shauna Keating",
       "avatar_url": "https://avatars.githubusercontent.com/u/59394696?v=4",
       "profile": "https://github.com/Shkeating",
-      "contributions": [
-        "a11y",
-        "code"
-      ]
+      "contributions": ["a11y", "code"]
     },
     {
       "login": "jcbcapps",
       "name": "Jacob Capps",
       "avatar_url": "https://avatars.githubusercontent.com/u/99674188?v=4",
       "profile": "https://github.com/jcbcapps",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "pearl-truss",
       "name": "pearl-truss",
       "avatar_url": "https://avatars.githubusercontent.com/u/67110378?v=4",
       "profile": "https://github.com/pearl-truss",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "werdnanoslen",
       "name": "Andrew Nelson",
       "avatar_url": "https://avatars.githubusercontent.com/u/764090?v=4",
       "profile": "https://andyhub.com/",
-      "contributions": [
-        "code",
-        "doc",
-        "maintenance",
-        "bug",
-        "a11y"
-      ]
+      "contributions": ["code", "doc", "maintenance", "bug", "a11y"]
     },
     {
       "login": "sawyerh",
       "name": "Sawyer Hollenshead",
       "avatar_url": "https://avatars.githubusercontent.com/u/371943?v=4",
       "profile": "https://sawyer.soy",
-      "contributions": [
-        "code",
-        "bug"
-      ]
+      "contributions": ["code", "bug"]
     },
     {
       "login": "rpdelaney",
       "name": "Ryan Delaney",
       "avatar_url": "https://avatars.githubusercontent.com/u/1139517?v=4",
       "profile": "https://keybase.io/rpdelaney",
-      "contributions": [
-        "maintenance",
-        "infra"
-      ]
+      "contributions": ["maintenance", "infra"]
     },
     {
       "login": "AnnaGingle",
       "name": "Anna Gingle",
       "avatar_url": "https://avatars.githubusercontent.com/u/48488699?v=4",
       "profile": "https://github.com/AnnaGingle",
-      "contributions": [
-        "design",
-        "code"
-      ]
+      "contributions": ["design", "code"]
     },
     {
       "login": "aybeedee",
       "name": "Abdullah Umer",
       "avatar_url": "https://avatars.githubusercontent.com/u/75930195?v=4",
       "profile": "https://github.com/aybeedee",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "m7adeel",
       "name": "Muhammad Adeel",
       "avatar_url": "https://avatars.githubusercontent.com/u/87698014?v=4",
       "profile": "https://github.com/m7adeel",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "vinodkv2511",
       "name": "Vinod Krishna Vellampalli",
       "avatar_url": "https://avatars.githubusercontent.com/u/44632502?v=4",
       "profile": "https://github.com/vinodkv2511",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "kleinschmidtj",
       "name": "Joe Kleinschmidt",
       "avatar_url": "https://avatars.githubusercontent.com/u/57681819?v=4",
       "profile": "https://joeforyou.xyz",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "jhancock532",
       "name": "James Hancock",
       "avatar_url": "https://avatars.githubusercontent.com/u/18164832?v=4",
       "profile": "https://jhancock532.github.io/",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "jpandersen87",
       "name": "Joseph Andersen",
       "avatar_url": "https://avatars.githubusercontent.com/u/12385932?v=4",
       "profile": "https://github.com/jpandersen87",
-      "contributions": [
-        "code",
-        "maintenance",
-        "infra"
-      ]
+      "contributions": ["code", "maintenance", "infra"]
     },
     {
       "login": "crwallace",
       "name": "Courtney Eimerman-Wallace",
       "avatar_url": "https://avatars.githubusercontent.com/u/3453669?v=4",
       "profile": "https://github.com/crwallace",
-      "contributions": [
-        "maintenance"
-      ]
+      "contributions": ["maintenance"]
     },
     {
       "login": "ocoutts-usds",
       "name": "Owen Coutts",
       "avatar_url": "https://avatars.githubusercontent.com/u/174364898?v=4",
       "profile": "https://github.com/ocoutts-usds",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "ajfarkas",
       "name": "AJ Farkas",
       "avatar_url": "https://avatars.githubusercontent.com/u/7841661?v=4",
       "profile": "http://github.com/ajfarkas",
-      "contributions": [
-        "code",
-        "maintenance",
-        "review"
-      ]
+      "contributions": ["code", "maintenance", "review"]
     },
     {
       "login": "lea-m-truss",
       "name": "Lea Melendez",
       "avatar_url": "https://avatars.githubusercontent.com/u/202806705?v=4",
       "profile": "https://github.com/lea-m-truss",
-      "contributions": [
-        "bug",
-        "code",
-        "maintenance",
-        "review"
-      ]
+      "contributions": ["bug", "code", "maintenance", "review"]
     },
     {
       "login": "aligg",
       "name": "Ali",
       "avatar_url": "https://avatars.githubusercontent.com/u/7331495?v=4",
       "profile": "http://aliglenesk.dev",
-      "contributions": [
-        "code",
-        "maintenance"
-      ]
+      "contributions": ["code", "maintenance"]
     },
     {
       "login": "Ivcota",
       "name": "Iverson Diles",
       "avatar_url": "https://avatars.githubusercontent.com/u/18635074?v=4",
       "profile": "https://github.com/Ivcota",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "doug-s-nava",
       "name": "doug-s-nava",
       "avatar_url": "https://avatars.githubusercontent.com/u/92806979?v=4",
       "profile": "https://github.com/doug-s-nava",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "TomNUSDS",
       "name": "TomNUSDS",
       "avatar_url": "https://avatars.githubusercontent.com/u/74203452?v=4",
       "profile": "https://github.com/TomNUSDS",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "mdmower-csnw",
       "name": "Matt Mower",
       "avatar_url": "https://avatars.githubusercontent.com/u/135273348?v=4",
       "profile": "https://github.com/mdmower-csnw",
-      "contributions": [
-        "bug",
-        "code",
-        "maintenance"
-      ]
+      "contributions": ["bug", "code", "maintenance"]
     },
     {
       "login": "mvanhorn",
       "name": "Matt Van Horn",
       "avatar_url": "https://avatars.githubusercontent.com/u/455140?v=4",
       "profile": "https://github.com/mvanhorn",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Steven7926",
       "name": "Steven Hudson",
       "avatar_url": "https://avatars.githubusercontent.com/u/49802017?v=4",
       "profile": "https://github.com/Steven7926",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "ronaktruss",
       "name": "Ronak",
       "avatar_url": "https://avatars.githubusercontent.com/u/84742904?v=4",
       "profile": "https://github.com/ronaktruss",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code", "maintenance"]
     },
     {
       "login": "abbyoung",
       "name": "Abigail Young",
       "avatar_url": "https://avatars.githubusercontent.com/u/6007259?v=4",
       "profile": "https://github.com/abbyoung",
-      "contributions": [
-        "code",
-        "bug",
-        "maintenance"
-      ]
+      "contributions": ["code", "bug", "maintenance"]
     }
   ],
   "contributorsPerLine": 7,
   "commitConvention": "angular",
   "commitType": "chore"
 }
+

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -448,7 +448,6 @@
         "code",
         "maintenance"
       ]
-
     },
     {
       "login": "abbyoung",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,7 +3,9 @@
   "projectOwner": "trussworks",
   "repoType": "github",
   "repoHost": "https://github.com",
-  "files": ["README.md"],
+  "files": [
+    "README.md"
+  ],
   "imageSize": 100,
   "commit": true,
   "contributors": [
@@ -12,326 +14,455 @@
       "name": "Suzanne Rozier",
       "avatar_url": "https://avatars.githubusercontent.com/u/2723066?v=4",
       "profile": "https://github.com/suzubara",
-      "contributions": ["code", "doc"]
+      "contributions": [
+        "code",
+        "doc"
+      ]
     },
     {
       "login": "haworku",
       "name": "haworku",
       "avatar_url": "https://avatars.githubusercontent.com/u/10750442?v=4",
       "profile": "https://github.com/haworku",
-      "contributions": ["code", "doc"]
+      "contributions": [
+        "code",
+        "doc"
+      ]
     },
     {
       "login": "ahobson",
       "name": "Andrew Hobson",
       "avatar_url": "https://avatars.githubusercontent.com/u/21983?v=4",
       "profile": "https://github.com/ahobson",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "gidjin",
       "name": "John Gedeon",
       "avatar_url": "https://avatars.githubusercontent.com/u/940173?v=4",
       "profile": "https://github.com/gidjin",
-      "contributions": ["code", "maintenance"]
+      "contributions": [
+        "code",
+        "maintenance"
+      ]
     },
     {
       "login": "eamahanna",
       "name": "Emily Mahanna",
       "avatar_url": "https://avatars.githubusercontent.com/u/56279459?v=4",
       "profile": "https://github.com/eamahanna",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "brandonlenz",
       "name": "Brandon Lenz",
       "avatar_url": "https://avatars.githubusercontent.com/u/15805554?v=4",
       "profile": "https://github.com/brandonlenz",
-      "contributions": ["code", "doc", "maintenance", "bug"]
+      "contributions": [
+        "code",
+        "doc",
+        "maintenance",
+        "bug"
+      ]
     },
     {
       "login": "sojeri",
       "name": "Jeri Sommers",
       "avatar_url": "https://avatars.githubusercontent.com/u/10818509?v=4",
       "profile": "https://github.com/sojeri",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "tinyels",
       "name": "Erin Stanfill",
       "avatar_url": "https://avatars.githubusercontent.com/u/3142631?v=4",
       "profile": "https://github.com/tinyels",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "esacteksab",
       "name": "Barry Morrison",
       "avatar_url": "https://avatars.githubusercontent.com/u/689591?v=4",
       "profile": "http://www.barrymorrison.com/",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "duncan-truss",
       "name": "Duncan",
       "avatar_url": "https://avatars.githubusercontent.com/u/52669884?v=4",
       "profile": "https://github.com/duncan-truss",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "SirenaBorracha",
       "name": "Arianna Kellogg",
       "avatar_url": "https://avatars.githubusercontent.com/u/16230705?v=4",
       "profile": "https://github.com/SirenaBorracha",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "christopherhuii",
       "name": "Christopher Hui",
       "avatar_url": "https://avatars.githubusercontent.com/u/8367504?v=4",
       "profile": "https://github.com/christopherhuii",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "jim",
       "name": "Jim Benton",
       "avatar_url": "https://avatars.githubusercontent.com/u/3331?v=4",
       "profile": "http://pandasguide.com/",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "jenbutongit",
       "name": "Jen Duong",
       "avatar_url": "https://avatars.githubusercontent.com/u/22080510?v=4",
       "profile": "https://github.com/jenbutongit",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "kimallen",
       "name": "Kim Allen",
       "avatar_url": "https://avatars.githubusercontent.com/u/13249580?v=4",
       "profile": "https://github.com/kimallen",
-      "contributions": ["code", "a11y"]
+      "contributions": [
+        "code",
+        "a11y"
+      ]
     },
     {
       "login": "kylehilltruss",
       "name": "Kyle Hill",
       "avatar_url": "https://avatars.githubusercontent.com/u/83614364?v=4",
       "profile": "https://github.com/kylehilltruss",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "rswerve",
       "name": "Mazdak Atighi",
       "avatar_url": "https://avatars.githubusercontent.com/u/8964335?v=4",
       "profile": "https://github.com/rswerve",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "hgarfinkle",
       "name": "Helen Garfinkle",
       "avatar_url": "https://avatars.githubusercontent.com/u/7664177?v=4",
       "profile": "https://github.com/hgarfinkle",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "rogeruiz",
       "name": "Roger Steve Ruiz",
       "avatar_url": "https://avatars.githubusercontent.com/u/706004?v=4",
       "profile": "https://github.com/rogeruiz",
-      "contributions": ["code", "doc"]
+      "contributions": [
+        "code",
+        "doc"
+      ]
     },
     {
       "login": "lpsinger",
       "name": "Leo Singer",
       "avatar_url": "https://avatars.githubusercontent.com/u/728407?v=4",
       "profile": "https://github.com/lpsinger",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "Shkeating",
       "name": "Shauna Keating",
       "avatar_url": "https://avatars.githubusercontent.com/u/59394696?v=4",
       "profile": "https://github.com/Shkeating",
-      "contributions": ["a11y", "code"]
+      "contributions": [
+        "a11y",
+        "code"
+      ]
     },
     {
       "login": "jcbcapps",
       "name": "Jacob Capps",
       "avatar_url": "https://avatars.githubusercontent.com/u/99674188?v=4",
       "profile": "https://github.com/jcbcapps",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "pearl-truss",
       "name": "pearl-truss",
       "avatar_url": "https://avatars.githubusercontent.com/u/67110378?v=4",
       "profile": "https://github.com/pearl-truss",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "werdnanoslen",
       "name": "Andrew Nelson",
       "avatar_url": "https://avatars.githubusercontent.com/u/764090?v=4",
       "profile": "https://andyhub.com/",
-      "contributions": ["code", "doc", "maintenance", "bug", "a11y"]
+      "contributions": [
+        "code",
+        "doc",
+        "maintenance",
+        "bug",
+        "a11y"
+      ]
     },
     {
       "login": "sawyerh",
       "name": "Sawyer Hollenshead",
       "avatar_url": "https://avatars.githubusercontent.com/u/371943?v=4",
       "profile": "https://sawyer.soy",
-      "contributions": ["code", "bug"]
+      "contributions": [
+        "code",
+        "bug"
+      ]
     },
     {
       "login": "rpdelaney",
       "name": "Ryan Delaney",
       "avatar_url": "https://avatars.githubusercontent.com/u/1139517?v=4",
       "profile": "https://keybase.io/rpdelaney",
-      "contributions": ["maintenance", "infra"]
+      "contributions": [
+        "maintenance",
+        "infra"
+      ]
     },
     {
       "login": "AnnaGingle",
       "name": "Anna Gingle",
       "avatar_url": "https://avatars.githubusercontent.com/u/48488699?v=4",
       "profile": "https://github.com/AnnaGingle",
-      "contributions": ["design", "code"]
+      "contributions": [
+        "design",
+        "code"
+      ]
     },
     {
       "login": "aybeedee",
       "name": "Abdullah Umer",
       "avatar_url": "https://avatars.githubusercontent.com/u/75930195?v=4",
       "profile": "https://github.com/aybeedee",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "m7adeel",
       "name": "Muhammad Adeel",
       "avatar_url": "https://avatars.githubusercontent.com/u/87698014?v=4",
       "profile": "https://github.com/m7adeel",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "vinodkv2511",
       "name": "Vinod Krishna Vellampalli",
       "avatar_url": "https://avatars.githubusercontent.com/u/44632502?v=4",
       "profile": "https://github.com/vinodkv2511",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "kleinschmidtj",
       "name": "Joe Kleinschmidt",
       "avatar_url": "https://avatars.githubusercontent.com/u/57681819?v=4",
       "profile": "https://joeforyou.xyz",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "jhancock532",
       "name": "James Hancock",
       "avatar_url": "https://avatars.githubusercontent.com/u/18164832?v=4",
       "profile": "https://jhancock532.github.io/",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "jpandersen87",
       "name": "Joseph Andersen",
       "avatar_url": "https://avatars.githubusercontent.com/u/12385932?v=4",
       "profile": "https://github.com/jpandersen87",
-      "contributions": ["code", "maintenance", "infra"]
+      "contributions": [
+        "code",
+        "maintenance",
+        "infra"
+      ]
     },
     {
       "login": "crwallace",
       "name": "Courtney Eimerman-Wallace",
       "avatar_url": "https://avatars.githubusercontent.com/u/3453669?v=4",
       "profile": "https://github.com/crwallace",
-      "contributions": ["maintenance"]
+      "contributions": [
+        "maintenance"
+      ]
     },
     {
       "login": "ocoutts-usds",
       "name": "Owen Coutts",
       "avatar_url": "https://avatars.githubusercontent.com/u/174364898?v=4",
       "profile": "https://github.com/ocoutts-usds",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "ajfarkas",
       "name": "AJ Farkas",
       "avatar_url": "https://avatars.githubusercontent.com/u/7841661?v=4",
       "profile": "http://github.com/ajfarkas",
-      "contributions": ["code", "maintenance", "review"]
+      "contributions": [
+        "code",
+        "maintenance",
+        "review"
+      ]
     },
     {
       "login": "lea-m-truss",
       "name": "Lea Melendez",
       "avatar_url": "https://avatars.githubusercontent.com/u/202806705?v=4",
       "profile": "https://github.com/lea-m-truss",
-      "contributions": ["bug", "code", "maintenance", "review"]
+      "contributions": [
+        "bug",
+        "code",
+        "maintenance",
+        "review"
+      ]
     },
     {
       "login": "aligg",
       "name": "Ali",
       "avatar_url": "https://avatars.githubusercontent.com/u/7331495?v=4",
       "profile": "http://aliglenesk.dev",
-      "contributions": ["code", "maintenance"]
+      "contributions": [
+        "code",
+        "maintenance"
+      ]
     },
     {
       "login": "Ivcota",
       "name": "Iverson Diles",
       "avatar_url": "https://avatars.githubusercontent.com/u/18635074?v=4",
       "profile": "https://github.com/Ivcota",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "doug-s-nava",
       "name": "doug-s-nava",
       "avatar_url": "https://avatars.githubusercontent.com/u/92806979?v=4",
       "profile": "https://github.com/doug-s-nava",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "TomNUSDS",
       "name": "TomNUSDS",
       "avatar_url": "https://avatars.githubusercontent.com/u/74203452?v=4",
       "profile": "https://github.com/TomNUSDS",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "mdmower-csnw",
       "name": "Matt Mower",
       "avatar_url": "https://avatars.githubusercontent.com/u/135273348?v=4",
       "profile": "https://github.com/mdmower-csnw",
-      "contributions": ["bug", "code", "maintenance"]
+      "contributions": [
+        "bug",
+        "code",
+        "maintenance"
+      ]
     },
     {
       "login": "mvanhorn",
       "name": "Matt Van Horn",
       "avatar_url": "https://avatars.githubusercontent.com/u/455140?v=4",
       "profile": "https://github.com/mvanhorn",
-      "contributions": ["code"]
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "Steven7926",
       "name": "Steven Hudson",
       "avatar_url": "https://avatars.githubusercontent.com/u/49802017?v=4",
       "profile": "https://github.com/Steven7926",
-      "contributions": ["bug", "code"]
+      "contributions": [
+        "bug",
+        "code"
+      ]
     },
     {
       "login": "ronaktruss",
       "name": "Ronak",
       "avatar_url": "https://avatars.githubusercontent.com/u/84742904?v=4",
       "profile": "https://github.com/ronaktruss",
-      "contributions": ["code", "maintenance"]
+      "contributions": [
+        "code",
+        "maintenance"
+      ]
+
     },
     {
       "login": "abbyoung",
       "name": "Abigail Young",
       "avatar_url": "https://avatars.githubusercontent.com/u/6007259?v=4",
       "profile": "https://github.com/abbyoung",
-      "contributions": ["code", "bug", "maintenance"]
+      "contributions": [
+        "code",
+        "bug",
+        "maintenance"
+      ]
     }
   ],
   "contributorsPerLine": 7,
   "commitConvention": "angular",
   "commitType": "chore"
 }
-

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+.all-contributorsrc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # @trussworks/react-uswds
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-46-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -232,7 +233,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mvanhorn"><img src="https://avatars.githubusercontent.com/u/455140?v=4?s=100" width="100px;" alt="Matt Van Horn"/><br /><sub><b>Matt Van Horn</b></sub></a><br /><a href="https://github.com/trussworks/react-uswds/commits?author=mvanhorn" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Steven7926"><img src="https://avatars.githubusercontent.com/u/49802017?v=4?s=100" width="100px;" alt="Steven Hudson"/><br /><sub><b>Steven Hudson</b></sub></a><br /><a href="https://github.com/trussworks/react-uswds/issues?q=author%3ASteven7926" title="Bug reports">🐛</a> <a href="https://github.com/trussworks/react-uswds/commits?author=Steven7926" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ronaktruss"><img src="https://avatars.githubusercontent.com/u/84742904?v=4?s=100" width="100px;" alt="Ronak"/><br /><sub><b>Ronak</b></sub></a><br /><a href="https://github.com/trussworks/react-uswds/commits?author=ronaktruss" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ronaktruss"><img src="https://avatars.githubusercontent.com/u/84742904?v=4?s=100" width="100px;" alt="Ronak"/><br /><sub><b>Ronak</b></sub></a><br /><a href="https://github.com/trussworks/react-uswds/commits?author=ronaktruss" title="Code">💻</a> <a href="#maintenance-ronaktruss" title="Maintenance">🚧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/abbyoung"><img src="https://avatars.githubusercontent.com/u/6007259?v=4?s=100" width="100px;" alt="Abigail Young"/><br /><sub><b>Abigail Young</b></sub></a><br /><a href="https://github.com/trussworks/react-uswds/commits?author=abbyoung" title="Code">💻</a> <a href="https://github.com/trussworks/react-uswds/issues?q=author%3Aabbyoung" title="Bug reports">🐛</a> <a href="#maintenance-abbyoung" title="Maintenance">🚧</a></td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # @trussworks/react-uswds
 
+<!-- prettier-ignore-start -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
 [![All Contributors](https://img.shields.io/badge/all_contributors-46-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+<!-- prettier-ignore-end -->
 
 [![npm version](https://img.shields.io/npm/v/@trussworks/react-uswds)](https://www.npmjs.com/package/@trussworks/react-uswds)
 [![uswds version](https://img.shields.io/github/package-json/dependency-version/trussworks/react-uswds/dev/@uswds/uswds)](https://www.npmjs.com/package/@uswds/uswds)


### PR DESCRIPTION
Adds @ronaktruss as a contributor for maintenance.

This was requested by brandonlenz [in this comment](https://github.com/trussworks/react-uswds/pull/3552#issuecomment-5022835710)

--- 

Recreation of https://github.com/trussworks/react-uswds/pull/3553.

I used the CLI, which caused a prettier reformat, so I restored that and then added the all contributors file to the prettier ignore list as well as prevented prettier from formatting the prettier badge in the README