### PR TITLE
fix: keep FilePreview synchronized

### DIFF
--- a/src/components/forms/FileInput/FileInput.stories.tsx
+++ b/src/components/forms/FileInput/FileInput.stories.tsx
@@ -19,6 +19,8 @@ const meta: Meta<typeof FileInput> = {
         component: `
 ### USWDS 3.0 FileInput component
 Source: https://designsystem.digital.gov/components/file-input
+
+File previews stay synchronized when a selected file is replaced by another file with the same name.
 `,
       },
     },

--- a/src/components/forms/FileInput/FilePreview.test.tsx
+++ b/src/components/forms/FileInput/FilePreview.test.tsx
@@ -5,6 +5,8 @@ import { FilePreview } from './FilePreview'
 import { SPACER_GIF, TEST_TEXT_FILE } from './constants'
 
 describe('FilePreview component', () => {
+  afterEach(() => vi.restoreAllMocks())
+
   const testProps = {
     imageId: 'testImageId_12345',
     file: TEST_TEXT_FILE,
@@ -27,7 +29,7 @@ describe('FilePreview component', () => {
     )
   })
 
-  it('renders without errors when loaded multiple times (simulating react dev mode)', () => {
+  it('loads the preview when rendered in StrictMode', async () => {
     const { getByTestId } = render(
       <StrictMode>
         <FilePreview imageId="" file={TEST_TEXT_FILE} />
@@ -35,6 +37,21 @@ describe('FilePreview component', () => {
     )
 
     expect(getByTestId('file-input-preview')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(getByTestId('file-input-preview-image')).toHaveAttribute(
+        'src',
+        'data:text/plain;base64,VGVzdCBGaWxlIENvbnRlbnRz'
+      )
+    )
+  })
+
+  it('aborts the file read when unmounted', () => {
+    const abortSpy = vi.spyOn(window.FileReader.prototype, 'abort')
+    const { unmount } = render(<FilePreview {...testProps} />)
+
+    unmount()
+
+    expect(abortSpy).toHaveBeenCalledOnce()
   })
 
   it('renders a preview image', async () => {
@@ -87,6 +104,58 @@ describe('FilePreview component', () => {
       const imageEl = getByTestId('file-input-preview-image')
       await waitFor(() => expect(imageEl).not.toHaveClass('is-loading'))
       expect(imageEl).toHaveAttribute('src', expectedSrc)
+    })
+
+    it('updates the preview when the file changes', async () => {
+      const firstFile = new File(['first'], 'same-name.txt', {
+        type: 'text/plain',
+      })
+      const secondFile = new File(['second'], 'same-name.txt', {
+        type: 'text/plain',
+      })
+      const { getByTestId, rerender } = render(
+        <FilePreview imageId="same-name" file={firstFile} />
+      )
+      const imageEl = getByTestId('file-input-preview-image')
+
+      await waitFor(() =>
+        expect(imageEl).toHaveAttribute(
+          'src',
+          'data:text/plain;base64,Zmlyc3Q='
+        )
+      )
+      fireEvent.error(imageEl)
+      expect(imageEl).toHaveClass('usa-file-input__preview-image--generic')
+
+      rerender(<FilePreview imageId="same-name" file={secondFile} />)
+
+      await waitFor(() =>
+        expect(imageEl).toHaveAttribute(
+          'src',
+          'data:text/plain;base64,c2Vjb25k'
+        )
+      )
+      expect(imageEl).not.toHaveClass('usa-file-input__preview-image--generic')
+    })
+
+    it('shows the loading state while a replacement file loads', async () => {
+      const firstFile = new File(['first'], 'same-name.txt', {
+        type: 'text/plain',
+      })
+      const secondFile = new File(['second'], 'same-name.txt', {
+        type: 'text/plain',
+      })
+      const { getByTestId, rerender } = render(
+        <FilePreview imageId="same-name" file={firstFile} />
+      )
+      const imageEl = getByTestId('file-input-preview-image')
+
+      await waitFor(() => expect(imageEl).not.toHaveClass('is-loading'))
+
+      rerender(<FilePreview imageId="same-name" file={secondFile} />)
+
+      expect(imageEl).toHaveClass('is-loading')
+      expect(imageEl).toHaveAttribute('src', SPACER_GIF)
     })
 
     describe.each([

--- a/src/components/forms/FileInput/FilePreview.tsx
+++ b/src/components/forms/FileInput/FilePreview.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useEffect, useRef, useState } from 'react'
+import React, { type JSX, useEffect, useState } from 'react'
 import classnames from 'classnames'
 
 /** Moving the SPACER_GIF definition here instead of the constants.ts file,
@@ -15,28 +15,29 @@ export const FilePreview = ({
   imageId: string
   file: File
 }): JSX.Element => {
-  const fileReaderRef = useRef<FileReader>(new FileReader())
   const [isLoading, setIsLoading] = useState(true)
   const [previewSrc, setPreviewSrc] = useState(SPACER_GIF)
   const [showGenericPreview, setShowGenericPreview] = useState(false)
-  const firstRenderRef = useRef(false)
 
   useEffect(() => {
-    if (firstRenderRef.current) {
-      // already run, do nothing
-      return
-    }
-    // only run once
-    firstRenderRef.current = true
+    const fileReader = new FileReader()
+    setIsLoading(true)
+    setPreviewSrc(SPACER_GIF)
+    setShowGenericPreview(false)
 
-    fileReaderRef.current.onloadend = (): void => {
+    fileReader.onloadend = (): void => {
       setIsLoading(false)
-      setPreviewSrc(fileReaderRef.current.result as string)
-      fileReaderRef.current.onloadend = null // is only run once
+      setPreviewSrc(fileReader.result as string)
     }
 
-    fileReaderRef.current.readAsDataURL(file)
-  }, [])
+    fileReader.readAsDataURL(file)
+
+    return (): void => {
+      // abort() fires loadend, so detach the handler before aborting.
+      fileReader.onloadend = null
+      fileReader.abort()
+    }
+  }, [file])
 
   const { name } = file
 


### PR DESCRIPTION
# Summary

- Re-read a replacement file when FilePreview receives a new File with the same name.
- Restore the loading and generic-preview state while the replacement is read.
- Create FileReader instances inside the effect and abort in-flight reads during cleanup, so render remains free of browser API construction.
- Add regression coverage for replacement previews, loading state, cleanup, and StrictMode.

The isolated review identified two missing assertions on the original diff. The amended tests cover both; the amended tree passed the full local gate and an additional targeted review.

## Related Issues or PRs

https://github.com/trussworks/react-uswds/issues/3585

## How To Test

1. Run `npx vitest --run src/components/forms/FileInput/FilePreview.test.tsx`.
2. Select a file, then replace it with a different file that has the same name; confirm the preview enters its loading state and then displays the replacement file.
3. Run `npm test`, `npm run lint`, and `npm run format:check`.

## Screenshots (optional)

Not applicable; the visible change occurs only while a replacement file is loading.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)