### PR TITLE
fix: announce FileInput selections

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -19,6 +19,8 @@ const meta: Meta<typeof FileInput> = {
         component: `
 ### USWDS 3.0 FileInput component
 Source: https://designsystem.digital.gov/components/file-input
+
+Selected filenames are announced through a polite live region.
 `,
       },
     },

--- a/src/components/forms/FileInput/FileInput.test.tsx
+++ b/src/components/forms/FileInput/FileInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { FileInput, FileInputRef } from './FileInput'
@@ -137,6 +137,130 @@ describe('FileInput component', () => {
       const { getByTestId } = render(<FileInput {...disabledProps} />)
       expect(getByTestId('file-input')).toHaveClass('usa-file-input--disabled')
       expect(getByTestId('file-input')).toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+
+  describe('screen reader status', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it.each([
+      [false, 'No file selected.'],
+      [true, 'No files selected.'],
+    ])(
+      'reports the initial selection state for multiple=%s',
+      (multiple, message) => {
+        const { getByTestId } = render(
+          <FileInput {...testProps} multiple={multiple} />
+        )
+
+        expect(getByTestId('file-input-sr-status')).toHaveClass('usa-sr-only')
+        expect(getByTestId('file-input-sr-status')).toHaveAttribute(
+          'aria-live',
+          'polite'
+        )
+        expect(getByTestId('file-input-sr-status')).toHaveTextContent(message)
+      }
+    )
+
+    it('announces a selected file', () => {
+      const { getByTestId } = render(<FileInput {...testProps} />)
+
+      fireEvent.change(getByTestId('file-input-input'), {
+        target: { files: [TEST_PNG_FILE] },
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(getByTestId('file-input-sr-status')).toHaveTextContent(
+        `You have selected the file: ${TEST_PNG_FILE.name}`
+      )
+    })
+
+    it('announces the count and names of selected files', () => {
+      const { getByTestId } = render(
+        <FileInput {...testProps} multiple={true} />
+      )
+
+      fireEvent.change(getByTestId('file-input-input'), {
+        target: { files: [TEST_PNG_FILE, TEST_TEXT_FILE] },
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(getByTestId('file-input-sr-status')).toHaveTextContent(
+        `You have selected 2 files: ${TEST_PNG_FILE.name}, ${TEST_TEXT_FILE.name}`
+      )
+    })
+
+    it('reports the empty state after files are cleared', () => {
+      const fileInputRef = React.createRef<FileInputRef>()
+      const { getByTestId } = render(
+        <FileInput {...testProps} ref={fileInputRef} />
+      )
+
+      fireEvent.change(getByTestId('file-input-input'), {
+        target: { files: [TEST_PNG_FILE] },
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      act(() => {
+        fileInputRef.current?.clearFiles()
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(getByTestId('file-input-sr-status')).toHaveTextContent(
+        'No file selected.'
+      )
+    })
+
+    it('preserves the selected file status when multiple changes', () => {
+      const { getByTestId, rerender } = render(<FileInput {...testProps} />)
+
+      fireEvent.change(getByTestId('file-input-input'), {
+        target: { files: [TEST_PNG_FILE] },
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      rerender(<FileInput {...testProps} multiple={true} />)
+
+      expect(getByTestId('file-input-sr-status')).toHaveTextContent(
+        `You have selected the file: ${TEST_PNG_FILE.name}`
+      )
+    })
+
+    it('restores the selected file status when re-enabled', () => {
+      const { getByTestId, queryByTestId, rerender } = render(
+        <FileInput {...testProps} />
+      )
+
+      fireEvent.change(getByTestId('file-input-input'), {
+        target: { files: [TEST_PNG_FILE] },
+      })
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      rerender(<FileInput {...testProps} disabled={true} />)
+      expect(queryByTestId('file-input-sr-status')).not.toBeInTheDocument()
+
+      rerender(<FileInput {...testProps} />)
+      expect(getByTestId('file-input-sr-status')).toHaveTextContent(
+        `You have selected the file: ${TEST_PNG_FILE.name}`
+      )
+    })
+
+    it('does not render a status for a disabled input', () => {
+      const { queryByTestId } = render(
+        <FileInput {...testProps} disabled={true} />
+      )
+
+      expect(queryByTestId('file-input-sr-status')).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -69,6 +69,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
   ref
 ): JSX.Element => {
   const internalRef = useRef<HTMLInputElement>(null)
+  const statusRef = useRef<HTMLDivElement>(null)
   const [isDragging, setIsDragging] = useState(false)
   const [showError, setShowError] = useState(false)
   const [files, setFiles] = useState<File[]>([])
@@ -120,6 +121,32 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
   const defaultSingleSelectedFileText = 'Selected file'
   const defaultMultipleSelectedFileText = ' files selected'
   const defaultChangeSelectedFileText = 'Change file'
+  const emptyStatusMessage = multiple
+    ? 'No files selected.'
+    : 'No file selected.'
+  const statusMessage =
+    files.length === 0
+      ? emptyStatusMessage
+      : files.length === 1
+        ? `You have selected the file: ${files[0].name}`
+        : `You have selected ${files.length} files: ${files
+            .map((file) => file.name)
+            .join(', ')}`
+
+  useEffect(() => {
+    const statusEl = statusRef.current
+    if (disabled || !statusEl || statusEl.textContent === statusMessage) return
+
+    if (statusEl.textContent === '') {
+      statusEl.textContent = statusMessage
+      return
+    }
+
+    const timer = setTimeout(() => {
+      statusEl.textContent = statusMessage
+    }, 1000)
+    return () => clearTimeout(timer)
+  }, [disabled, statusMessage])
 
   const filePreviews = []
   if (files) {
@@ -191,6 +218,14 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
       data-testid="file-input"
       className={fileInputClasses}
       aria-disabled={disabled}>
+      {!disabled && (
+        <div
+          ref={statusRef}
+          className="usa-sr-only"
+          aria-live="polite"
+          data-testid="file-input-sr-status"
+        />
+      )}
       <div
         data-testid="file-input-droptarget"
         className={targetClasses}


### PR DESCRIPTION
# Summary

Add an enabled-only, screen-reader-only polite status to `FileInput`. The status reports the initial empty state, announces selected filenames after the same delay USWDS uses, and returns to the empty message after `clearFiles()`.

The implementation keeps the live-region text outside React's child reconciliation so prop changes and disable/re-enable cycles preserve the current selection announcement. Visible output and the public API do not change.

This PR is stacked on #3582 because rejected picker selections now clear the component's file state. A rejected selection therefore announces the truthful empty state rather than retaining a stale filename; that differs from upstream USWDS, which leaves its prior status unchanged on rejection.

Two narrow limits remain: selecting a different file with the same filename does not repeat the announcement, and the issue-specified English status strings are not configurable. Changing `multiple` while the input is empty updates the empty-state announcement after the normal delay.

## Related Issues or PRs

- https://github.com/trussworks/react-uswds/issues/3581
- Stacked on https://github.com/trussworks/react-uswds/pull/3582

## How To Test

- Run `npm test -- src/components/forms/FileInput/FileInput.test.tsx`.
- Confirm the screen-reader status tests cover singular and plural initial messages, one and several selected files, `clearFiles()`, `multiple` changes, and disable/re-enable behavior.
- Run `npm test`, `npm run lint`, `npm run format:check`, `npm run build`, `npm run test:serverside`, `npm run build-storybook`, and `npm audit --omit=dev`.

## Screenshots (optional)

Not applicable; the new status uses `usa-sr-only` and does not change visible output.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
