### PR TITLE
fix: honor midnight TimePicker limits

### DIFF
--- a/src/components/forms/FileInput/FileInput.tsx
+++ b/src/components/forms/FileInput/FileInput.tsx
@@ -70,7 +70,7 @@ export const FileInputForwardRef: React.ForwardRefRenderFunction<
       /Edge\/\d./i.test(navigator?.userAgent)
 
     setHideDragText(hideDragText)
-  }, [typeof navigator])
+  }, [])
 
   useImperativeHandle(
     ref,

--- a/src/components/forms/TextInput/TextInput.stories.tsx
+++ b/src/components/forms/TextInput/TextInput.stories.tsx
@@ -13,6 +13,8 @@ const meta = {
 ### USWDS 3.0 TextInput component
 
 Source: https://designsystem.digital.gov/components/text-input
+
+The legacy \`inputRef\` prop is deprecated and will be removed in a future major version. Use the React \`ref\` prop instead.
 `,
       },
     },

--- a/src/components/forms/TextInput/TextInput.test.tsx
+++ b/src/components/forms/TextInput/TextInput.test.tsx
@@ -1,7 +1,10 @@
 import React, { MutableRefObject, useRef } from 'react'
 import { render } from '@testing-library/react'
+import { deprecationWarning } from '../../../deprecation'
 import { TextInput } from './TextInput'
 import { ValidationStatus } from '../../../types/validationStatus'
+
+vi.mock('../../../deprecation')
 
 describe('TextInput component', () => {
   it('renders without errors', () => {
@@ -86,5 +89,55 @@ describe('TextInput component', () => {
       expect(parentRef.current).toBeInTheDocument()
       expect(parentRef.current.tagName).toBe('INPUT')
     })
+  })
+
+  it('warns when the deprecated inputRef prop is added after mount', () => {
+    vi.clearAllMocks()
+    const inputRef = { current: null }
+    const { rerender } = render(
+      <TextInput id="input-type-text" name="input-type-text" type="text" />
+    )
+
+    rerender(
+      <TextInput
+        id="input-type-text"
+        name="input-type-text"
+        type="text"
+        inputRef={inputRef}
+      />
+    )
+
+    expect(deprecationWarning).toHaveBeenCalledOnce()
+  })
+
+  it('warns only once when an inline inputRef changes identity', () => {
+    vi.clearAllMocks()
+    const { rerender } = render(
+      <TextInput
+        id="input-type-text"
+        name="input-type-text"
+        type="text"
+        inputRef={() => undefined}
+      />
+    )
+
+    rerender(
+      <TextInput
+        id="input-type-text"
+        name="input-type-text"
+        type="text"
+        inputRef={() => undefined}
+      />
+    )
+    rerender(
+      <TextInput
+        id="input-type-text"
+        name="input-type-text"
+        type="text"
+        inputRef={() => undefined}
+      />
+    )
+
+    expect(deprecationWarning).toHaveBeenCalledOnce()
   })
 })

--- a/src/components/forms/TextInput/TextInput.tsx
+++ b/src/components/forms/TextInput/TextInput.tsx
@@ -39,14 +39,15 @@ export const TextInput = forwardRef(
       inputRef,
       ...inputProps
     } = props
+    const hasInputRef = !!inputRef
 
     useEffect(() => {
-      if (inputRef) {
+      if (hasInputRef) {
         deprecationWarning(
           'TextInput: The `inputRef` prop is deprecated. Use the `ref` prop instead. `inputRef` will be removed in a future major version.'
         )
       }
-    }, [])
+    }, [hasInputRef])
 
     const isError = validationStatus === 'error'
     const isSuccess = validationStatus === 'success'

--- a/src/components/forms/TimePicker/TimePicker.stories.tsx
+++ b/src/components/forms/TimePicker/TimePicker.stories.tsx
@@ -22,6 +22,8 @@ const meta = {
 ### USWDS 3.0 TimePicker component
 
 https://designsystem.digital.gov/components/time-picker/
+
+With the default \`minTime\` and \`step\`, \`maxTime="00:00"\` limits the options to midnight.
 `,
       },
     },

--- a/src/components/forms/TimePicker/TimePicker.test.tsx
+++ b/src/components/forms/TimePicker/TimePicker.test.tsx
@@ -44,6 +44,18 @@ describe('TimePicker Component', () => {
     expect(comboBoxDropdownList.children.length).toEqual(7)
   })
 
+  it('limits options to midnight when maxTime is 00:00', () => {
+    const { getByTestId } = render(
+      <TimePicker {...testProps} maxTime="00:00" />
+    )
+
+    const comboBoxDropdownList = getByTestId('combo-box-option-list')
+    expect(comboBoxDropdownList.children).toHaveLength(1)
+    expect(
+      within(comboBoxDropdownList).getByText('12:00am')
+    ).toBeInTheDocument()
+  })
+
   it('displays 24 hour time labels without am/pm when format is 24h', () => {
     const { getByTestId } = render(
       <TimePicker

--- a/src/components/forms/TimePicker/TimePicker.tsx
+++ b/src/components/forms/TimePicker/TimePicker.tsx
@@ -53,12 +53,12 @@ export const TimePicker = ({
 }: TimePickerProps): JSX.Element => {
   const classes = classnames('usa-time-picker', className)
 
-  const parsedMinTime = parseTimeString(minTime) || DEFAULT_MIN_TIME_MINUTES
-  const parsedMaxTime = parseTimeString(maxTime) || DEFAULT_MAX_TIME_MINUTES
+  const parsedMinTime = parseTimeString(minTime) ?? DEFAULT_MIN_TIME_MINUTES
+  const parsedMaxTime = parseTimeString(maxTime) ?? DEFAULT_MAX_TIME_MINUTES
   const validStep = step < MIN_STEP ? MIN_STEP : step
   const timeOptions = useMemo(
     () => getTimeOptions(parsedMinTime, parsedMaxTime, validStep, format),
-    [minTime, maxTime, step, format]
+    [parsedMinTime, parsedMaxTime, validStep, format]
   )
 
   const customFilter =


### PR DESCRIPTION
# Summary

- Treat parsed midnight (`0`) as a valid `TimePicker` limit instead of falling back to the end of the day.
- Keep the `FileInput` and `TimePicker` effect dependencies aligned with the values their effects use.
- Emit the deprecated `TextInput.inputRef` warning when the prop first appears without repeating it when callback-ref identity changes.
- Document the affected `TextInput` and `TimePicker` behavior in Storybook.

The public APIs are unchanged. This is a non-breaking patch.

## Related Issues or PRs

https://github.com/trussworks/react-uswds/issues/3585

This PR is stacked on the TextInputMask hook-dependency fix.

## How To Test

- Run `npm test`.
- Run `npm run lint` and `npm run format:check`.
- Render `TimePicker` with `maxTime="00:00"`; the option list should contain midnight only.
- Render `TextInput` with an inline `inputRef`, rerender it with new callback identities, and confirm the deprecation warning is emitted once.

## Screenshots (optional)

No visible change requires a screenshot; the corrected TimePicker case affects the options in the closed dropdown.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)