### PR TITLE
fix: keep Modal portals accessible

### DIFF
--- a/src/components/modal/Modal.server.test.tsx
+++ b/src/components/modal/Modal.server.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment node
+
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+
+import { Modal } from './Modal'
+
+describe('Modal server rendering', () => {
+  it('does not access the document when rendering to a portal', () => {
+    expect(() =>
+      renderToString(
+        <Modal
+          id="test-modal"
+          aria-labelledby="modal-heading"
+          aria-describedby="modal-description">
+          Test modal
+        </Modal>
+      )
+    ).not.toThrow()
+  })
+})

--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -39,6 +39,8 @@ Follow the [USWDS](https://designsystem.digital.gov/components/modal/) guidance 
 - Use the forceAction prop on the modal component if the user should be forced to take an action before closing the modal.
 
 You can also use the provided ModalToggleButton and/or ModalOpenLink components, which will adhere to the above guidelines for convenience.
+
+When a page provides an element with the ID \`modal-root\`, the Modal renders there and keeps that element exposed to assistive technology while the dialog is open.
 `,
       },
     },

--- a/src/components/modal/Modal.test.tsx
+++ b/src/components/modal/Modal.test.tsx
@@ -1,5 +1,6 @@
 import React, { type JSX, createRef, useRef } from 'react'
 import {
+  act,
   cleanup,
   render,
   screen,
@@ -448,6 +449,29 @@ describe('Modal component', () => {
       expect(container).not.toHaveAttribute('data-modal-hidden')
       expect(screen.getByTestId('nonhidden')).not.toHaveAttribute('aria-hidden')
       expect(screen.getByTestId('hidden')).toHaveAttribute('aria-hidden')
+    })
+
+    it('does not hide the body child containing the modal', async () => {
+      const modalRef = createRef<ModalRef>()
+      const { container } = renderWithModalRoot(
+        <Modal
+          id="testModal"
+          ref={modalRef}
+          aria-labelledby="modal-heading"
+          aria-describedby="modal-description">
+          Test modal
+        </Modal>
+      )
+      const modalRoot = document.getElementById('modal-root')
+
+      act(() => {
+        modalRef.current?.toggleModal(undefined, true)
+      })
+
+      await waitFor(() => expect(container).toHaveAttribute('aria-hidden'))
+      expect(modalRoot).not.toHaveAttribute('aria-hidden')
+      expect(modalRoot).not.toHaveAttribute('data-modal-hidden')
+      expect(modalRoot).toContainElement(screen.getByRole('dialog'))
     })
 
     it('hides other elements from screen readers with a custom modal root', async () => {

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -53,7 +53,7 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
     ...divProps
   },
   ref
-): JSX.Element => {
+): JSX.Element | null => {
   const { isOpen, toggleModal } = useModal(isInitiallyOpen)
   const [mounted, setMounted] = useState(false)
   const initialPaddingRef = useRef<string | undefined>(undefined)
@@ -85,6 +85,8 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
     body.classList.add('usa-js-modal--active')
 
     document.querySelectorAll(NON_MODALS).forEach((el) => {
+      if (renderToPortal && el.contains(modalEl.current)) return
+
       el.setAttribute('aria-hidden', 'true')
       el.setAttribute('data-modal-hidden', '')
     })
@@ -195,6 +197,8 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
   )
 
   if (renderToPortal) {
+    if (!mounted) return null
+
     const modalRoot = document.getElementById('modal-root')
     const target = modalRoot || document.body
     return ReactDOM.createPortal(modal, target)


### PR DESCRIPTION
## Summary

- defer portal creation until `Modal` mounts so server rendering never reads `document`
- keep the body child containing an open portal modal exposed to assistive technology
- cover both regressions and document the default `#modal-root` behavior

## Related Issues or PRs

Closes #3575

## How To Test

- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`
- `npm run build`
- `npm run test:serverside`
- `npm run build-storybook`

## Screenshots (optional)

Not applicable.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
