### PR TITLE
fix: reposition visible Tooltips

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -26,6 +26,8 @@ const meta: Meta<typeof Tooltip> = {
 ### USWDS 3.0 Tooltip component
 
 Source: https://designsystem.digital.gov/components/tooltip/
+
+Changing the \`position\` prop repositions a tooltip that is already visible.
 `,
       },
     },

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -154,6 +154,29 @@ describe('Tooltip component', () => {
         `usa-tooltip__body--bottom`
       )
     })
+
+    it('repositions a visible tooltip when the position prop changes', () => {
+      const { rerender } = render(
+        <Tooltip position="top" label="Click me">
+          My Tooltip
+        </Tooltip>
+      )
+
+      fireEvent.mouseEnter(screen.getByTestId('triggerElement'))
+      expect(screen.getByTestId('tooltipBody')).toHaveClass(
+        'usa-tooltip__body--top'
+      )
+
+      rerender(
+        <Tooltip position="bottom" label="Click me">
+          My Tooltip
+        </Tooltip>
+      )
+
+      expect(screen.getByTestId('tooltipBody')).toHaveClass(
+        'usa-tooltip__body--bottom'
+      )
+    })
   })
 
   describe('with a className prop', () => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -192,7 +192,7 @@ export function Tooltip<
         }
       }
     }
-  }, [isVisible])
+  }, [isVisible, position])
 
   const showTooltip = useCallback((): void => {
     setVisible(true)


### PR DESCRIPTION
## Summary

- Reapply Tooltip positioning when the `position` prop changes while the tooltip is visible.
- Add a regression test for changing from top to bottom without hiding the tooltip.
- Document the live prop-change behavior in Storybook.

The retry-loop dependency finding remains for the final exhaustive-deps enforcement change because adding those dependencies would change the retry model.

## Related Issues

https://github.com/trussworks/react-uswds/issues/3585

## How To Test

1. Render a Tooltip with `position="top"` and show it.
2. Rerender it with `position="bottom"` while it remains visible.
3. Confirm the tooltip body changes from the top class to the bottom class.
4. Run `npm test`, `npm run lint`, `npm run format:check`, `npm run test:coverage`, `npm run build`, `npm run build:storybook`, and `npm run test:serverside`.

## Screenshots

Not applicable; the regression is a prop update while the tooltip is visible.

## Checklist

- [x] This change is non-breaking.
- [ ] This change includes a breaking change.
