### PR TITLE
fix: make Footer responsive fallback reliable

### DIFF
--- a/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.hydration.test.tsx
+++ b/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.hydration.test.tsx
@@ -1,0 +1,45 @@
+import React, { act } from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { renderToString } from 'react-dom/server'
+
+import { FooterExtendedNavList } from './FooterExtendedNavList'
+
+const browserWindow = window
+const restoreWindow = (): void => {
+  Object.defineProperty(globalThis, 'window', {
+    value: browserWindow,
+    writable: true,
+    configurable: true,
+  })
+}
+
+describe('FooterExtendedNavList hydration', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    restoreWindow()
+  })
+
+  it('hydrates with the current window width', () => {
+    const props = { nestedLinks: [[<>Section</>, <>Link</>]] }
+    Reflect.deleteProperty(globalThis, 'window')
+    const markup = renderToString(<FooterExtendedNavList {...props} />)
+    restoreWindow()
+    vi.stubGlobal('innerWidth', 479)
+
+    document.body.innerHTML = `<div id="root">${markup}</div>`
+    const container = document.getElementById('root') as HTMLElement
+    const onRecoverableError = vi.fn()
+
+    let root: ReturnType<typeof hydrateRoot>
+    act(() => {
+      root = hydrateRoot(container, <FooterExtendedNavList {...props} />, {
+        onRecoverableError,
+      })
+    })
+
+    expect(container.querySelectorAll('section.hidden')).toHaveLength(1)
+    expect(onRecoverableError).not.toHaveBeenCalled()
+
+    act(() => root.unmount())
+  })
+})

--- a/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.server.test.tsx
+++ b/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.server.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment node
+
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+
+import { FooterExtendedNavList } from './FooterExtendedNavList'
+
+describe('FooterExtendedNavList server rendering', () => {
+  it('does not access the window while rendering', () => {
+    expect(() =>
+      renderToString(
+        <FooterExtendedNavList nestedLinks={[[<>Section</>, <>Link</>]]} />
+      )
+    ).not.toThrow()
+  })
+})

--- a/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.test.tsx
+++ b/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.test.tsx
@@ -1,7 +1,7 @@
 /*  eslint-disable jsx-a11y/anchor-is-valid */
 
 import React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { FooterExtendedNavList } from './FooterExtendedNavList'
@@ -141,6 +141,36 @@ describe('FooterExtendedNavList component', () => {
 
         const elementsWithHiddenClass = container.querySelectorAll('.hidden')
         expect(elementsWithHiddenClass.length).toEqual(0)
+      })
+
+      it('tracks repeated window width changes', () => {
+        vi.stubGlobal('innerWidth', 1024)
+        const { container } = setup()
+
+        vi.stubGlobal('innerWidth', 479)
+        fireEvent.resize(window)
+        expect(container.querySelectorAll('.hidden')).toHaveLength(2)
+
+        vi.stubGlobal('innerWidth', 1024)
+        fireEvent.resize(window)
+        expect(container.querySelectorAll('.hidden')).toHaveLength(0)
+      })
+
+      it('uses the current width when automatic layout is enabled', () => {
+        vi.stubGlobal('innerWidth', 1024)
+        const { container, rerender } = setup({ isMobile: false })
+
+        expect(container.querySelectorAll('.hidden')).toHaveLength(0)
+
+        vi.stubGlobal('innerWidth', 479)
+        rerender(
+          <>
+            <style>{'.hidden { display: none; }'}</style>
+            <FooterExtendedNavList nestedLinks={links} isMobile={undefined} />
+          </>
+        )
+
+        expect(container.querySelectorAll('.hidden')).toHaveLength(2)
       })
     })
   })

--- a/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.tsx
+++ b/src/components/footer/FooterExtendedNavList/FooterExtendedNavList.tsx
@@ -21,11 +21,8 @@ export const FooterExtendedNavList = ({
   nestedLinks,
 }: FooterExtendedNavListProps): JSX.Element => {
   const classes = classnames('grid-row grid-gap-4', className)
-  const isClient = window && typeof window === 'object'
 
-  const [isMobileFallback, setIsMobileFallback] = React.useState<boolean>(
-    isClient && window.innerWidth < 480
-  )
+  const [isMobileFallback, setIsMobileFallback] = React.useState(false)
   const [sectionsOpenState, setSectionsOpenState] = useState<boolean[]>(
     nestedLinks.map(() => false)
   )
@@ -34,18 +31,16 @@ export const FooterExtendedNavList = ({
   const useMobile = isMobile || (isMobile === undefined && isMobileFallback)
 
   useEffect(() => {
-    if (isMobile) return
+    if (isMobile !== undefined) return
 
     function handleResize(): void {
-      const updatedIsMobileFallback = isClient && window.innerWidth < 480
-      if (updatedIsMobileFallback !== isMobileFallback) {
-        setIsMobileFallback(updatedIsMobileFallback)
-      }
+      setIsMobileFallback(window.innerWidth < 480)
     }
 
+    handleResize()
     window.addEventListener('resize', handleResize)
     return (): void => window.removeEventListener('resize', handleResize)
-  }, [])
+  }, [isMobile])
 
   const onToggle = (index: number): void => {
     setSectionsOpenState((prevIsOpen) => {

--- a/src/components/footer/FooterNav/FooterNav.stories.tsx
+++ b/src/components/footer/FooterNav/FooterNav.stories.tsx
@@ -89,6 +89,12 @@ export const BigFooterNav: Story = {
     />
   ),
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Without an explicit `isMobile` prop, the extended navigation follows changes to the browser width.',
+      },
+    },
     happo: { waitForContent: 'Secondary link that is pretty long' },
   },
 }


### PR DESCRIPTION
# Summary

- make `FooterExtendedNavList` safe to render without `window`
- recompute the mobile fallback from the current viewport on every resize instead of toggling stale state
- keep server and client hydration markup aligned, then apply the current client width after hydration
- cover server rendering, hydration, prop-to-fallback transitions, and repeated desktop/mobile transitions
- document the responsive fallback in Storybook

## Related Issues or PRs

https://github.com/trussworks/react-uswds/issues/3585

## How To Test

Run the full local gate on Node 26.3.0:

```sh
npm run test
npm run lint
npm run format:check
npm audit
npm run test:coverage
npm run build
npm run test:serverside
npm run build-storybook
```

The focused regressions are in `FooterExtendedNavList.test.tsx`, `FooterExtendedNavList.server.test.tsx`, and `FooterExtendedNavList.hydration.test.tsx`.

## Screenshots (optional)

Not applicable; the change corrects responsive state transitions and server rendering without changing the intended rendered states.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
