### PR TITLE
fix: revalidate DatePicker format changes

### DIFF
--- a/src/components/forms/DatePicker/DatePicker.stories.tsx
+++ b/src/components/forms/DatePicker/DatePicker.stories.tsx
@@ -55,10 +55,11 @@ Source: https://designsystem.digital.gov/components/date-picker
 - typing the Enter key in the external text input
 - on focusout (blur) of the external text input
 
-Because this component uses the useEffect hook to trigger validation whenever the date value changes (regardless of how), the React DatePicker will validate when:
+Because this component uses the useEffect hook to trigger validation whenever the date value or its validation props change, the React DatePicker will validate when:
 - setting the initial value based on the default value passed in (same as above)
 - clicking on a date in the calendar UI (same as above)
 - on input (change) of the external text input
+- changing the \`dateFormat\` prop for the current input value
 
 It's also worth mentioning that validation in this case is just calling [setCustomValidity](https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity) on the external text input, and library users should be able to determine how & when they want invalid UI to display by inspecting the [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) of the external input.
 

--- a/src/components/forms/DatePicker/DatePicker.test.tsx
+++ b/src/components/forms/DatePicker/DatePicker.test.tsx
@@ -13,6 +13,7 @@ import { sampleLocalization } from './i18n'
 import { today } from './utils'
 import {
   DAY_OF_WEEK_LABELS,
+  INTERNAL_DATE_FORMAT,
   MONTH_LABELS,
   VALIDATION_MESSAGE,
 } from './constants'
@@ -599,6 +600,21 @@ describe('DatePicker component', () => {
   })
 
   describe('validation', () => {
+    it('revalidates the current value when dateFormat changes', async () => {
+      const { getByTestId, rerender } = renderDatePicker()
+      const externalInput = getByTestId(
+        'date-picker-external-input'
+      ) as HTMLInputElement
+
+      await userEvent.type(externalInput, '12/31/2024')
+      expect(externalInput).toBeValid()
+
+      rerender(<DatePicker {...testProps} dateFormat={INTERNAL_DATE_FORMAT} />)
+
+      expect(externalInput).toBeInvalid()
+      expect(externalInput.validationMessage).toEqual(VALIDATION_MESSAGE)
+    })
+
     it('entering an empty value is valid', async () => {
       const { getByTestId } = renderDatePicker()
       const externalInput = getByTestId(

--- a/src/components/forms/DatePicker/DatePicker.tsx
+++ b/src/components/forms/DatePicker/DatePicker.tsx
@@ -188,7 +188,7 @@ export const DatePicker = ({
 
   useEffect(() => {
     validateInput()
-  }, [externalValue, minDate, maxDate])
+  }, [externalValue, dateFormat, minDate, maxDate])
 
   const handleToggleClick = (): void => {
     if (isAriaDisabled) {


### PR DESCRIPTION
## Summary

- revalidate the current DatePicker value when `dateFormat` changes
- document the validation behavior in Storybook

The validation effect omitted `dateFormat`, so a value could remain marked valid after the accepted format changed. This PR adds the missing reactive input and a regression test that changes the format without changing the value.

## Related Issues

https://github.com/trussworks/react-uswds/issues/3585

## How To Test

1. Run `npm run test -- src/components/forms/DatePicker`.
2. Run `npm run lint`.
3. Run `npm run format:check`.

The full test, coverage, build, server-side, Storybook, lint, format, and production-audit checks pass locally on Node 26.3.0.

## Semver

Patch, non-breaking. No public API changes.

- [x] This is not a breaking change.