### PR TITLE
fix: apply initially open Modal effects

### DIFF
--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -229,6 +229,14 @@ export const CustomFocusElementModal: Story = {
 }
 
 export const InitiallyOpenModal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The modal applies its body scroll lock and accessibility effects as soon as it mounts.',
+      },
+    },
+  },
   render: () => {
     const modalRef = useRef<ModalRef>(null)
 

--- a/src/components/modal/Modal.test.tsx
+++ b/src/components/modal/Modal.test.tsx
@@ -334,6 +334,39 @@ describe('Modal component', () => {
     expect(modalRef.current?.modalIsOpen).toBe(true)
   })
 
+  it('applies document effects when initially open', async () => {
+    const modalRef = createRef<ModalRef>()
+    const { baseElement, container } = renderWithModalRoot(
+      <Modal
+        ref={modalRef}
+        id="testModal"
+        aria-labelledby="modal-heading"
+        aria-describedby="modal-description"
+        isInitiallyOpen>
+        Test modal
+      </Modal>
+    )
+
+    await waitFor(() => expect(baseElement).toHaveClass('usa-js-modal--active'))
+    expect(baseElement).toHaveStyle('padding-right: 15px')
+    expect(container).toHaveAttribute('aria-hidden')
+    expect(container).toHaveAttribute('data-modal-hidden')
+    expect(document.getElementById('modal-root')).not.toHaveAttribute(
+      'aria-hidden'
+    )
+
+    act(() => {
+      modalRef.current?.toggleModal(undefined, false)
+    })
+
+    await waitFor(() =>
+      expect(baseElement).not.toHaveClass('usa-js-modal--active')
+    )
+    expect(baseElement).toHaveStyle('padding-right: 0px')
+    expect(container).not.toHaveAttribute('aria-hidden')
+    expect(container).not.toHaveAttribute('data-modal-hidden')
+  })
+
   it('does not render a close button when forceAction is true', () => {
     const testModalId = 'testModal'
 
@@ -350,6 +383,47 @@ describe('Modal component', () => {
   })
 
   describe('toggling', () => {
+    it('preserves document effects when another closed modal mounts', async () => {
+      const firstModalRef = createRef<ModalRef>()
+      const Modals = ({ showSecond }: { showSecond: boolean }) => (
+        <>
+          <Modal
+            id="firstModal"
+            ref={firstModalRef}
+            aria-labelledby="first-heading"
+            aria-describedby="first-description">
+            First modal
+          </Modal>
+          {showSecond && (
+            <Modal
+              id="secondModal"
+              aria-labelledby="second-heading"
+              aria-describedby="second-description">
+              Second modal
+            </Modal>
+          )}
+        </>
+      )
+
+      const { baseElement, container, rerender } = render(
+        <Modals showSecond={false} />
+      )
+
+      act(() => {
+        firstModalRef.current?.toggleModal(undefined, true)
+      })
+
+      await waitFor(() =>
+        expect(baseElement).toHaveClass('usa-js-modal--active')
+      )
+      expect(container).toHaveAttribute('aria-hidden')
+
+      rerender(<Modals showSecond />)
+
+      expect(baseElement).toHaveClass('usa-js-modal--active')
+      expect(container).toHaveAttribute('aria-hidden')
+    })
+
     it('styles the body element', async () => {
       const modalRef = createRef<ModalRef>()
       const handleOpen = () => modalRef.current?.toggleModal(undefined, true)

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -59,6 +59,7 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
   const initialPaddingRef = useRef<string | undefined>(undefined)
   const tempPaddingRef = useRef<string | undefined>(undefined)
   const modalEl = useRef<HTMLDivElement>(null)
+  const wasOpenRef = useRef(false)
 
   const modalRootSelector = modalRoot || '.usa-modal-wrapper'
 
@@ -132,14 +133,13 @@ export const ModalForwardRef: React.ForwardRefRenderFunction<
   }, [])
 
   useEffect(() => {
-    if (mounted) {
-      if (isOpen === true) {
-        handleOpenEffect()
-      } else if (isOpen === false) {
-        handleCloseEffect()
-      }
-    }
-  }, [isOpen])
+    if (!mounted) return
+
+    if (isOpen) handleOpenEffect()
+    else if (wasOpenRef.current) handleCloseEffect()
+
+    wasOpenRef.current = isOpen
+  }, [isOpen, mounted])
 
   const ariaLabelledBy = divProps['aria-labelledby']
   const ariaDescribedBy = divProps['aria-describedby']


### PR DESCRIPTION
## Summary

- apply Modal body and accessibility effects when `isInitiallyOpen` is set
- preserve an open Modal's document effects when another closed Modal mounts
- restore body padding and hidden siblings when the initially open Modal closes

## Related Issues or PRs

Closes #3577

Stacked on #3576.

## How To Test

- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`
- `npm run build`
- `npm run test:serverside`
- `npm run build-storybook`

## Screenshots (optional)

Not applicable.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
