### PR TITLE
fix: synchronize controlled TextInputMask values

### DIFF
--- a/src/components/forms/TextInputMask/TextInputMask.stories.tsx
+++ b/src/components/forms/TextInputMask/TextInputMask.stories.tsx
@@ -14,6 +14,8 @@ const meta: Meta<typeof TextInputMask> = {
 ### USWDS 3.0 TextInputMask component
 
 Source: https://designsystem.digital.gov/components/input-mask/
+
+Controlled values are re-masked when the value, mask, or charset changes.
 `,
       },
     },

--- a/src/components/forms/TextInputMask/TextInputMask.test.tsx
+++ b/src/components/forms/TextInputMask/TextInputMask.test.tsx
@@ -4,6 +4,8 @@ import { userEvent } from '@testing-library/user-event'
 import { TextInputMask } from './TextInputMask'
 
 describe('TextInputMask component', () => {
+  const requiredProps = { name: 'masked-input', type: 'text' as const }
+
   const setup = () => {
     const utils = render(
       <TextInputMask
@@ -43,5 +45,103 @@ describe('TextInputMask component', () => {
     const { input, user } = setup()
     await user.type(input, 'A1B 2C')
     expect((input as HTMLInputElement).value).toBe('A1B 2C')
+  })
+
+  it('updates the mask overlay when a controlled value changes', () => {
+    const { rerender } = render(
+      <TextInputMask
+        {...requiredProps}
+        id="controlled"
+        mask="____"
+        value="12"
+      />
+    )
+
+    expect(screen.getByTestId('controlledMask')).toHaveTextContent('12__', {
+      normalizeWhitespace: false,
+    })
+
+    rerender(
+      <TextInputMask
+        {...requiredProps}
+        id="controlled"
+        mask="____"
+        value="1234"
+      />
+    )
+
+    expect(screen.getByTestId('controlledMask').textContent).toBe('1234')
+  })
+
+  it('re-masks a controlled value when the mask changes', () => {
+    const { rerender } = render(
+      <TextInputMask
+        {...requiredProps}
+        id="controlled-mask"
+        mask="____"
+        value="1234"
+      />
+    )
+
+    rerender(
+      <TextInputMask
+        {...requiredProps}
+        id="controlled-mask"
+        mask="__-__"
+        value="1234"
+      />
+    )
+
+    expect(screen.getByTestId('textInput')).toHaveValue('12-34')
+  })
+
+  it('re-masks a controlled value when the charset changes', () => {
+    const { rerender } = render(
+      <TextInputMask
+        {...requiredProps}
+        id="controlled-charset"
+        mask="____"
+        charset="####"
+        value="1234"
+      />
+    )
+
+    rerender(
+      <TextInputMask
+        {...requiredProps}
+        id="controlled-charset"
+        mask="____"
+        charset="AAAA"
+        value="1234"
+      />
+    )
+
+    // The letter-only charset rejects the numeric value at its first character.
+    expect(screen.getByTestId('textInput')).toHaveValue('')
+  })
+
+  it('does not reapply a changed defaultValue after user input', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <TextInputMask
+        {...requiredProps}
+        id="uncontrolled"
+        mask="____"
+        defaultValue="12"
+      />
+    )
+    const input = screen.getByTestId('textInput')
+
+    await user.type(input, '34')
+    rerender(
+      <TextInputMask
+        {...requiredProps}
+        id="uncontrolled"
+        mask="____"
+        defaultValue="9"
+      />
+    )
+
+    expect(input).toHaveValue('1234')
   })
 })

--- a/src/components/forms/TextInputMask/TextInputMask.tsx
+++ b/src/components/forms/TextInputMask/TextInputMask.tsx
@@ -63,19 +63,13 @@ export const TextInputMask = ({
   )
   useEffect(() => {
     // Make sure this component behaves correctly when used as a controlled component
-    setValue(
-      maskString(
-        ((externalValue ?? defaultValue) as string) ?? ``,
-        mask,
-        charset
-      )
-    )
-  }, [externalValue])
-  const [maskValue, setMaskValue] = useState(mask.substring(value.length))
+    if (externalValue === undefined) return
+    setValue(maskString(externalValue as string, mask, charset))
+  }, [externalValue, mask, charset])
+  const maskValue = mask.substring(value.length)
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const newValue = maskString(e.target.value, mask, charset)
 
-    setMaskValue(mask.substring(newValue.length))
     setValue(newValue)
 
     // Ensure the new value is available to upstream onChange listeners


### PR DESCRIPTION
# Summary

- derive the visible mask overlay from the current input value
- re-mask controlled values when `value`, `mask`, or `charset` changes
- preserve initial-only `defaultValue` behavior for uncontrolled inputs
- document the controlled synchronization behavior in Storybook

A controlled-to-uncontrolled transition now preserves the last controlled value instead of resetting to `defaultValue`. React treats switching control modes as unsupported; the change avoids surprising data loss on that transition.

## Related Issues or PRs

Relates to #3585.

Stacked on #3595; merge that PR first.

## How To Test

1. Run `npx vitest --run src/components/forms/TextInputMask`.
2. Verify the controlled-value, mask-change, and charset-change tests pass.
3. Run `npm test`, `npm run lint`, `npm run format:check`, `npm audit --omit=dev --audit-level=high`, `npm run test:coverage`, `npm run build`, `npm run test:serverside`, and `npm run build-storybook`.

## Screenshots (optional)

Not applicable; the change corrects controlled-state synchronization without changing the component API or default rendered appearance.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
