### PR TITLE
fix: keep ComboBox state coherent when options change

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -119,6 +119,13 @@ export const Disabled: Story = {
 }
 
 export const WithOtherFields: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Changing the first field replaces the combo box options.',
+      },
+    },
+  },
   render: () => {
     const fruitList = Object.entries(fruits).map(([value, key]) => ({
       value: value,

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, render, waitFor } from '@testing-library/react'
+import { act, screen, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { ComboBox, ComboBoxOption, ComboBoxRef } from './ComboBox'
@@ -93,7 +93,7 @@ describe('ComboBox component', () => {
     expect(comboBoxInput).toHaveValue('Avocado')
   })
 
-  it('updates options when prop changes', () => {
+  it('resets the input and list when options change', async () => {
     const Wrapper = (props: { options: ComboBoxOption[] }) => {
       return (
         <ComboBox
@@ -105,10 +105,75 @@ describe('ComboBox component', () => {
       )
     }
     const { rerender } = render(<Wrapper options={fruitOptions} />)
-    const comboBoxSelect = screen.getByTestId('combo-box-select')
-    expect(comboBoxSelect).toHaveValue(fruitOptions[0].value)
+    const input = screen.getByRole('combobox')
+    await userEvent.type(input, 'yu')
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+
     rerender(<Wrapper options={veggieOptions} />)
-    expect(comboBoxSelect).toHaveValue(veggieOptions[0].value)
+
+    expect(input).toHaveValue('')
+    expect(screen.getAllByRole('option')).toHaveLength(veggieOptions.length)
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'favorite-fruit--list--option-0'
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(
+      `${veggieOptions.length} results available.`
+    )
+  })
+
+  it('clears a selection that is missing from updated options', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <ComboBox
+        id="favorite-fruit"
+        name="favorite-fruit"
+        options={fruitOptions}
+        defaultValue="apple"
+        onChange={onChange}
+      />
+    )
+
+    rerender(
+      <ComboBox
+        id="favorite-fruit"
+        name="favorite-fruit"
+        options={veggieOptions}
+        defaultValue="apple"
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.getByRole('combobox')).toHaveValue('')
+    expect(onChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('preserves a selection without notifying when updated options contain its value', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <ComboBox
+        id="favorite-fruit"
+        name="favorite-fruit"
+        options={fruitOptions}
+        defaultValue="apple"
+        onChange={onChange}
+      />
+    )
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <ComboBox
+        id="favorite-fruit"
+        name="favorite-fruit"
+        options={fruitOptions.map((option) => ({ ...option }))}
+        defaultValue="apple"
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.getByRole('combobox')).toHaveValue('Apple')
+    expect(onChange).toHaveBeenCalledTimes(1)
   })
 
   describe('toggling the list', () => {
@@ -349,6 +414,31 @@ describe('ComboBox component', () => {
   })
 
   describe('scrolling to a focused option', () => {
+    it('scrolls to the focused option when a consumer refocuses the input', async () => {
+      const comboRef = React.createRef<ComboBoxRef>()
+      const { getByTestId } = render(
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={fruitOptions}
+          onChange={vi.fn()}
+          ref={comboRef}
+        />
+      )
+      const input = getByTestId('combo-box-input')
+      const listEl = getByTestId('combo-box-option-list')
+      const apple = getByTestId('combo-box-option-apple')
+
+      vi.spyOn(apple, 'offsetTop', 'get').mockReturnValue(600)
+      await userEvent.click(input)
+      await userEvent.type(input, '{ArrowDown}')
+      listEl.scrollTop = 2000
+
+      act(() => comboRef.current?.focus())
+
+      expect(listEl.scrollTop).toBe(600)
+    })
+
     it('scrolls options list to the very top when the menu opens if nothing is selected', async () => {
       const { getByTestId } = render(
         <ComboBox

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -146,14 +146,17 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
   const containerRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLUListElement>(null)
   const focusedItemRef = useRef<HTMLLIElement>(null)
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
 
   useEffect(() => {
-    state.filteredOptions = options
-  }, [options])
+    dispatch({ type: ActionTypes.UPDATE_OPTIONS, options })
+  }, [dispatch, options])
 
+  const selectedValue = state.selectedOption?.value
   useEffect(() => {
-    onChange && onChange(state.selectedOption?.value || undefined)
-  }, [state.selectedOption])
+    onChangeRef.current?.(selectedValue)
+  }, [selectedValue])
 
   useEffect(() => {
     if (
@@ -187,7 +190,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
         listRef.current.scrollTop = focusedItemRef.current.offsetTop
       }
     }
-  }, [state.isOpen, state.focusedOption])
+  }, [state.focusMode, state.focusedOption, state.isOpen])
 
   // If the focused element (activeElement) is outside of the combo box,
   // make sure the focusMode is BLUR
@@ -199,7 +202,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
         })
       }
     }
-  }, [state.focusMode])
+  }, [dispatch, state.focusMode])
 
   useImperativeHandle(
     ref,
@@ -208,7 +211,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
       clearSelection: (): void =>
         dispatch({ type: ActionTypes.CLEAR_SELECTION }),
     }),
