### PR TITLE
chore: enforce React hook rules

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -76,6 +76,7 @@ module.exports = defineConfig([
     rules: {
       'no-only-tests/no-only-tests': 'error',
       'react/prop-types': 'off',
+      'react-hooks/rules-of-hooks': 'error',
       '@typescript-eslint/no-unused-expressions': [
         'error',
         { allowShortCircuit: true },
@@ -129,6 +130,15 @@ module.exports = defineConfig([
 
     rules: {
       'import/no-unresolved': 'off',
+    },
+  },
+  {
+    // Storybook treats CSF render functions as component boundaries, but the
+    // hooks rule cannot infer that from their lowercase property name.
+    files: ['**/*.stories.tsx'],
+
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
     },
   },
   {

--- a/src/eslintConfig.test.ts
+++ b/src/eslintConfig.test.ts
@@ -1,0 +1,43 @@
+import { ESLint } from 'eslint'
+
+const eslint = new ESLint()
+
+const lint = async (code: string, filePath: string) => {
+  const [result] = await eslint.lintText(code, { filePath })
+
+  expect(result.fatalErrorCount).toBe(0)
+
+  return result.messages
+}
+
+describe('React Hooks lint configuration', () => {
+  it('enforces source rules while allowing Storybook render functions', async () => {
+    // Project Service requires probe paths that already exist in tsconfig.json.
+    const sourceMessages = await lint(
+      `import { useState } from 'react'
+export function Example({ enabled }: { enabled: boolean }) {
+  if (enabled) useState(0)
+  return null
+}`,
+      'src/index.ts'
+    )
+    const storyMessages = await lint(
+      `import { useState } from 'react'
+export default { title: 'Example' }
+export const Example = { render: () => { useState(0); return null } }`,
+      'src/components/forms/FileInput/FileInput.stories.tsx'
+    )
+
+    expect(sourceMessages).toEqual([
+      expect.objectContaining({
+        ruleId: 'react-hooks/rules-of-hooks',
+        severity: 2,
+      }),
+    ])
+    expect(storyMessages).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ruleId: 'react-hooks/rules-of-hooks' }),
+      ])
+    )
+  }, 15_000)
+})


### PR DESCRIPTION
## Summary

- enable `react-hooks/rules-of-hooks` as an ESLint error for shipped source
- exempt Storybook CSF render callbacks, whose lowercase `render` name produces false positives
- add a regression test that exercises both paths through the repository's real ESLint configuration
- leave `react-hooks/exhaustive-deps` for #3585, where its 23 existing findings can be triaged before the rule blocks commits

## Related Issues

https://github.com/trussworks/react-uswds/issues/3584

Follow-up: https://github.com/trussworks/react-uswds/issues/3585

## How To Test

Run:

```sh
npm run test
npm run test:coverage
npm run lint
npm run format:check
npm run build
npm run test:serverside
npm run build-storybook
npm audit
```

The ESLint configuration test must report a source hook-order violation as an error while allowing the same hook shape inside a Storybook `render` callback.

## Screenshots

Not applicable.

## Breaking Changes

- [x] This change is not breaking.

