### PR TITLE
fix: treat exact CharacterCount limit as valid

### DIFF
--- a/src/components/forms/CharacterCount/CharacterCount.stories.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.stories.tsx
@@ -42,10 +42,16 @@ export const TextInput: Story = {
           name="with-hint-input"
           aria-describedby="with-hint-input-info with-hint-input-hint"
           maxLength={args.maxLength}
+          defaultValue={args.defaultValue}
         />
       </FormGroup>
     </Form>
   ),
+}
+
+export const AtCharacterLimit: Story = {
+  ...TextInput,
+  args: { maxLength: 5, defaultValue: 'abcde' },
 }
 
 export const Textarea: Story = {

--- a/src/components/forms/CharacterCount/CharacterCount.test.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.test.tsx
@@ -248,6 +248,46 @@ describe('CharacterCount component', () => {
       expect(getByText('20 characters allowed')).toBeInTheDocument()
     })
 
+    it('treats an initial value at the character limit as valid', () => {
+      const { getByRole, getByTestId } = render(
+        <CharacterCount
+          id="character-count-id"
+          name="characterCount"
+          maxLength={5}
+          defaultValue="abcde"
+        />
+      )
+      const input = getByRole('textbox')
+
+      expect(input).not.toHaveClass('usa-input--error')
+      expect(getByTestId('characterCountMessage')).not.toHaveClass(
+        'usa-character-count__status--invalid'
+      )
+
+      fireEvent.blur(input)
+      expect(input).toBeValid()
+    })
+
+    it('treats an initial value over the character limit as invalid', () => {
+      const { getByRole, getByTestId } = render(
+        <CharacterCount
+          id="character-count-id"
+          name="characterCount"
+          maxLength={5}
+          defaultValue="abcdef"
+        />
+      )
+      const input = getByRole('textbox')
+
+      expect(input).toHaveClass('usa-input--error')
+      expect(getByTestId('characterCountMessage')).toHaveClass(
+        'usa-character-count__status--invalid'
+      )
+
+      fireEvent.blur(input)
+      expect(input).toBeInvalid()
+    })
+
     it('updates message text with characters left onChange', async () => {
       const { getByRole, getAllByText } = render(
         <CharacterCount

--- a/src/components/forms/CharacterCount/CharacterCount.tsx
+++ b/src/components/forms/CharacterCount/CharacterCount.tsx
@@ -74,7 +74,7 @@ export const CharacterCount = ({
   const [message, setMessage] = useState(() =>
     getMessage(initialCount, maxLength)
   )
-  const [isValid, setIsValid] = useState(initialCount < maxLength)
+  const [isValid, setIsValid] = useState(initialCount <= maxLength)
   const srMessageRef = useRef<HTMLDivElement>(null)
 
   const classes = classnames(


### PR DESCRIPTION
# Summary

- Treat an initial CharacterCount value exactly at `maxLength` as valid, matching the component's post-edit behavior and USWDS.
- Add regression coverage for initial values at and over the limit.
- Add an `AtCharacterLimit` Storybook state.

This is a non-breaking correction. The CharacterCount API and structural redesign in #3492 remains deferred to the v13 breaking-change work.

## Related Issues or PRs

Closes #3573.

Related future breaking work: #3492.

## How To Test

1. Run `npm test -- src/components/forms/CharacterCount/CharacterCount.test.tsx`.
2. Open the CharacterCount / At Character Limit story.
3. Confirm the five-character initial value has no invalid styling at a five-character limit.

The full local gate also passed: coverage, server-side rendering and bundle tests, lint, format check, production dependency audit, and the Storybook production build.

## Screenshots (optional)

Not included; the new Storybook state exposes the corrected boundary for review. Happo reports five added snapshots and 1,554 unchanged snapshots. The comparison requires snapshot acceptance before merge but is not treated as a code defect.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
