### PR TITLE
fix: make mobile navigation accessible

### DIFF
--- a/src/components/header/ExtendedNav/ExtendedNav.test.tsx
+++ b/src/components/header/ExtendedNav/ExtendedNav.test.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import React, { useState } from 'react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 
 import { ExtendedNav } from './ExtendedNav'
+import { Header } from '../Header/Header'
+import { NavMenuButton } from '../NavMenuButton/NavMenuButton'
 
 const testPrimaryItems = [
   <a className="usa-current" href="#linkOne" key="one">
@@ -23,6 +26,28 @@ const testSecondaryItems = [
 
 const onToggleMobileNav = (): void => {
   /* mock submit fn */
+}
+
+const ExtendedNavHarness = () => {
+  const [expanded, setExpanded] = useState(false)
+  const toggleNav = (): void => setExpanded((current) => !current)
+
+  return (
+    <>
+      <Header extended>
+        <div className="usa-nav-container">
+          <NavMenuButton label="Menu" onClick={toggleNav} />
+          <ExtendedNav
+            onToggleMobileNav={toggleNav}
+            primaryItems={testPrimaryItems}
+            secondaryItems={testSecondaryItems}
+            mobileExpanded={expanded}
+          />
+        </div>
+      </Header>
+      <main data-testid="pageContent">Page content</main>
+    </>
+  )
 }
 
 describe('ExtendedNav component', () => {
@@ -97,6 +122,23 @@ describe('ExtendedNav component', () => {
     )
     expect(container.querySelector('.is-visible')).toBeInTheDocument()
     expect(document.body).toHaveClass('usa-js-mobile-nav--active')
+  })
+
+  it('contains focus and hides page content while expanded', async () => {
+    const user = userEvent.setup()
+    render(<ExtendedNavHarness />)
+
+    await user.click(screen.getByRole('button', { name: 'Menu' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Close Navigation Menu' })
+      ).toHaveFocus()
+    )
+    expect(screen.getByTestId('pageContent')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
   })
 
   it('does not render the is-visible class when mobileExpanded is false', () => {

--- a/src/components/header/ExtendedNav/ExtendedNav.tsx
+++ b/src/components/header/ExtendedNav/ExtendedNav.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 
 import { NavCloseButton } from '../NavCloseButton/NavCloseButton'
 import { NavList } from '../NavList/NavList'
-import { useMobileNavScrollLock } from '../useMobileNavScrollLock'
+import { MobileNav } from '../MobileNav'
 
 export type ExtendedNavProps = {
   primaryItems: React.ReactNode[]
@@ -23,8 +23,6 @@ export const ExtendedNav = ({
   onToggleMobileNav,
   ...navProps
 }: ExtendedNavProps): JSX.Element => {
-  useMobileNavScrollLock(mobileExpanded)
-
   const classes = classnames(
     'usa-nav',
     {
@@ -34,16 +32,18 @@ export const ExtendedNav = ({
   )
 
   return (
-    <nav className={classes} {...navProps}>
-      <div className="usa-nav__inner">
-        <NavCloseButton onClick={onToggleMobileNav} />
-        <NavList items={primaryItems} type="primary" />
-        <div className="usa-nav__secondary">
-          <NavList items={secondaryItems} type="secondary" />
-          {children}
+    <MobileNav expanded={mobileExpanded} onToggleMobileNav={onToggleMobileNav}>
+      <nav className={classes} {...navProps}>
+        <div className="usa-nav__inner">
+          <NavCloseButton onClick={onToggleMobileNav} />
+          <NavList items={primaryItems} type="primary" />
+          <div className="usa-nav__secondary">
+            <NavList items={secondaryItems} type="secondary" />
+            {children}
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
+    </MobileNav>
   )
 }
 

--- a/src/components/header/Header/Header.stories.tsx
+++ b/src/components/header/Header/Header.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof Header> = {
 
 Source: https://designsystem.digital.gov/components/header/
 
-Expanding the mobile navigation locks body scrolling until the navigation closes or unmounts.
+Expanding the mobile navigation locks body scrolling, contains focus, and hides page content from assistive technology until the navigation closes or unmounts. Focus returns to the control that opened the navigation.
 `,
       },
     },

--- a/src/components/header/MobileNav.ts
+++ b/src/components/header/MobileNav.ts
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef, type JSX } from 'react'
+import { FocusTrap } from 'focus-trap-react'
+
+import { useMobileNavScrollLock } from './useMobileNavScrollLock'
+
+const NON_NAV_ELEMENTS =
+  'body *:not(.usa-header, .usa-nav-container, .usa-nav, .usa-nav *):not([aria-hidden])'
+
+type MobileNavProps = {
+  children: React.ReactElement<JSX.IntrinsicElements['nav']>
+  expanded?: boolean
+  onToggleMobileNav?: React.MouseEventHandler<HTMLButtonElement>
+}
+
+const getCloseButton = (target?: EventTarget | null) => {
+  const targetElement = target instanceof Element ? target : null
+
+  return (
+    targetElement
+      ?.closest('.usa-nav')
+      ?.querySelector<HTMLButtonElement>('.usa-nav__close') ??
+    document.querySelector<HTMLButtonElement>(
+      '.usa-nav.is-visible .usa-nav__close'
+    )
+  )
+}
+
+export const MobileNav = ({
+  children,
+  expanded,
+  onToggleMobileNav,
+}: MobileNavProps): JSX.Element => {
+  const onToggleMobileNavRef = useRef(onToggleMobileNav)
+  onToggleMobileNavRef.current = onToggleMobileNav
+
+  useMobileNavScrollLock(expanded)
+
+  useEffect(() => {
+    if (!expanded) return
+
+    // ponytail: one active mobile nav per page; scope by instance if multiple headers are supported.
+    const nav = document.querySelector<HTMLElement>('.usa-nav.is-visible')
+    if (!nav) return
+
+    const hiddenElements = Array.from(
+      document.querySelectorAll<HTMLElement>(NON_NAV_ELEMENTS)
+    ).filter((element) => !element.contains(nav))
+
+    hiddenElements.forEach((element) => {
+      element.setAttribute('aria-hidden', 'true')
+      element.setAttribute('data-nav-hidden', '')
+    })
+
+    return () => {
+      hiddenElements.forEach((element) => {
+        element.removeAttribute('aria-hidden')
+        element.removeAttribute('data-nav-hidden')
+      })
+    }
+  }, [expanded])
+
+  useEffect(() => {
+    if (!expanded) return
+
+    const closeAtDesktopWidth = (): void => {
+      const closeButton = getCloseButton()
+
+      if (
+        closeButton &&
+        window.getComputedStyle(closeButton).display === 'none' &&
+        onToggleMobileNavRef.current
+      ) {
+        closeButton.click()
+      }
+    }
+
+    closeAtDesktopWidth()
+    window.addEventListener('resize', closeAtDesktopWidth)
+    return () => window.removeEventListener('resize', closeAtDesktopWidth)
+  }, [expanded])
+
+  const focusTrapOptions = useRef({
+    escapeDeactivates: (event: KeyboardEvent): boolean => {
+      if (!onToggleMobileNavRef.current) return false
+
+      const closeButton = getCloseButton(event.target)
+      closeButton?.click()
+      return Boolean(closeButton)
+    },
+  }).current
+
+  return React.createElement(
+    FocusTrap,
+    {
+      active: Boolean(expanded && onToggleMobileNav),
+      focusTrapOptions,
+    },
+    children
+  )
+}

--- a/src/components/header/PrimaryNav/PrimaryNav.server.test.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.server.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment node
+
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+
+import { PrimaryNav } from './PrimaryNav'
+
+it('renders an expanded mobile navigation on the server', () => {
+  expect(() =>
+    renderToString(
+      <PrimaryNav
+        mobileExpanded
+        items={[
+          <a href="#one" key="one">
+            One
+          </a>,
+        ]}
+        onToggleMobileNav={() => undefined}
+      />
+    )
+  ).not.toThrow()
+})

--- a/src/components/header/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.test.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import React, { useState } from 'react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 
 import { PrimaryNav } from './PrimaryNav'
+import { Header } from '../Header/Header'
+import { NavMenuButton } from '../NavMenuButton/NavMenuButton'
 
 vi.mock('../../modal/utils', async (importOriginal) => {
   const utils = await importOriginal<typeof import('../../modal/utils')>()
@@ -34,6 +37,34 @@ const renderNav = (mobileExpanded: boolean) => (
     />
   </React.StrictMode>
 )
+
+const MobileNavHarness = ({
+  initiallyExpanded = false,
+}: {
+  initiallyExpanded?: boolean
+}) => {
+  const [expanded, setExpanded] = useState(initiallyExpanded)
+  const toggleNav = (): void => setExpanded((current) => !current)
+
+  return (
+    <>
+      <Header basic showMobileOverlay={expanded}>
+        <div className="usa-nav-container">
+          <NavMenuButton label="Menu" onClick={toggleNav} />
+          <PrimaryNav
+            items={testItems}
+            onToggleMobileNav={toggleNav}
+            mobileExpanded={expanded}
+          />
+        </div>
+      </Header>
+      <main data-testid="pageContent">Page content</main>
+      <aside data-testid="alreadyHidden" aria-hidden="true">
+        Already hidden
+      </aside>
+    </>
+  )
+}
 
 describe('PrimaryNav component', () => {
   afterEach(() => {
@@ -117,6 +148,102 @@ describe('PrimaryNav component', () => {
 
     expect(document.body).toHaveClass('usa-js-mobile-nav--active')
     expect(document.body).toHaveStyle({ paddingRight: '20px' })
+  })
+
+  it('contains focus and restores the opener and page accessibility state', async () => {
+    const user = userEvent.setup()
+    render(<MobileNavHarness />)
+
+    const menuButton = screen.getByRole('button', { name: 'Menu' })
+    await user.click(menuButton)
+
+    const closeButton = screen.getByRole('button', {
+      name: 'Close Navigation Menu',
+    })
+    const lastLink = screen.getByRole('link', { name: 'Simple link two' })
+    const pageContent = screen.getByTestId('pageContent')
+
+    await waitFor(() => expect(closeButton).toHaveFocus())
+    expect(pageContent).toHaveAttribute('aria-hidden', 'true')
+    expect(pageContent).toHaveAttribute('data-nav-hidden')
+    expect(screen.getByTestId('header')).not.toHaveAttribute('aria-hidden')
+    expect(screen.getByTestId('header').parentElement).not.toHaveAttribute(
+      'aria-hidden'
+    )
+    expect(screen.getByRole('navigation')).not.toHaveAttribute('aria-hidden')
+    expect(screen.getByTestId('alreadyHidden')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+    expect(screen.getByTestId('alreadyHidden')).not.toHaveAttribute(
+      'data-nav-hidden'
+    )
+
+    await user.tab({ shift: true })
+    expect(lastLink).toHaveFocus()
+    await user.tab()
+    expect(closeButton).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => expect(menuButton).toHaveFocus())
+    expect(pageContent).not.toHaveAttribute('aria-hidden')
+    expect(pageContent).not.toHaveAttribute('data-nav-hidden')
+    expect(screen.getByTestId('alreadyHidden')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+  })
+
+  it('does not trap focus without a mobile navigation toggle handler', () => {
+    render(
+      <>
+        <PrimaryNav items={testItems} mobileExpanded />
+        <button type="button">Outside</button>
+      </>
+    )
+
+    const outsideButton = screen.getByText('Outside')
+    outsideButton.focus()
+
+    expect(outsideButton).toHaveFocus()
+  })
+
+  it('restores page accessibility state when unmounted while expanded', () => {
+    const pageContent = document.createElement('main')
+    document.body.appendChild(pageContent)
+
+    const { unmount } = render(
+      <React.StrictMode>
+        <MobileNavHarness initiallyExpanded />
+      </React.StrictMode>
+    )
+    expect(pageContent).toHaveAttribute('aria-hidden', 'true')
+
+    unmount()
+    expect(pageContent).not.toHaveAttribute('aria-hidden')
+    expect(pageContent).not.toHaveAttribute('data-nav-hidden')
+
+    pageContent.remove()
+  })
+
+  it('closes the mobile navigation when it becomes hidden at desktop width', async () => {
+    const user = userEvent.setup()
+    render(<MobileNavHarness />)
+
+    const menuButton = screen.getByRole('button', { name: 'Menu' })
+    await user.click(menuButton)
+
+    const closeButton = screen.getByRole('button', {
+      name: 'Close Navigation Menu',
+    })
+    closeButton.style.display = 'none'
+
+    fireEvent(window, new Event('resize'))
+
+    await waitFor(() => expect(menuButton).toHaveFocus())
+    expect(screen.getByRole('navigation')).not.toHaveClass('is-visible')
+    expect(screen.getByTestId('pageContent')).not.toHaveAttribute('aria-hidden')
   })
 
   it('does not render the is-visible class when mobileExpanded is false', () => {

--- a/src/components/header/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/header/PrimaryNav/PrimaryNav.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 
 import { NavCloseButton } from '../NavCloseButton/NavCloseButton'
 import { NavList } from '../NavList/NavList'
-import { useMobileNavScrollLock } from '../useMobileNavScrollLock'
+import { MobileNav } from '../MobileNav'
 
 export type PrimaryNavProps = {
   items: React.ReactNode[]
@@ -21,8 +21,6 @@ export const PrimaryNav = ({
   className,
   ...navProps
 }: PrimaryNavProps): JSX.Element => {
-  useMobileNavScrollLock(mobileExpanded)
-
   const classes = classnames(
     'usa-nav',
     {
@@ -32,11 +30,13 @@ export const PrimaryNav = ({
   )
 
   return (
-    <nav className={classes} {...navProps}>
-      <NavCloseButton onClick={onToggleMobileNav} />
-      <NavList items={items} type="primary" />
-      {children}
-    </nav>
+    <MobileNav expanded={mobileExpanded} onToggleMobileNav={onToggleMobileNav}>
+      <nav className={classes} {...navProps}>
+        <NavCloseButton onClick={onToggleMobileNav} />
+        <NavList items={items} type="primary" />
+        {children}
+      </nav>
+    </MobileNav>
   )
 }
 


### PR DESCRIPTION
## Summary

- Trap keyboard focus inside expanded PrimaryNav and ExtendedNav, focus the close button on open, and return focus to the actual opener on close.
- Hide non-navigation page content from assistive technology while preserving content that was already hidden.
- Close through the existing toggle handler when Escape is pressed or the desktop breakpoint hides the close button.
- Clean up focus, body state, and owned aria-hidden attributes on close and unmount, including StrictMode and server rendering paths.

This is a stacked PR. #3601 must merge first. #3590 should also land before release so the published peer range includes the installed and verified focus-trap-react 12 major. The implementation was separately verified against focus-trap-react 11.0.4 and 11.0.6.

Known limits: the implementation assumes one expanded mobile navigation per document; a programmatically opened navigation returns focus to whatever element was active; Modal and mobile navigation still independently own body padding; and the USWDS Safari-specific navigation workaround remains out of scope.

## Related Issues

https://github.com/trussworks/react-uswds/issues/3602

## How To Test

1. Open a Header mobile navigation from the menu button and confirm focus moves to the close button.
2. Press Tab and Shift+Tab and confirm focus remains inside the navigation.
3. Press Escape and confirm the navigation closes, page content is restored to assistive technology, and focus returns to the menu button.
4. Open the navigation, hide the close button as the desktop breakpoint does, dispatch resize, and confirm the existing close path runs.
5. Run `npm run test:coverage`, `npm run test:serverside`, `npm run lint`, `npm run format:check`, `npm audit --omit=dev --audit-level=high`, and `npm run build-storybook`.

## Screenshots

Not applicable; the visible component markup is unchanged.

## Breaking Change

- [x] This change is non-breaking.
- [ ] This change is breaking and follows `docs/breaking-changes.md`.