### PR TITLE
fix: validate FileInput selections

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -54,7 +54,7 @@ export const AcceptTextAndPDF: Story = {
       <FileInput
         id="file-input-specific"
         name="file-input-specific"
-        accept=".pdf,.txt"
+        accept=".pdf, .txt"
         aria-describedby="file-input-specific-hint"
         multiple
       />

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -141,6 +141,14 @@ describe('FileInput component', () => {
   })
 
   describe('drag and drop', () => {
+    it('handles a drop event without transferred files', () => {
+      const { getByTestId } = render(<FileInput {...testProps} />)
+
+      expect(() =>
+        fireEvent.drop(getByTestId('file-input-droptarget'))
+      ).not.toThrow()
+    })
+
     it('toggles the drag class when dragging over and leaving the target element', () => {
       const { getByTestId } = render(<FileInput {...testProps} />)
       const targetEl = getByTestId('file-input-droptarget')
@@ -297,6 +305,91 @@ describe('FileInput component', () => {
       )
 
       expect(queryByTestId('file-input-preview')).not.toBeInTheDocument()
+    })
+
+    it.each([
+      ['whitespace around accepted types', '.pdf, .txt', TEST_TEXT_FILE],
+      ['an exact MIME type', 'application/pdf', TEST_PDF_FILE],
+      [
+        'case differences in file extensions',
+        '.pdf',
+        new File([], 'REPORT.PDF', { type: 'application/pdf' }),
+      ],
+    ])('accepts files with %s', (_case, accept, file) => {
+      const { getByTestId, queryByTestId } = render(
+        <FileInput {...testProps} accept={accept} />
+      )
+
+      fireEvent.drop(getByTestId('file-input-droptarget'), {
+        dataTransfer: { files: [file] },
+      })
+
+      expect(queryByTestId('file-input-error')).not.toBeInTheDocument()
+    })
+
+    it.each([
+      [
+        'partial extension and MIME type matches',
+        '.pdf,application/json',
+        new File([], 'report.pdf.exe', {
+          type: 'application/json-patch+json',
+        }),
+      ],
+      ['empty accepted types', '.pdf,', TEST_PNG_FILE],
+    ])('rejects files with %s', (_case, accept, file) => {
+      const { getByTestId } = render(
+        <FileInput {...testProps} accept={accept} />
+      )
+
+      fireEvent.drop(getByTestId('file-input-droptarget'), {
+        dataTransfer: { files: [file] },
+      })
+
+      expect(getByTestId('file-input-error')).toBeInTheDocument()
+    })
+
+    it('shows an error and clears an unaccepted picker selection before onChange', async () => {
+      const user = userEvent.setup({ applyAccept: false })
+      let selectedFileCount = -1
+      const onChange = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+        selectedFileCount = event.target.files?.length ?? 0
+      })
+      const { getByTestId, queryByTestId } = render(
+        <FileInput {...testProps} accept=".pdf,.txt" onChange={onChange} />
+      )
+
+      const inputEl = getByTestId('file-input-input') as HTMLInputElement
+      await user.upload(inputEl, TEST_PNG_FILE)
+
+      expect(getByTestId('file-input-error')).toHaveTextContent(
+        'Error: This is not a valid file type.'
+      )
+      expect(getByTestId('file-input-droptarget')).toHaveClass(
+        'has-invalid-file'
+      )
+      expect(queryByTestId('file-input-preview')).not.toBeInTheDocument()
+      expect(inputEl.files).toHaveLength(0)
+      expect(inputEl).toHaveValue('')
+      expect(onChange).toHaveBeenCalledOnce()
+      expect(selectedFileCount).toBe(0)
+    })
+
+    it('clears a previous selection when any dropped file is unaccepted', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <FileInput {...testProps} accept=".pdf,.txt" multiple />
+      )
+      const inputEl = getByTestId('file-input-input') as HTMLInputElement
+      const targetEl = getByTestId('file-input-droptarget')
+      await userEvent.upload(inputEl, TEST_PDF_FILE)
+
+      fireEvent.drop(targetEl, {
+        dataTransfer: { files: [TEST_TEXT_FILE, TEST_PNG_FILE] },
+      })
+
+      expect(getByTestId('file-input-error')).toBeInTheDocument()
+      expect(queryByTestId('file-input-preview')).not.toBeInTheDocument()
+      expect(inputEl.files).toHaveLength(0)
+      expect(inputEl).toHaveValue('')
     })
   })
 

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -143,10 +143,12 @@ describe('FileInput component', () => {
   describe('drag and drop', () => {
     it('handles a drop event without transferred files', () => {
       const { getByTestId } = render(<FileInput {...testProps} />)
+      const targetEl = getByTestId('file-input-droptarget')
 
-      expect(() =>
-        fireEvent.drop(getByTestId('file-input-droptarget'))
-      ).not.toThrow()
+      fireEvent.dragOver(targetEl)
+      fireEvent.drop(targetEl)
+
+      expect(targetEl).not.toHaveClass('usa-file-input--drag')
     })
 
     it('toggles the drag class when dragging over and leaving the target element', () => {

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -11,6 +11,18 @@ import classnames from 'classnames'
 import { FilePreview } from './FilePreview'
 import { makeSafeForID } from './utils'
 
+const fileMatchesAccept = (file: File, acceptedType: string): boolean => {
+  const normalizedType = acceptedType.trim().toLowerCase()
+  const fileType = file.type.split(';')[0].trim().toLowerCase()
+  if (normalizedType.startsWith('.')) {
+    return file.name.toLowerCase().endsWith(normalizedType)
+  }
+  if (normalizedType.endsWith('/*')) {
+    return fileType.startsWith(normalizedType.slice(0, -1))
+  }
+  return fileType === normalizedType
+}
+
 export type FileInputProps = {
   id: string
   name: string
@@ -135,57 +147,41 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
         : `${filePreviews.length} ${defaultMultipleSelectedFileText}`
       : previewSingleSelectedFileText || defaultSingleSelectedFileText
 
-  const preventInvalidFiles = (e: React.DragEvent): void => {
+  const validateFiles = (selectedFiles: File[]): boolean => {
     setShowError(false)
 
     if (accept) {
-      const acceptedTypes = accept.split(',')
-      let allFilesAllowed = true
-      for (let i = 0; i < e.dataTransfer.files.length; i += 1) {
-        const file = e.dataTransfer.files[parseInt(`${i}`)]
-        if (allFilesAllowed) {
-          for (let j = 0; j < acceptedTypes.length; j += 1) {
-            const fileType = acceptedTypes[parseInt(`${j}`)]
-            allFilesAllowed =
-              file.name.indexOf(fileType) > 0 ||
-              file.type.includes(fileType.replace(/\*/g, ''))
-            if (allFilesAllowed) break
-          }
-        } else break
-      }
+      const acceptedTypes = accept.split(',').filter((type) => type.trim())
+      const allFilesAllowed = selectedFiles.every((file) =>
+        acceptedTypes.some((type) => fileMatchesAccept(file, type))
+      )
 
       if (!allFilesAllowed) {
         setFiles([])
         setShowError(true)
-        e.preventDefault()
-        e.stopPropagation()
+        if (internalRef.current) internalRef.current.value = ''
+        return false
       }
     }
+
+    return true
   }
 
   // Event handlers
   const handleDragOver = (): void => setIsDragging(true)
   const handleDragLeave = (): void => setIsDragging(false)
   const handleDrop = (e: React.DragEvent): void => {
-    preventInvalidFiles(e)
+    if (!validateFiles(Array.from(e.dataTransfer?.files ?? []))) {
+      e.preventDefault()
+      e.stopPropagation()
+    }
     setIsDragging(false)
     if (onDrop) onDrop(e)
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    setShowError(false)
-
-    // Map input FileList to array of Files
-    const fileArr = []
-    if (e.target?.files?.length) {
-      const fileLength = e.target?.files?.length || 0
-
-      for (let i = 0; i < fileLength; i++) {
-        const file = e.target.files.item(i)
-        if (file) fileArr.push(file)
-      }
-    }
-    setFiles(fileArr)
+    const selectedFiles = Array.from(e.target.files || [])
+    if (validateFiles(selectedFiles)) setFiles(selectedFiles)
 
     if (onChange) onChange(e)
   }


### PR DESCRIPTION
# Summary

- validate files selected through the native picker with the same path used for dropped files
- match `accept` tokens using native-style extension and MIME semantics, including surrounding whitespace, ASCII-insensitive extensions, blank tokens, and exact rather than substring matches; malformed dotless values such as `pdf` no longer match filenames
- clear an invalid picker selection before forwarding `onChange`, so consumers observe the corrected input state, and clear a prior picker selection after an invalid drop
- exercise whitespace-separated `accept` tokens in the existing FileInput story

## Related Issues or PRs

Fixes #3579
Fixes #3580

## How To Test

1. Run `npm test -- src/components/forms/FileInput/FileInput.test.tsx`.
2. In the `AcceptTextAndPDF` Storybook story, select or drop PDF and TXT files and confirm they are previewed.
3. Select or drop another file type and confirm the error appears and no preview remains.
4. Run `npm run test:coverage`, `npm run test:serverside`, `npm run lint`, `npm run format:check`, `npm run build-storybook`, and `npm audit --omit=dev --audit-level=high`.

## Screenshots (optional)

Not included. The existing valid and invalid FileInput states are unchanged; this change makes picker selection and `accept` parsing reach those states consistently.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
