### PR TITLE
fix: synchronize ComboBox native select

### DIFF
--- a/src/components/forms/ComboBox/ComboBox.stories.tsx
+++ b/src/components/forms/ComboBox/ComboBox.stories.tsx
@@ -18,6 +18,9 @@ const meta: Meta<typeof ComboBox> = {
 ### USWDS 3.0 ComboBox component
 
 Source: https://designsystem.digital.gov/components/combo-box
+
+To match USWDS, \`selectProps.required\` is applied to the visible text input
+instead of the hidden native select.
 `,
       },
     },
@@ -174,6 +177,14 @@ export const WithOtherFields: Story = {
 }
 
 export const ExposedRefMethods: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The hidden native select follows the selected value and returns to an empty value when cleared.',
+      },
+    },
+  },
   render: () => {
     const ref = useRef<ComboBoxRef>(null)
 

--- a/src/components/forms/ComboBox/ComboBox.test.tsx
+++ b/src/components/forms/ComboBox/ComboBox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { act, screen, render, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { ComboBox, ComboBoxOption, ComboBoxRef } from './ComboBox'
@@ -28,6 +28,10 @@ const veggieOptions: ComboBoxOption[] = Object.entries(veggies).map(
 
 describe('ComboBox component', () => {
   it('renders the expected markup without errors', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
     render(
       <ComboBox
         id="favorite-fruit"
@@ -49,6 +53,7 @@ describe('ComboBox component', () => {
     expect(comboBoxSelect).toHaveClass(
       'usa-select usa-sr-only usa-combo-box__select'
     )
+    expect(comboBoxSelect).toHaveValue('')
 
     const comboBoxInput = screen.getByRole('combobox')
     expect(comboBoxInput).toBeInTheDocument()
@@ -64,6 +69,9 @@ describe('ComboBox component', () => {
     expect(comboBoxInput).toHaveAttribute('autocapitalize', 'off')
     expect(comboBoxInput).toHaveAttribute('autocomplete', 'off')
     expect(comboBoxInput).toHaveAttribute('type', 'text')
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
 
     const comboBoxList = screen.getByTestId('combo-box-option-list')
     expect(comboBoxList).toBeInstanceOf(HTMLUListElement)
@@ -174,6 +182,53 @@ describe('ComboBox component', () => {
 
     expect(screen.getByRole('combobox')).toHaveValue('Apple')
     expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the native select when updated options omit the selection', () => {
+    const Wrapper = (props: { options: ComboBoxOption[] }) => {
+      return (
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={props.options}
+          defaultValue="apple"
+          onChange={vi.fn()}
+        />
+      )
+    }
+    const { rerender } = render(<Wrapper options={fruitOptions} />)
+    const comboBoxSelect = screen.getByTestId('combo-box-select')
+    expect(comboBoxSelect).toHaveValue('apple')
+    rerender(<Wrapper options={veggieOptions} />)
+    expect(comboBoxSelect).toHaveValue('')
+  })
+
+  it('submits the current selection through the native select', async () => {
+    const comboRef = React.createRef<ComboBoxRef>()
+    render(
+      <form data-testid="fruit-form">
+        <ComboBox
+          id="favorite-fruit"
+          name="favorite-fruit"
+          options={fruitOptions}
+          onChange={vi.fn()}
+          ref={comboRef}
+        />
+      </form>
+    )
+
+    const form = screen.getByTestId<HTMLFormElement>('fruit-form')
+    const comboBoxSelect = screen.getByTestId('combo-box-select')
+    expect(new FormData(form).get('favorite-fruit')).toBe('')
+
+    await userEvent.click(screen.getByTestId('combo-box-toggle'))
+    await userEvent.click(screen.getByTestId('combo-box-option-yuzu'))
+    expect(comboBoxSelect).toHaveValue('yuzu')
+    expect(new FormData(form).get('favorite-fruit')).toBe('yuzu')
+
+    act(() => comboRef.current?.clearSelection())
+    expect(comboBoxSelect).toHaveValue('')
+    expect(new FormData(form).get('favorite-fruit')).toBe('')
   })
 
   describe('toggling the list', () => {
@@ -346,18 +401,25 @@ describe('ComboBox component', () => {
 
   describe('with custom props', () => {
     it('renders select with custom props if passed in', () => {
+      const onChange = vi.fn()
       const { getByTestId } = render(
         <ComboBox
           id="favorite-fruit"
           name="favorite-fruit"
           options={fruitOptions}
           onChange={vi.fn()}
-          selectProps={{ required: true, role: 'testing' }}
+          selectProps={{ required: true, role: 'testing', onChange }}
         />
       )
       const comboBoxSelect = getByTestId('combo-box-select')
-      expect(comboBoxSelect).toHaveAttribute('required')
+      const comboBoxInput = getByTestId('combo-box-input')
+      expect(comboBoxSelect).not.toHaveAttribute('required')
+      expect(comboBoxInput).toHaveAttribute('required')
+      expect(comboBoxInput).toBeInvalid()
       expect(comboBoxSelect).toHaveAttribute('role', 'testing')
+
+      fireEvent.change(comboBoxSelect, { target: { value: 'apple' } })
+      expect(onChange).toHaveBeenCalledTimes(1)
     })
 
     it('renders input with custom props if passed in', () => {

--- a/src/components/forms/ComboBox/ComboBox.tsx
+++ b/src/components/forms/ComboBox/ComboBox.tsx
@@ -14,8 +14,9 @@ import { ActionTypes, Action, State, useComboBox } from './useComboBox'
 /*  As per USWDS spec, ComboBox includes a HTML <select> with options AND a separate <input> and dropdown <ul> with items.
     The select is usa-sr-only and is always hidden via CSS. The input and dropdown list are the elements used for interaction.
 
-    There is the ability to pass in custom props directly to the select and input.
-    This should be using sparingly and not with existing Combobox props such as disabled, onChange, defaultValue. 
+    There is the ability to pass in custom props directly to the select and input. To match USWDS,
+    selectProps.required is applied to the visible input instead of the hidden select.
+    This should be used sparingly and not with existing Combobox props such as disabled, onChange, defaultValue.
 */
 
 export const DEFAULT_FILTER = '.*{{query}}.*'
@@ -114,6 +115,12 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
   ref
 ): JSX.Element => {
   const isDisabled = !!disabled
+  // USWDS validates the visible input rather than its hidden native select.
+  const {
+    required: selectRequired,
+    onChange: selectOnChange,
+    ...nativeSelectProps
+  } = selectProps ?? {}
 
   let defaultOption
   if (defaultValue) {
@@ -379,13 +386,16 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
       className={containerClasses}
       ref={containerRef}>
       <select
-        {...selectProps}
+        {...nativeSelectProps}
         className="usa-select usa-sr-only usa-combo-box__select"
         name={name}
         aria-hidden
         tabIndex={-1}
-        defaultValue={state.selectedOption?.value}
+        value={state.selectedOption?.value ?? ''}
+        onChange={(event): void => selectOnChange?.(event)}
         data-testid="combo-box-select">
+        {/* Keep first so an empty selection stays empty in the native select. */}
+        <option value="" />
         {options.map((option) => (
           <option key={option.value} value={option.value}>
             {option.label}
@@ -416,6 +426,7 @@ const ComboBoxForwardRef: React.ForwardRefRenderFunction<
         aria-activedescendant={(state.isOpen && focusedItemId) || ''}
         id={id}
         disabled={isDisabled}
+        required={inputProps?.required ?? selectRequired}
       />
       <span className="usa-combo-box__clear-input__wrapper" tabIndex={-1}>
         <button


### PR DESCRIPTION
## Summary

- keep the hidden native select synchronized with the ComboBox selection
- add the empty native option used by USWDS so an unselected ComboBox submits an empty value
- move `selectProps.required` to the visible input while preserving other native select props and `onChange`
- document the form-submission behavior in Storybook

This is a non-breaking bug fix under `docs/breaking-changes.md`: the previous submitted value contradicted both the visible ComboBox state and upstream USWDS behavior. Required validation now applies to an empty visible input. As in upstream USWDS, validating non-empty text that does not match an option remains outside this change.

**Compatibility note:** `selectProps.required` now applies to the visible text input instead of the hidden native select, matching USWDS. Consumers that query the hidden select for `required` should query the visible input instead.

`selectProps.defaultValue` remains unsupported because the component owns the native select value; supplying it now produces React's normal controlled/uncontrolled warning instead of being silently overridden.

## Related Issues

https://github.com/trussworks/react-uswds/issues/3591

## How To Test

1. Render a named ComboBox inside a form without a selection and verify `FormData` contains an empty value.
2. Select an option and verify both the hidden select and `FormData` contain its value.
3. Clear the selection through the public ref and verify both return to an empty value.
4. Replace the options so the selected value disappears and verify the hidden select returns to empty.
5. Pass `selectProps.required` and verify the visible input, rather than the hidden select, is required.
6. Run `npm run test`, `npm run test:coverage`, `npm run lint`, `npm run format:check`, `npm run build`, `npm run test:serverside`, `npm run build-storybook`, and `npm audit` on Node 26.3.0.

## Screenshots

Not applicable; the behavior is in the screen-reader-only native select.

## Checklist

- [ ] This is a breaking change