-    []
+    [dispatch]
   )
 
   const handleInputKeyDown = (event: KeyboardEvent): void => {

--- a/src/components/forms/ComboBox/useComboBox.ts
+++ b/src/components/forms/ComboBox/useComboBox.ts
@@ -10,6 +10,7 @@ export enum ActionTypes {
   CLOSE_LIST,
   FOCUS_OPTION,
   UPDATE_FILTER,
+  UPDATE_OPTIONS,
   BLUR,
   CLEAR_SELECTION,
   FOCUS_INPUT,
@@ -38,6 +39,10 @@ export type Action =
       value: string
     }
   | {
+      type: ActionTypes.UPDATE_OPTIONS
+      options: ComboBoxOption[]
+    }
+  | {
       type: ActionTypes.BLUR
     }
   | {
@@ -61,6 +66,11 @@ interface FilterResults {
   closestMatch: ComboBoxOption
   optionsToDisplay: ComboBoxOption[]
 }
+
+const getStatusText = (resultCount: number): string =>
+  resultCount
+    ? `${resultCount} result${resultCount === 1 ? '' : 's'} available.`
+    : 'No results.'
 
 export const useComboBox = (
   initialState: State,
@@ -128,13 +138,7 @@ export const useComboBox = (
           isOpen: true,
           filteredOptions: optionsToDisplay,
           inputValue: action.value,
-          statusText: `${optionsToDisplay.length} result${
-            optionsToDisplay.length > 1 ? 's' : ''
-          } available.`,
-        }
-
-        if (optionsToDisplay.length < 1) {
-          newState.statusText = 'No results.'
+          statusText: getStatusText(optionsToDisplay.length),
         }
 
         if (disableFiltering || !state.selectedOption) {
@@ -149,20 +153,29 @@ export const useComboBox = (
 
         return newState
       }
+      case ActionTypes.UPDATE_OPTIONS: {
+        const selectedOption = state.selectedOption
+          ? action.options.find(
+              (option) => option.value === state.selectedOption?.value
+            )
+          : undefined
+        return {
+          ...state,
+          selectedOption,
+          focusedOption: selectedOption || action.options[0],
+          filteredOptions: action.options,
+          inputValue: selectedOption?.label || '',
+          statusText: state.isOpen ? getStatusText(action.options.length) : '',
+        }
+      }
       case ActionTypes.OPEN_LIST: {
-        const statusText = state.filteredOptions.length
-          ? `${state.filteredOptions.length} result${
-              state.filteredOptions.length > 1 ? 's' : ''
-            } available.`
-          : 'No results.'
-
         return {
           ...state,
           isOpen: true,
           focusMode: FocusMode.Input,
           focusedOption:
             state.selectedOption || state.focusedOption || optionsList[0],
-          statusText,
+          statusText: getStatusText(state.filteredOptions.length),
         }
       }
       case ActionTypes.CLOSE_LIST: {
@@ -187,18 +200,12 @@ export const useComboBox = (
       }
 
       case ActionTypes.FOCUS_OPTION: {
-        const statusText = state.filteredOptions.length
-          ? `${state.filteredOptions.length} result${
-              state.filteredOptions.length > 1 ? 's' : ''
-            } available.`
-          : 'No results.'
-
         return {
           ...state,
           isOpen: true,
           focusedOption: action.option,
           focusMode: FocusMode.Item,
-          statusText,
+          statusText: getStatusText(state.filteredOptions.length),
         }
       }
       case ActionTypes.CLEAR:


### PR DESCRIPTION
## Summary

- replace ComboBox's direct reducer-state mutation when `options` changes with an explicit reducer action
- keep the filtered list, input, focused option, status text, and selected option coherent after an options change
- notify consumers when an options change removes the selected option, while preserving equivalent selections by value
- rerun focused-option scrolling when a consumer refocuses the open ComboBox through its public ref
- document the options-replacement behavior in Storybook

## Related Issues

- https://github.com/trussworks/react-uswds/issues/3585
- Follow-up for the hidden native select: https://github.com/trussworks/react-uswds/issues/3591

## How To Test

1. Run `npm run test -- src/components/forms/ComboBox/ComboBox.test.tsx`.
2. Run `npm run test`, `npm run test:coverage`, `npm run lint`, and `npm run format:check`.
3. Run `npm run build`, `npm run test:serverside`, `npm run build-storybook`, and `npm audit`.
4. In Storybook, open ComboBox > With other fields and confirm the documented dynamic-options behavior remains usable.

## Screenshots

Not applicable. The story change adds documentation for behavior already represented by the story.

## Breaking change checklist

- [ ] This change is breaking.

The change is non-breaking: it corrects previously stale internal state and reports a removed selection through the existing `onChange` contract.
