### PR TITLE
fix: lock body scroll for mobile navigation

### DIFF
--- a/src/components/header/ExtendedNav/ExtendedNav.test.tsx
+++ b/src/components/header/ExtendedNav/ExtendedNav.test.tsx
@@ -96,6 +96,7 @@ describe('ExtendedNav component', () => {
       />
     )
     expect(container.querySelector('.is-visible')).toBeInTheDocument()
+    expect(document.body).toHaveClass('usa-js-mobile-nav--active')
   })
 
   it('does not render the is-visible class when mobileExpanded is false', () => {

--- a/src/components/header/ExtendedNav/ExtendedNav.tsx
+++ b/src/components/header/ExtendedNav/ExtendedNav.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames'
 
 import { NavCloseButton } from '../NavCloseButton/NavCloseButton'
 import { NavList } from '../NavList/NavList'
+import { useMobileNavScrollLock } from '../useMobileNavScrollLock'
 
 export type ExtendedNavProps = {
   primaryItems: React.ReactNode[]
@@ -22,6 +23,8 @@ export const ExtendedNav = ({
   onToggleMobileNav,
   ...navProps
 }: ExtendedNavProps): JSX.Element => {
+  useMobileNavScrollLock(mobileExpanded)
+
   const classes = classnames(
     'usa-nav',
     {

--- a/src/components/header/Header/Header.stories.tsx
+++ b/src/components/header/Header/Header.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof Header> = {
 ### USWDS 3.0 Header component
 
 Source: https://designsystem.digital.gov/components/header/
+
+Expanding the mobile navigation locks body scrolling until the navigation closes or unmounts.
 `,
       },
     },

--- a/src/components/header/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.test.tsx
@@ -3,6 +3,15 @@ import { render, fireEvent } from '@testing-library/react'
 
 import { PrimaryNav } from './PrimaryNav'
 
+vi.mock('../../modal/utils', async (importOriginal) => {
+  const utils = await importOriginal<typeof import('../../modal/utils')>()
+
+  return {
+    ...utils,
+    getScrollbarWidth: vi.fn().mockReturnValue('15px'),
+  }
+})
+
 const testItems = [
   <a className="usa-current" href="#linkOne" key="one">
     Simple link one
@@ -16,7 +25,22 @@ const onToggleMobileNav = (): void => {
   /* mock submit fn */
 }
 
+const renderNav = (mobileExpanded: boolean) => (
+  <React.StrictMode>
+    <PrimaryNav
+      items={testItems}
+      onToggleMobileNav={onToggleMobileNav}
+      mobileExpanded={mobileExpanded}
+    />
+  </React.StrictMode>
+)
+
 describe('PrimaryNav component', () => {
+  afterEach(() => {
+    document.body.classList.remove('usa-js-mobile-nav--active')
+    document.body.style.removeProperty('padding-right')
+  })
+
   it('renders without errors', () => {
     const { queryByRole } = render(
       <PrimaryNav items={testItems} onToggleMobileNav={onToggleMobileNav} />
@@ -59,6 +83,40 @@ describe('PrimaryNav component', () => {
       />
     )
     expect(container.querySelector('.is-visible')).toBeInTheDocument()
+  })
+
+  it('locks body scrolling only while the mobile navigation is expanded', () => {
+    document.body.style.paddingRight = '5px'
+
+    const { rerender, unmount } = render(renderNav(false))
+
+    rerender(renderNav(true))
+    expect(document.body).toHaveClass('usa-js-mobile-nav--active')
+    expect(document.body).toHaveStyle({ paddingRight: '20px' })
+
+    rerender(renderNav(false))
+    expect(document.body).not.toHaveClass('usa-js-mobile-nav--active')
+    expect(document.body).toHaveStyle({ paddingRight: '5px' })
+
+    rerender(renderNav(true))
+    unmount()
+    expect(document.body).not.toHaveClass('usa-js-mobile-nav--active')
+    expect(document.body).toHaveStyle({ paddingRight: '5px' })
+
+    document.body.style.removeProperty('padding-right')
+
+    const { unmount: unmountWithoutInitialPadding } = render(renderNav(true))
+    unmountWithoutInitialPadding()
+    expect(document.body.style.paddingRight).toBe('')
+  })
+
+  it('locks body scrolling when initially expanded in StrictMode', () => {
+    document.body.style.paddingRight = '5px'
+
+    render(renderNav(true))
+
+    expect(document.body).toHaveClass('usa-js-mobile-nav--active')
+    expect(document.body).toHaveStyle({ paddingRight: '20px' })
   })
 
   it('does not render the is-visible class when mobileExpanded is false', () => {

--- a/src/components/header/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames'
 
 import { NavCloseButton } from '../NavCloseButton/NavCloseButton'
 import { NavList } from '../NavList/NavList'
+import { useMobileNavScrollLock } from '../useMobileNavScrollLock'
 
 export type PrimaryNavProps = {
   items: React.ReactNode[]
@@ -20,6 +21,8 @@ export const PrimaryNav = ({
   className,
   ...navProps
 }: PrimaryNavProps): JSX.Element => {
+  useMobileNavScrollLock(mobileExpanded)
+
   const classes = classnames(
     'usa-nav',
     {

--- a/src/components/header/useMobileNavScrollLock.ts
+++ b/src/components/header/useMobileNavScrollLock.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+import { getScrollbarWidth } from '../modal/utils'
+
+const ACTIVE_CLASS = 'usa-js-mobile-nav--active'
+
+export const useMobileNavScrollLock = (expanded?: boolean): void => {
+  useEffect(() => {
+    if (!expanded) return
+
+    const { body } = document
+    const initialPadding = body.style.paddingRight
+    const computedPadding =
+      window.getComputedStyle(body).getPropertyValue('padding-right') || '0px'
+    const scrollbarWidth = getScrollbarWidth()
+    const temporaryPadding = `${
+      parseInt(computedPadding.replace(/px/, ''), 10) +
+      parseInt(scrollbarWidth.replace(/px/, ''), 10)
+    }px`
+
+    body.style.paddingRight = temporaryPadding
+    body.classList.add(ACTIVE_CLASS)
+
+    return (): void => {
+      body.style.paddingRight = initialPadding
+      body.classList.remove(ACTIVE_CLASS)
+    }
+  }, [expanded])
+}


### PR DESCRIPTION
# Summary

- lock body scrolling while `PrimaryNav` or `ExtendedNav` is expanded on mobile
- compensate for the removed scrollbar without leaving an inline body style after close or unmount
- cover open, close, unmount, and StrictMode mount behavior

This restores the scroll-lock portion of USWDS mobile navigation behavior. The change is non-breaking and requires no consumer migration unless an application already supplies its own mobile-nav scroll lock; in that case both mechanisms will run.

Known limits retained for follow-up work:

- simultaneous expanded navs do not coordinate ownership of the body class or padding
- Modal and mobile navigation do not coordinate their body padding changes
- widening the viewport does not automatically close the React nav and release the lock as USWDS JavaScript does
- Safari-specific USWDS scroll handling is outside this PR

## Related Issues or PRs

Closes https://github.com/trussworks/react-uswds/issues/3600

## How To Test

1. Run `npx vitest --run src/components/header/PrimaryNav src/components/header/ExtendedNav`.
2. Open a Header story at a mobile viewport and expand the navigation.
3. Confirm the page body has `usa-js-mobile-nav--active` and does not scroll.
4. Close the navigation and confirm body scrolling and its original inline padding are restored.

## Screenshots (optional)

Not applicable; the change affects body scroll behavior rather than rendered component appearance.

## Author & Maintainer checklist

- Is this is a [breaking change](https://github.com/trussworks/react-uswds/blob/main/docs/breaking-changes.md)?
  - [ ] Yes, and I accounted for the breaking changes according to the linked documentation
  - [x] No
- Once merged, add the PR and Issue author(s) as a contributor(s) via the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage#all-contributors-add)
